### PR TITLE
more linearham improvements

### DIFF
--- a/python/processargs.py
+++ b/python/processargs.py
@@ -38,7 +38,6 @@ def process(args):
     args.extra_annotation_columns = utils.get_arg_list(args.extra_annotation_columns, choices=utils.extra_annotation_headers)
     if args.linearham:
        assert args.action == 'partition', '--linearham mode must be run with \'partis partition\''
-       args.extra_annotation_columns = utils.add_lists(args.extra_annotation_columns, ['flexbounds', 'relpos'])
 
     args.cluster_indices = utils.get_arg_list(args.cluster_indices, intify=True)
 

--- a/python/utils.py
+++ b/python/utils.py
@@ -1228,6 +1228,7 @@ def add_linearham_info(sw_info, gene_probs, line):
         line['flexbounds']['v_l'][0] = 0
         line['flexbounds']['j_r'][1] = len(swfo['seqs'][0])  # remember 'seqs' refers to indel-reversed sequences so they're all the same length
 
+        assert status == 'ok'
         break
 
     return status

--- a/python/utils.py
+++ b/python/utils.py
@@ -1118,26 +1118,119 @@ def re_sort_per_gene_support(line):
             line[region + '_per_gene_support'] = collections.OrderedDict(sorted(line[region + '_per_gene_support'].items(), key=operator.itemgetter(1), reverse=True))
 
 # ----------------------------------------------------------------------------------------
-def add_linearham_info(glfo, sw_info, query_names, line):
-    """ find the representative query sequence, restrict to non-zero probability flexbounds/relpos values, and add to <line> """
-    # find the "representative" query sequence
-    consensus_seq = ''.join([Counter(site_bases).most_common()[0][0] for site_bases in zip(*line['indel_reversed_seqs'])])
-    dists_to_consensus = [hamming_distance(consensus_seq, seq) for seq in line['indel_reversed_seqs']]
-    query_ind = dists_to_consensus.index(min(dists_to_consensus))
-
-    # restrict flexbounds/relpos to gene matches with non-zero probability
-    line['flexbounds'] = {}
+def add_linearham_info(sw_info, gene_probs, line):
+    """ compute the flexbounds/relpos values and add to <line> """
+    # rank the possible "representative" query sequences
+    cons_seq = ''.join([Counter(site_bases).most_common()[0][0] for site_bases in zip(*line['indel_reversed_seqs'])])
+    dists_to_cons = {line['unique_ids'][i] : hamming_distance(cons_seq, line['indel_reversed_seqs'][i]) for i in range(len(line['unique_ids']))}
     def span(bound_list):
