### PR TITLE
--linearham changes round 500

### DIFF
--- a/python/partitiondriver.py
+++ b/python/partitiondriver.py
@@ -1603,7 +1603,7 @@ class PartitionDriver(object):
                     continue
 
                 if self.args.linearham:
-                    # add aggregated flexbounds/relpos to padded line
+                    # add representative flexbounds/relpos to padded line
                     utils.add_linearham_info(self.sw_info, uids, padded_line)
 
                 utils.process_per_gene_support(padded_line)  # switch per-gene support from log space to normalized probabilities

--- a/python/waterer.py
+++ b/python/waterer.py
@@ -801,10 +801,11 @@ class Waterer(object):
             sortmatches = {r : [g for _, g in qinfo['matches'][r]] for r in utils.regions}
             infoline['flexbounds'] = {}
             def span(boundlist):
-                return [min(boundlist) - 2, max(boundlist) + 2]
+                return [min(boundlist), max(boundlist)]
             for region in utils.regions:
                 bounds_l, bounds_r = zip(*[qinfo['qrbounds'][g] for g in sortmatches[region]])  # left- (and right-) bounds for each gene
-                infoline['flexbounds'][region] = {'l' : span(bounds_l), 'r' : span(bounds_r)}
+                infoline['flexbounds'][region + '_l'] = span(bounds_l)
+                infoline['flexbounds'][region + '_r'] = span(bounds_r)
             infoline['relpos'] = {gene: qinfo['qrbounds'][gene][0] - glbound[0] for gene, glbound in qinfo['glbounds'].items()}  # position in the query sequence of the start of each uneroded germline match
 
         infoline['cdr3_length'] = codon_positions['j'] - codon_positions['v'] + 3
@@ -1160,10 +1161,9 @@ class Waterer(object):
                 swfo['regional_bounds'][region] = tuple([rb - fv_len for rb in swfo['regional_bounds'][region]])  # I kind of want to just use a list now, but a.t.m. don't much feel like changing it everywhere else
 
             if self.args.linearham:
-                for region in utils.regions:
-                    for side in ['l', 'r']:
-                        swfo['flexbounds'][region][side][0] -= fv_len  # the left-bounds need to be adjusted for V 5' framework insertions
-                        swfo['flexbounds'][region][side][1] -= fv_len  # the right-bounds need to be adjusted for V 5' framework insertions
+                for k in swfo['flexbounds'].keys():
+                    swfo['flexbounds'][k][0] -= fv_len  # the left-bounds need to be adjusted for V 5' framework insertions
+                    swfo['flexbounds'][k][1] -= fv_len  # the right-bounds need to be adjusted for V 5' framework insertions
                 for k in swfo['relpos'].keys():
                     swfo['relpos'][k] -= fv_len  # the relpos needs to be adjusted for V 5' framework insertions
 
@@ -1358,10 +1358,9 @@ class Waterer(object):
                 swfo['regional_bounds'][region] = tuple([rb + padleft for rb in swfo['regional_bounds'][region]])  # I kind of want to just use a list now, but a.t.m. don't much feel like changing it everywhere else
 
             if self.args.linearham:
-                for region in utils.regions:
-                    for side in ['l', 'r']:
-                        swfo['flexbounds'][region][side][0] += padleft  # the left-bounds need to be adjusted for V 5' padding
-                        swfo['flexbounds'][region][side][1] += padleft  # the right-bounds need to be adjusted for V 5' padding
+                for k in swfo['flexbounds'].keys():
+                    swfo['flexbounds'][k][0] += padleft  # the left-bounds need to be adjusted for V 5' padding
+                    swfo['flexbounds'][k][1] += padleft  # the right-bounds need to be adjusted for V 5' padding
                 for k in swfo['relpos'].keys():
                     swfo['relpos'][k] += padleft  # the relpos needs to be adjusted for V 5' padding
 


### PR DESCRIPTION
* now finds flexbounds/relpos using a "representative" clonal sequence (instead of aggregating over CF)
* now makes separate directories for the "partition" FASTA's
* removed the +/- 2 bounds fuzz (for short D gene matches, this leads to errors!)

The "representative" stuff was inspired by Laura's messy `QA255.067-Vh` data, which had tons of uncertainty and D gene matches of length 4 with tons of D genes aligned all over the place, and this caused the flexbounds/relpos to be inconsistent with each other.