### PR TITLE
partis partition --linearham

### DIFF
--- a/python/partitiondriver.py
+++ b/python/partitiondriver.py
@@ -1592,6 +1592,10 @@ class PartitionDriver(object):
                     hmm_failures |= set(padded_line['unique_ids'])  # NOTE adds the ids individually (will have to be updated if we start accepting multi-seq input file)
                     continue
 
+                if self.args.linearham:
+                    # add flexbounds/relpos to padded line
+                    utils.add_linearham_info(self.sw_info, uids, padded_line)
+
                 utils.process_per_gene_support(padded_line)  # switch per-gene support from log space to normalized probabilities
                 if padded_line['invalid']:
                     n_invalid_events += 1
@@ -1605,7 +1609,7 @@ class PartitionDriver(object):
                     print '%s uidstr %s already read from file %s' % (utils.color('yellow', 'warning'), uidstr, annotation_fname)
                 padded_annotations[uidstr] = padded_line
 
-                if len(uids) > 1:  # if there's more than one sequence, we need to use the padded line
+                if len(uids) > 1 or self.args.linearham:  # if there's more than one sequence (or we're in linearham mode), we need to use the padded line
                     at_least_one_mult_hmm_line = True
                     line_to_use = padded_line
                 else:  # otherwise, the eroded line is kind of simpler to look at

--- a/python/processargs.py
+++ b/python/processargs.py
@@ -38,9 +38,6 @@ def process(args):
     args.extra_annotation_columns = utils.get_arg_list(args.extra_annotation_columns, choices=utils.extra_annotation_headers)
     if args.linearham:
        args.extra_annotation_columns = utils.add_lists(args.extra_annotation_columns, ['flexbounds', 'relpos'])
-       args.only_smith_waterman = True
-       args.dont_write_parameters = True
-       args.dont_remove_framework_insertions = True
 
     args.cluster_indices = utils.get_arg_list(args.cluster_indices, intify=True)
 


### PR DESCRIPTION
* multi-seqs spit out from `partis partition` are now accounted for (again) in flexbounds/relpos
* in the case of single sequence, we still want padded sequences (for consistency across all CF sizes)
* in the case of V/J FWK insertions and padding and its effect on flexbounds/relpos, that is manually accounted for in the code as S-W operates on the input sequences before removal of FWK insertions and addition of N-padding, but we would like to use `indel-reversed-seqs` (i.e. sequences with FWK insertions removed, indels reversed, and N-padding so they are all of equal length) for linearham.

Command: `bin/partis partition --infname testing_amrit/partis_input_seqs.fa --outfname testing_amrit/partis_output.yaml --parameter-dir _output --linearham`