-        return (min(bound_list), max(bound_list))
-    for region in regions:
-        for k in sw_info[query_names[query_ind]]['flexbounds'][region + '_l'].keys():
-            if k not in glfo['seqs'][region]:
-                del sw_info[query_names[query_ind]]['flexbounds'][region + '_l'][k]
-                del sw_info[query_names[query_ind]]['flexbounds'][region + '_r'][k]
-                del sw_info[query_names[query_ind]]['relpos'][k]
-        line['flexbounds'][region + '_l'] = span(sw_info[query_names[query_ind]]['flexbounds'][region + '_l'].values())
-        line['flexbounds'][region + '_r'] = span(sw_info[query_names[query_ind]]['flexbounds'][region + '_r'].values())
-    line['relpos'] = sw_info[query_names[query_ind]]['relpos']
+        return [min(bound_list), max(bound_list)]
+
+    while len(dists_to_cons) > 0:
+        status = 'ok'
+
+        # extract the Smith-Waterman information associated with the current "representative" query sequence
+        query_name = min(dists_to_cons, key=dists_to_cons.get)
+        swfo = sw_info[query_name]
+
+        # 1) restrict flexbounds/relpos to gene matches with non-zero probability
+        # 2) if the left/right flexbounds overlap in a particular region, remove the worst gene matches until the overlap disappears
+        # 3) if neighboring flexbounds overlap across different regions, apportion the flexbounds until the overlap disappears
+        # 4) align the V-entry/J-exit flexbounds to the sequence bounds
+        line['flexbounds'] = {}
+        for region in regions:
+            left_region, right_region = region + '_l', region + '_r'
+
+            # remove the zero-probability gene matches
+            for k in swfo['flexbounds'][left_region].keys():
+                if k not in gene_probs[region].keys():
+                    del swfo['flexbounds'][left_region][k]
+                    del swfo['flexbounds'][right_region][k]
+                    del swfo['relpos'][k]
+                    del swfo['match_scores'][region][k]
+
+            # have all the gene matches been assigned zero probability?
+            if len(swfo['flexbounds'][left_region]) == 0:
+                status = 'nonsense'
+                break
+
+            # calculate the composite gene scores
+            region_gene_probs = {k : gene_probs[region][k] for k in swfo['flexbounds'][left_region].keys()}
+            region_comp_scores = {k : float(region_gene_probs[k]) / max(region_gene_probs.values()) +
+                                      float(swfo['match_scores'][region][k]) / max(swfo['match_scores'][region].values())
+                                  for k in swfo['flexbounds'][left_region].keys()}
+
+            # compute the initial left/right flexbounds
+            line['flexbounds'][left_region] = span(swfo['flexbounds'][left_region].values())
+            line['flexbounds'][right_region] = span(swfo['flexbounds'][right_region].values())
+
+            # make sure there is no overlap between the left/right flexbounds
+            while line['flexbounds'][left_region][1] >= line['flexbounds'][right_region][0]:
+                k = min(region_comp_scores, key=region_comp_scores.get)
+                del swfo['flexbounds'][left_region][k]
+                del swfo['flexbounds'][right_region][k]
+                del swfo['relpos'][k]
+                del region_comp_scores[k]
+                line['flexbounds'][left_region] = span(swfo['flexbounds'][left_region].values())
+                line['flexbounds'][right_region] = span(swfo['flexbounds'][right_region].values())
+
+        if status == 'nonsense':
+            del dists_to_cons[query_name]
+            continue
+
+        line['relpos'] = swfo['relpos']
+
+        # make sure there is no overlap between neighboring flexbounds
+        for rpair in region_pairs():
+            left_region, right_region = rpair['left'] + '_r', rpair['right'] + '_l'
+            leftleft_region, rightright_region = rpair['left'] + '_l', rpair['right'] + '_r'
+
+            left_germ_len = line['flexbounds'][left_region][0] - line['flexbounds'][leftleft_region][1]
+            junction_len = line['flexbounds'][right_region][1] - line['flexbounds'][left_region][0]
+            right_germ_len = line['flexbounds'][rightright_region][0] - line['flexbounds'][right_region][1]
+
+            if junction_len <= 0:
+                line['flexbounds'][left_region][0] = line['flexbounds'][right_region][0]
+                line['flexbounds'][right_region][1] = line['flexbounds'][left_region][1]
+
+                left_germ_len = line['flexbounds'][left_region][0] - line['flexbounds'][leftleft_region][1]
+                junction_len = line['flexbounds'][right_region][1] - line['flexbounds'][left_region][0]
+                right_germ_len = line['flexbounds'][rightright_region][0] - line['flexbounds'][right_region][1]
+
+                # are the neighboring flexbounds even fixable?
+                if left_germ_len <= 0 or right_germ_len <= 0:
+                    status = 'nonsense'
+                    break
+
+            # are the neighboring flexbounds both 0-length?
+            if junction_len == 0:
+                if rpair['left'] == 'v':
+                    if right_germ_len > 1:
+                        line['flexbounds'][right_region][0] += 1
+                        line['flexbounds'][right_region][1] += 1
+                    else:
+                        line['flexbounds'][left_region][0] -= 1
+                        line['flexbounds'][left_region][1] -= 1
+                else:
+                    assert rpair['right'] == 'j'
+                    if left_germ_len > 1:
+                        line['flexbounds'][left_region][0] -= 1
+                        line['flexbounds'][left_region][1] -= 1
+                    else:
+                        line['flexbounds'][right_region][0] += 1
+                        line['flexbounds'][right_region][1] += 1
+
+        if status == 'nonsense':
+            del dists_to_cons[query_name]
+            continue
+
+        # align the V-entry/J-exit flexbounds to the possible sequence positions
+        line['flexbounds']['v_l'][0] = 0
+        line['flexbounds']['j_r'][1] = len(swfo['seqs'][0])  # remember 'seqs' refers to indel-reversed sequences so they're all the same length
+
+        break
+
+    return status
 
 # ----------------------------------------------------------------------------------------
 def add_implicit_info(glfo, line, aligned_gl_seqs=None, check_line_keys=False, reset_indel_genes=False):  # should turn on <check_line_keys> for a bit if you change anything

--- a/python/waterer.py
+++ b/python/waterer.py
@@ -174,7 +174,7 @@ class Waterer(object):
         # NOTE does *not* write failed queries also
         headers = utils.sw_cache_headers
         if self.args.linearham:
-            headers = utils.add_lists(headers, ['flexbounds', 'relpos'])
+            headers = utils.add_lists(headers, ['flexbounds', 'relpos', 'match_scores'])
         utils.write_annotations(cachefname, self.glfo, [self.info[q]for q in self.info['queries']], headers)
 
     # ----------------------------------------------------------------------------------------
@@ -805,6 +805,7 @@ class Waterer(object):
                 infoline['flexbounds'][region + '_l'] = dict(zip(sortmatches[region], bounds_l))
                 infoline['flexbounds'][region + '_r'] = dict(zip(sortmatches[region], bounds_r))
             infoline['relpos'] = {gene: qinfo['qrbounds'][gene][0] - glbound[0] for gene, glbound in qinfo['glbounds'].items()}  # position in the query sequence of the start of each uneroded germline match
+            infoline['match_scores'] = {r : {gene : score for score, gene in qinfo['matches'][r]} for r in utils.regions}
 
         infoline['cdr3_length'] = codon_positions['j'] - codon_positions['v'] + 3
         infoline['codon_positions'] = codon_positions


### PR DESCRIPTION
* store S-W match scores in S-W cache file
* making sure `flexbounds/relpos` are computed only for the final annotation phase in `partis partition`.
* changed the `flexbounds/relpos` logic
    1. Find the "consensus" sequence of the partition, and compute distances from each query seq to it.
    2. We look through each query seq, from closest to "consensus" to farthest, and see if they can be used to compute `flexbounds/relpos`; if a query seq doesn't produce adequate bounds, go to the next query seq.
    3. To produce adequate bounds, we 1) remove any 0-probability gene matches, 2) remove any "overlap" among same germline flexbounds (i.e. `v_l/v_r`), 3) remove any "overlap" between neighboring junction flexbounds (i.e. `v_r/d_l`), and 4) align the earliest V-entry and latest J-exit point to the observed sequence bounds.
* If `flexbounds/relpos` are impossible to compute for a given partition, we flag it as a `hmm_failure` and do not write it to output.

Example command:
`bin/partis partition --infname testing_amrit/input_seqs.fasta --outfname testing_amrit/tmp.yaml --linearham`