### PR TITLE
Add task and node specification for srun

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -1461,7 +1461,7 @@ def run_cmd(cmdfo, batch_system=None, batch_options=None):
     prefix = None
     if batch_system is not None:
         if batch_system == 'slurm':
-            prefix = 'srun'  # --exclude=data/gizmod.txt'
+            prefix = 'srun -N 1 -n 1'  # --exclude=data/gizmod.txt'
             if 'threads' in cmdfo:
                 prefix += ' --cpus-per-task %d' % cmdfo['threads']
         elif batch_system == 'sge':


### PR DESCRIPTION
Just a follow-up from the ticket... didn't think to use github for the update.

> Inside an allocation (via salloc or sbatch), the default behavior of srun is to run a copy of _prog_ for every task allocated in the salloc command.  This is crude, assigns a single task and node for each command executed by run_cmd