### PR TITLE
flexbounds/relpos restricted to non-zero probability gene matches

### DIFF
--- a/python/partitiondriver.py
+++ b/python/partitiondriver.py
@@ -1604,7 +1604,7 @@ class PartitionDriver(object):
 
                 if self.args.linearham:
                     # add representative flexbounds/relpos to padded line
-                    utils.add_linearham_info(self.sw_info, uids, padded_line)
+                    utils.add_linearham_info(self.glfo, self.sw_info, uids, padded_line)
 
                 utils.process_per_gene_support(padded_line)  # switch per-gene support from log space to normalized probabilities
                 if padded_line['invalid']:

--- a/python/waterer.py
+++ b/python/waterer.py
@@ -800,12 +800,10 @@ class Waterer(object):
         if self.args.linearham:
             sortmatches = {r : [g for _, g in qinfo['matches'][r]] for r in utils.regions}
             infoline['flexbounds'] = {}
-            def span(boundlist):
-                return [min(boundlist), max(boundlist)]
             for region in utils.regions:
                 bounds_l, bounds_r = zip(*[qinfo['qrbounds'][g] for g in sortmatches[region]])  # left- (and right-) bounds for each gene
-                infoline['flexbounds'][region + '_l'] = span(bounds_l)
-                infoline['flexbounds'][region + '_r'] = span(bounds_r)
+                infoline['flexbounds'][region + '_l'] = dict(zip(sortmatches[region], bounds_l))
+                infoline['flexbounds'][region + '_r'] = dict(zip(sortmatches[region], bounds_r))
             infoline['relpos'] = {gene: qinfo['qrbounds'][gene][0] - glbound[0] for gene, glbound in qinfo['glbounds'].items()}  # position in the query sequence of the start of each uneroded germline match
 
         infoline['cdr3_length'] = codon_positions['j'] - codon_positions['v'] + 3
@@ -1161,9 +1159,9 @@ class Waterer(object):
                 swfo['regional_bounds'][region] = tuple([rb - fv_len for rb in swfo['regional_bounds'][region]])  # I kind of want to just use a list now, but a.t.m. don't much feel like changing it everywhere else
 
             if self.args.linearham:
-                for k in swfo['flexbounds'].keys():
-                    swfo['flexbounds'][k][0] -= fv_len  # the left-bounds need to be adjusted for V 5' framework insertions
-                    swfo['flexbounds'][k][1] -= fv_len  # the right-bounds need to be adjusted for V 5' framework insertions
+                for k1 in swfo['flexbounds'].keys():
+                    for k2 in swfo['flexbounds'][k1].keys():
+                        swfo['flexbounds'][k1][k2] -= fv_len  # the bounds need to be adjusted for V 5' framework insertions
                 for k in swfo['relpos'].keys():
                     swfo['relpos'][k] -= fv_len  # the relpos needs to be adjusted for V 5' framework insertions
 
@@ -1358,9 +1356,9 @@ class Waterer(object):
                 swfo['regional_bounds'][region] = tuple([rb + padleft for rb in swfo['regional_bounds'][region]])  # I kind of want to just use a list now, but a.t.m. don't much feel like changing it everywhere else
 
             if self.args.linearham:
-                for k in swfo['flexbounds'].keys():
-                    swfo['flexbounds'][k][0] += padleft  # the left-bounds need to be adjusted for V 5' padding
-                    swfo['flexbounds'][k][1] += padleft  # the right-bounds need to be adjusted for V 5' padding
+                for k1 in swfo['flexbounds'].keys():
+                    for k2 in swfo['flexbounds'][k1].keys():
+                        swfo['flexbounds'][k1][k2] += padleft  # the bounds need to be adjusted for V 5' padding
                 for k in swfo['relpos'].keys():
                     swfo['relpos'][k] += padleft  # the relpos needs to be adjusted for V 5' padding
 


### PR DESCRIPTION
* I've now made it so we have no flexbounds/relpos values associated with 0 `gene_prob` as determined from the partis HMM. To do this, I check to see if the flexbounds/relpos gene names are in `self.glfo['seqs'][region]` for `region in ['v','d','j']`. From what I understand, `self.glfo` has a restricted set of genes that have a `gene_prob > 0`.

Let me know if there are mistakes in my logic.

Command:
`bin/partis partition --infname testing_amrit/partis_input_seqs.fa --outfname testing_amrit/partis_output.yaml --linearham`