### PR TITLE
fix standalone disjoint grouping actions for batch workflows

### DIFF
--- a/docs/subcommands.md
+++ b/docs/subcommands.md
@@ -165,12 +165,15 @@ Since normal annotation, unlike partitioning, is easily split up into independen
 Split sequences for a single locus into disjoint CDR3 length groups, writing per-group FASTAs, per-group SW cache subsets, and a manifest to the output directory.
 Requires `--locus` and `--parameter-dir` (which must already contain an SW cache from a prior `cache-parameters` run).
 `--sw-cachefname` can point to a single SW cache file, a colon-separated list of files, or a directory containing multiple SW caches (e.g. from running cache-parameters independently on each part of a split input).
+When running `cache-parameters` independently on unpaired data for this purpose, pass `--paired-loci --no-pairing-info` so the parameter directory layout is compatible with downstream functions.
+At scale, merge only HMM parameters and germline sets across parts externally, and pass the directory of per-part SW caches to `--sw-cachefname` rather than merging them into one file.
 This is the standalone version of the grouping step in `--disjoint-groups` (see [above](#disjoint-groups)), intended for workflows where each step is submitted as a separate batch job.
 
 ### assemble-groups
 
 Concatenate per-group partition results from disjoint grouping into a single output file for one locus.
 Requires `--locus` and `--outfname`.
+If partition files are not recorded in the manifest (e.g. when partition was run as standalone batch jobs), they are auto-discovered in the group directories.
 This is the standalone version of the assembly step in `--disjoint-groups`, intended for workflows where each step is submitted as a separate batch job.
 
 ### merge-paired-partitions

--- a/partis/disjointgrouper.py
+++ b/partis/disjointgrouper.py
@@ -140,13 +140,10 @@ def get_partition_paths(manifest, manifest_dir):
     for ginfo in manifest['groups']:
         ppath = ginfo.get('partition_path')
         if ppath is None:
-            # try to discover partition file by globbing for partition-{locus}.yaml in the cdr3 group dir
-            discovered = glob.glob('%s/**/cdr3-%d/partition-%s.yaml' % (manifest_dir, ginfo['cdr3_length'], ginfo['locus']), recursive=True)
-            if len(discovered) == 1:
-                ppath = os.path.relpath(discovered[0], manifest_dir)
-            elif len(discovered) > 1:
-                print('      warning: found %d partition files for cdr3-%d, using first: %s' % (len(discovered), ginfo['cdr3_length'], discovered[0]))
-                ppath = os.path.relpath(discovered[0], manifest_dir)
+            # check default path: groups/cdr3-N/partition-{locus}.yaml
+            default_ppath = 'groups/cdr3-%d/partition-%s.yaml' % (ginfo['cdr3_length'], ginfo['locus'])
+            if os.path.exists('%s/%s' % (manifest_dir, default_ppath)):
+                ppath = default_ppath
             else:
                 skipped_groups.append(ginfo['group_id'])
                 continue
@@ -186,12 +183,20 @@ def validate_assembly(manifest, manifest_dir):
 # ----------------------------------------------------------------------------------------
 def resolve_sw_cache_paths(sw_cache_paths):
     # resolve <sw_cache_paths> to a list: accepts a single path string, a list of paths, or a directory
-    # (recursively globs for sw-cache*.yaml)
+    # for directory input, checks two expected patterns:
+    #   paired/chunked layout: {dir}/*/parameters/*/sw-cache*.yaml
+    #   flat unpaired layout:  {dir}/*/parameters/sw-cache*.yaml
     if isinstance(sw_cache_paths, str):
         if os.path.isdir(sw_cache_paths):
-            paths = sorted(glob.glob('%s/**/sw-cache*.yaml' % sw_cache_paths, recursive=True))
+            paths = sorted(glob.glob('%s/*/parameters/*/sw-cache*.yaml' % sw_cache_paths))
             if len(paths) == 0:
-                raise Exception('no sw-cache*.yaml files found in %s or its subdirectories' % sw_cache_paths)
+                paths = sorted(glob.glob('%s/*/parameters/sw-cache*.yaml' % sw_cache_paths))
+            if len(paths) == 0:
+                paths = sorted(glob.glob('%s/*/sw-cache*.yaml' % sw_cache_paths))
+            if len(paths) == 0:
+                paths = sorted(glob.glob('%s/sw-cache*.yaml' % sw_cache_paths))
+            if len(paths) == 0:
+                raise Exception('no sw-cache*.yaml files found in %s (checked */parameters/*/sw-cache*.yaml, */parameters/sw-cache*.yaml, */sw-cache*.yaml, sw-cache*.yaml)' % sw_cache_paths)
             return paths
         else:
             return [sw_cache_paths]

--- a/partis/disjointgrouper.py
+++ b/partis/disjointgrouper.py
@@ -170,12 +170,10 @@ def validate_assembly(manifest, manifest_dir):
 # ----------------------------------------------------------------------------------------
 def resolve_sw_cache_paths(sw_cache_paths):
     # resolve <sw_cache_paths> to a list: accepts a single path string, a list of paths, or a directory
-    # (globs for sw-cache*.yaml in subdirs, then in the directory itself)
+    # (recursively globs for sw-cache*.yaml)
     if isinstance(sw_cache_paths, str):
         if os.path.isdir(sw_cache_paths):
-            paths = sorted(glob.glob('%s/*/sw-cache*.yaml' % sw_cache_paths))
-            if len(paths) == 0:
-                paths = sorted(glob.glob('%s/sw-cache*.yaml' % sw_cache_paths))
+            paths = sorted(glob.glob('%s/**/sw-cache*.yaml' % sw_cache_paths, recursive=True))
             if len(paths) == 0:
                 raise Exception('no sw-cache*.yaml files found in %s or its subdirectories' % sw_cache_paths)
             return paths

--- a/partis/disjointgrouper.py
+++ b/partis/disjointgrouper.py
@@ -131,22 +131,26 @@ def validate_sequence_count(manifest):
 # ----------------------------------------------------------------------------------------
 def get_partition_paths(manifest, manifest_dir):
     # collect and verify partition file paths for a single locus
+    # groups with partition_path=None are skipped (e.g. groups too small to partition)
     paths = []
-    missing_partitions = []
+    skipped_groups = []
+    missing_files = []
     for ginfo in manifest['groups']:
         ppath = ginfo.get('partition_path')
         if ppath is None:
-            missing_partitions.append(ginfo['group_id'])
+            skipped_groups.append(ginfo['group_id'])
             continue
         full_ppath = '%s/%s' % (manifest_dir, ppath)
         if not os.path.exists(full_ppath):
-            missing_partitions.append(ginfo['group_id'])
+            missing_files.append(ginfo['group_id'])
             continue
         if os.path.getsize(full_ppath) == 0:
             raise Exception('partition file is empty for group %d: %s' % (ginfo['group_id'], full_ppath))
         paths.append(full_ppath)
-    if len(missing_partitions) > 0:
-        raise Exception('partition files missing for %d groups: %s' % (len(missing_partitions), missing_partitions))
+    if len(skipped_groups) > 0:
+        print('      skipping %d groups with no partition output (e.g. too small): %s' % (len(skipped_groups), skipped_groups))
+    if len(missing_files) > 0:
+        raise Exception('partition files missing for %d groups (partition_path set but file not found): %s' % (len(missing_files), missing_files))
     return paths
 
 # ----------------------------------------------------------------------------------------

--- a/partis/disjointgrouper.py
+++ b/partis/disjointgrouper.py
@@ -155,9 +155,11 @@ def get_partition_paths(manifest, manifest_dir):
 
 # ----------------------------------------------------------------------------------------
 def validate_assembly(manifest, manifest_dir):
-    # validate uid uniqueness and sequence counts by reading each group one at a time
+    # validate uid uniqueness and sequence counts by reading partitioned groups
     all_uids = set()
     total_seqs = 0
+    skipped = [g for g in manifest['groups'] if g.get('partition_path') is None]
+    skipped_seqs = sum(g['sequence_count'] for g in skipped)
     for ppath in get_partition_paths(manifest, manifest_dir):
         _, annotation_list, _ = utils.read_yaml_output(ppath, dont_add_implicit_info=True)
         for line in annotation_list:
@@ -166,10 +168,10 @@ def validate_assembly(manifest, manifest_dir):
                     raise Exception('duplicate uid %s found across groups' % uid)
                 all_uids.add(uid)
         total_seqs += sum(len(line['unique_ids']) for line in annotation_list)
-    expected = manifest['grouping-info']['total_grouped_sequences']
+    expected = manifest['grouping-info']['total_grouped_sequences'] - skipped_seqs
     if total_seqs != expected:
-        raise Exception('sequence count mismatch after assembly: found %d uids in partition files, expected %d' % (total_seqs, expected))
-    print('      assembly validation passed: %d unique sequences across %d groups' % (total_seqs, len(manifest['groups'])))
+        raise Exception('sequence count mismatch after assembly: found %d in partition files, expected %d (total %d minus %d skipped)' % (total_seqs, expected, manifest['grouping-info']['total_grouped_sequences'], skipped_seqs))
+    print('      assembly validation passed: %d sequences from %d groups (%d sequences in %d groups skipped)' % (total_seqs, len(manifest['groups']) - len(skipped), skipped_seqs, len(skipped)))
 
 # ----------------------------------------------------------------------------------------
 def resolve_sw_cache_paths(sw_cache_paths):

--- a/partis/disjointgrouper.py
+++ b/partis/disjointgrouper.py
@@ -131,15 +131,25 @@ def validate_sequence_count(manifest):
 # ----------------------------------------------------------------------------------------
 def get_partition_paths(manifest, manifest_dir):
     # collect and verify partition file paths for a single locus
-    # groups with partition_path=None are skipped (e.g. groups too small to partition)
+    # if partition_path is set in manifest, use it directly
+    # if partition_path is None, try to discover the partition file in the group dir
+    # (supports standalone partition jobs that do not update the manifest)
     paths = []
     skipped_groups = []
     missing_files = []
     for ginfo in manifest['groups']:
         ppath = ginfo.get('partition_path')
         if ppath is None:
-            skipped_groups.append(ginfo['group_id'])
-            continue
+            # try to discover partition file by globbing for partition-{locus}.yaml in the cdr3 group dir
+            discovered = glob.glob('%s/**/cdr3-%d/partition-%s.yaml' % (manifest_dir, ginfo['cdr3_length'], ginfo['locus']), recursive=True)
+            if len(discovered) == 1:
+                ppath = os.path.relpath(discovered[0], manifest_dir)
+            elif len(discovered) > 1:
+                print('      warning: found %d partition files for cdr3-%d, using first: %s' % (len(discovered), ginfo['cdr3_length'], discovered[0]))
+                ppath = os.path.relpath(discovered[0], manifest_dir)
+            else:
+                skipped_groups.append(ginfo['group_id'])
+                continue
         full_ppath = '%s/%s' % (manifest_dir, ppath)
         if not os.path.exists(full_ppath):
             missing_files.append(ginfo['group_id'])

--- a/partis/processargs.py
+++ b/partis/processargs.py
@@ -326,7 +326,7 @@ def process(args):
         args.workdir = get_workdir(args.batch_system)
     else:
         args.workdir = args.workdir.rstrip('/')
-    if os.path.exists(args.workdir):
+    if os.path.exists(args.workdir) and args.action not in ['create-disjoint-groups', 'assemble-groups']:
         raise Exception('workdir %s already exists' % args.workdir)
 
     if args.batch_system == 'sge' and args.batch_options is not None:


### PR DESCRIPTION
#### Summary

Fixes found while validating the disjoint grouping pipeline on soto-bcr benchmark subsets (1M sequences). These address compatibility issues when running create-disjoint-groups, partition, and assemble-groups as standalone batch jobs.

- Use recursive glob for SW cache discovery in nested directory structures
- Skip workdir-exists check for create-disjoint-groups and assemble-groups (these actions create subdirectories within an existing workdir)
- Skip groups with no partition output in assembly instead of erroring (supports excluding tiny groups from partition)
- Account for skipped groups in assembly sequence count validation
- Auto-discover partition files in group dirs when manifest partition_path is not set (supports standalone partition jobs that do not update the manifest)
- Document standalone workflow notes for unpaired data and at-scale parameter merging

#### Validation

Tested on soto-bcr Donor03 1M subset using the standalone batch workflow (chunked cache-parameters, multi-cache CDR3 grouping, per-group vsearch partition, assembly). Assembled output compared against v0 standard partition:

- 91% cluster consistency
- 28,257 vs 27,676 clusters (filtered to size >3)
- 574,020 shared sequences (99.5% overlap)
- Largest cluster identical (5,333 in both)

Per-step wall time comparison:

| Step | Disjoint vsearch (parallel) | Standard partition (v0) |
|------|----------------------------|------------------------|
| Cache-params | 42 min (2 chunks) | ~1 hr |
| CDR3 grouping | 5 min | n/a |
| Partition | 9 min (longest group) | 2:30 |
| Assembly | 58s | n/a |
| Total | ~60 min | ~3.5 hrs |

Max per-job memory: 17.5 GB (cache-params chunk) vs 20.7 GB (standard partition).