### PR TITLE
A few fixes to the docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -70,7 +70,7 @@ R --vanilla --slave -e 'install.packages(c("TreeSim", "TreeSimGM", "geiger", "MA
 ```
 The default mutation model also requires compilation of an updated (development) version of bpp that's in `packages/bpp-newlik/`:
 ```
-./bin/build.sh with-simulation  # this takes a while, maybe 20-60 mimutes
+./bin/build.sh with-simulation  # this takes a while, maybe 20-60 minutes
 ```
 However, if you don't much care about mutation model accuracy (in particular, if you don't care about modeling different rates between different bases e.g. A->C vs A->T), you can set `--no-per-base-mutation` and it'll fall back to an older, already-compiled bpp version in `packages/bpp`.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -68,7 +68,7 @@ You can then install the required R packages with:
 ```
 R --vanilla --slave -e 'install.packages(c("TreeSim", "TreeSimGM", "geiger", "MASS"), repos="http://cran.rstudio.com/", dependencies=TRUE)'
 ```
-The default mutation model also requires compilatoin of an updated (development) version of bpp that's in `packages/bpp-newlik/`:
+The default mutation model also requires compilation of an updated (development) version of bpp that's in `packages/bpp-newlik/`:
 ```
 ./bin/build.sh with-simulation  # this takes a while, maybe 20-60 mimutes
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -19,7 +19,7 @@ To paralellize over many machines, the slurm and sge batch systems are currently
 Typically, you can expect to annotate 10,000 sequences on an 8-core desktop in about five minutes, and partition in 25 minutes.
 If it's taking too long, or using too much memory, there are many ways to improve these by orders of magnitude by trading some accuracy, or by focusing only on specific aspects of the repertoire, described [here](subcommands.md#partition), [here](parallel.md) and [here](https://groups.google.com/forum/#!topic/partis/1IEfLapbStw).
 
-In addition to any output files specified with `--oufname` (described [here](output-formats.md)), partis writes to two directories on your file system.
+In addition to any output files specified with `--outfname` (described [here](output-formats.md)), partis writes to two directories on your file system.
 Temporary working files go in `--workdir`, which is entirely removed upon successful completion.
 The workdir defaults to a subdirectory of `/tmp` (`/tmp/$USER/hmms/<random.randint>`), and this default shouldn't need to be changed unless you're using a batch system to run on multiple machines, in which case it needs to be on a network mount that they can all see.
 Permament parameter files are written to `--parameter-dir`, which defaults to a subdirectory of the current directory (see [here](subcommands.md#cache-parameters)).

--- a/docs/subcommands.md
+++ b/docs/subcommands.md
@@ -43,7 +43,7 @@ In order to find the most likely annotation (VDJ assignment, deletion boundaries
 partis annotate --infname test/example.fa --outfname _output/example.yaml
 ```
 
-For information on parsing the output file, see [here](#output-formats.md).
+For information on parsing the output file, see [here](output-formats.md).
 
 ### partition
 
@@ -53,7 +53,7 @@ In order to cluster sequences into clonal families and annotate each family, run
 partis partition --infname test/example.fa --outfname _output/example.yaml
 ```
 
-For information on parsing the output file, see [here](#output-formats.md).
+For information on parsing the output file, see [here](output-formats.md).
 
 By default, this uses the most accurate and slowest method: hierarchical agglomeration with, first, hamming distance between naive sequences for distant clusters, and full likelihood calculation for more similar clusters. This method is typically appropriate (finishing in minutes to tens of hours) for tens of thousands of sequences on a laptop, or hundreds of thousands on a server. Because the usual optimizations that prevent clustering time from scaling quadratically with sample size do not translate well to BCR rearrangement space (at least not if you care about getting accurate clusters), run time varies significantly from sample to sample, hence the large range of quoted run times.
 


### PR DESCRIPTION
This just fixes two links to output-formats.md in the subcommands documentation and a few typos the install and quick-start files.