### PR TITLE
zig: bump glomerator cache-file read cap from 256 MiB to 4 GiB

### DIFF
--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -422,7 +422,10 @@ pub const Glomerator = struct {
             return;
         }
 
-        const content = try std.fs.cwd().readFileAlloc(allocator, self.args.input_cachefname, 256 * 1024 * 1024);
+        // 4 GiB cap accommodates collision-heavy paired runs (e.g. 50k all-singleton
+        // events) where the partition cache grows past 256 MiB. Not a memory guard —
+        // if RSS is genuinely tight the program will OOM regardless.
+        const content = try std.fs.cwd().readFileAlloc(allocator, self.args.input_cachefname, 4 * 1024 * 1024 * 1024);
         defer allocator.free(content);
 
         var line_iter = std.mem.splitScalar(u8, content, '\n');


### PR DESCRIPTION
Precondition for the issue #342 perf work: lets the 50k collision-sample serve as the
topic-branch acceptance test before merging to main.

## Problem

`readCacheFile()` in `src/ham/glomerator/glomerator.zig` used a 256 MiB cap on
`readFileAlloc` for the partition cache file. On collision-heavy paired runs
(e.g. `vs-n-sim-events/v1/.../n-sim-events-50000` — 100k seqs / 50k events,
nearly all singletons), the cache grows past 256 MiB during hieraglom and the
partition crashes with `error: FileTooBig` after ~1h49m of work, around iter 13
of clustering.

The 256 MiB cap was not protecting anything meaningful — if RSS is genuinely
tight the program OOMs regardless. Bumping to 4 GiB unblocks the 50k validation
sample called out in #342.

## Change

One-line bump in `glomerator.zig:425`, plus a comment explaining the rationale.

```zig
const content = try std.fs.cwd().readFileAlloc(allocator, self.args.input_cachefname, 4 * 1024 * 1024 * 1024);
```

## Validation

| Rung | Result |
|---|---|
| 0 (`zig build test`) | ✓ pass |
| 1 (`partis-test --quick --zig`) | ✓ pass |
| 2a (`partis-test --no-simu --zig`) | ✓ 0/40 naive seqs and 0/14 logprobs differ |
| 2b (`partis-test --paired --no-simu --zig`) | same pre-existing `subset-partition` failure as on main, identical w/ and w/o `--zig` (`max-ccf-fail-frac 0.15 < 0.190` missing-id frac); not introduced by this PR |
| 3 (500-seq paired) | ✓ identical to baseline (22.3s, 304 MB) |
| 4 (5k-seq paired) | ✓ identical to main baseline (5:10, 466 MB; 3797 igh + 3802 igk events) |
| pre-merge (30k-seq paired, full paper data) | ✓ identical to main baseline (1:34:13, 3.0 GB; 10802 igh + 10861 igk events) |
| pre-merge (50k-collision) | ✓ runs past iter 13 (where 256 MB cap previously crashed); finishing in background as topic-branch 50k baseline |

Validation harness: `/tmp/zig-compare.py` (events + naive seq + V/D/J fields + insertions + cdr3 length).

## Notes

- Issue #342's spec uses `--no-reduce-n-procs` for reproducibility; the flag was renamed to `--no-time-based-n-proc-reduction` in commit 54d21b1f7 / 0ad3f7443 after the issue was filed. All validation runs use the new name.
- Pre-existing `subset-partition` test failure on `main` (both backends) is unrelated to this PR. See validation row 2b.

Refs #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)