### PR TITLE
adding a linearham option assuming all clonal sequences

### DIFF
--- a/python/processargs.py
+++ b/python/processargs.py
@@ -36,8 +36,6 @@ def process(args):
     if args.write_additional_cluster_annotations is not None and len(args.write_additional_cluster_annotations) != 2:
         raise Exception('--write-additional-cluster-annotations must be specified as two numbers \'m:n\', but I got %s' % args.write_additional_cluster_annotations)
     args.extra_annotation_columns = utils.get_arg_list(args.extra_annotation_columns, choices=utils.extra_annotation_headers)
-    if args.linearham:
-       assert args.action == 'partition', '--linearham mode must be run with \'partis partition\''
 
     args.cluster_indices = utils.get_arg_list(args.cluster_indices, intify=True)
 


### PR DESCRIPTION
now linearham can be run with `partis annotate` as well

originally:
`bin/partis partition --linearham --infname X --outfname Y`
now, we can run:
`bin/partis annotate --linearham --infname X --outfname Y --n-simultaneous-seqs N_SEQS`