### PR TITLE
zig: materialize transitions as flat log_probs at finalize

### DIFF
--- a/packages/zig-core/src/ham/model.zig
+++ b/packages/zig-core/src/ham/model.zig
@@ -176,6 +176,12 @@ pub const Model = struct {
         // Build from_state_indices
         try self.addMaybeFasterFromStateStuff(allocator);
 
+        // Materialize flat log_probs and free *Transition allocations. Must run
+        // after every reader of to_state_name/to_state_ptr (finalizeState,
+        // reorderTransitions, checkTopology, addMaybeFasterFromStateStuff).
+        for (self.states.items) |st| try st.materializeTransitionLogProbs(allocator);
+        if (self.initial) |init_st| try init_st.materializeTransitionLogProbs(allocator);
+
         self.finalized = true;
     }
 

--- a/packages/zig-core/src/ham/state.zig
+++ b/packages/zig-core/src/ham/state.zig
@@ -39,11 +39,20 @@ pub const State = struct {
 
     /// Transitions to other states (not the "end" state), in parse order.
     /// After reorderTransitions(), reindexed to model order (with null sentinels for absent).
-    /// Each pointer is owned by this State.
+    /// Each pointer is owned by this State. Kept alive after finalize so print() can
+    /// resolve destination names; the hot path reads `log_probs` and ignores this.
     transitions: std.ArrayListUnmanaged(?*Transition),
-    /// Transition to the "end" state (null if none).
-    /// Owned by this State.
+    /// Transition to the "end" state (null if none). Owned by this State.
+    /// Kept alive after finalize for print(); the hot path reads `end_log_prob`.
     trans_to_end: ?*Transition,
+    /// Flat log-probabilities indexed by destination state, populated by
+    /// materializeTransitionLogProbs() at the end of Model.finalize. Replaces the
+    /// pointer-of-pointers chase in transitionLogprob() — that's the hottest data
+    /// access in the trellis DP. NEG_INF for absent transitions.
+    log_probs: []f64,
+    /// Log-probability for the transition to "end". Set during parse(); read by
+    /// endTransitionLogprob() in the hot path. NEG_INF if no end transition.
+    end_log_prob: f64,
 
     /// Emission model for this state.
     emission: Emission,
@@ -70,6 +79,8 @@ pub const State = struct {
             .ambiguous_char = &[_]u8{},
             .transitions = .{},
             .trans_to_end = null,
+            .log_probs = &[_]f64{},
+            .end_log_prob = mathutils.NEG_INF,
             .emission = Emission.init(),
             .index = std.math.maxInt(usize),
             .to_states = StateBitset.initEmpty(),
@@ -94,6 +105,7 @@ pub const State = struct {
             t.deinit(allocator);
             allocator.destroy(t);
         }
+        if (self.log_probs.len > 0) allocator.free(self.log_probs);
         self.emission.deinit(allocator);
         self.from_state_indices.deinit(allocator);
         self.to_state_indices.deinit(allocator);
@@ -157,6 +169,7 @@ pub const State = struct {
             trans.* = try Transition.init(allocator, to_state, prob);
             if (std.mem.eql(u8, to_state, "end")) {
                 self.trans_to_end = trans;
+                self.end_log_prob = trans.log_prob;
             } else {
                 try self.transitions.append(allocator, trans);
             }
@@ -204,19 +217,20 @@ pub const State = struct {
         return logprob;
     }
 
-    /// Transition log-probability to state at index `to_state` (post-reorder).
-    /// Returns -inf if no transition exists to that state.
+    /// Transition log-probability to state at index `to_state` (post-finalize).
+    /// Returns -inf if no transition exists to that state. Reads from the flat
+    /// `log_probs` array materialized at the end of Model.finalize — eliminates
+    /// the pointer-chain dereference that was the hottest data access in the
+    /// trellis DP.
     pub inline fn transitionLogprob(self: *const State, to_state: usize) f64 {
-        if (to_state >= self.transitions.items.len) return mathutils.NEG_INF;
-        const maybe_t = self.transitions.items[to_state];
-        return if (maybe_t) |t| t.log_prob else mathutils.NEG_INF;
+        if (to_state >= self.log_probs.len) return mathutils.NEG_INF;
+        return self.log_probs[to_state];
     }
 
     /// Log-probability for the transition to "end" (-inf if no such transition).
     /// Corresponds to C++ `State::end_transition_logprob()`.
     pub fn endTransitionLogprob(self: *const State) f64 {
-        if (self.trans_to_end) |t| return t.log_prob;
-        return mathutils.NEG_INF;
+        return self.end_log_prob;
     }
 
     /// Mark that this state transitions to `st`.
@@ -234,6 +248,25 @@ pub const State = struct {
     /// Set this state's index.
     pub fn setIndex(self: *State, val: usize) void {
         self.index = val;
+    }
+
+    /// Materialize a flat `log_probs: []f64` from `transitions` (post-reorder).
+    /// Called at the end of Model.finalize, after every reader of `to_state_name`
+    /// /`to_state_ptr` has run.
+    ///
+    /// Eliminates the pointer-chain dereference in transitionLogprob (the hottest
+    /// data access in the trellis DP). The original `*Transition` allocations
+    /// remain alive — print() walks them post-finalize to resolve destination
+    /// names. Memory cost is one f64 per state per slot (~2 MB total across all
+    /// loaded models); the wall-time win comes from the read pattern, not from
+    /// freeing.
+    pub fn materializeTransitionLogProbs(self: *State, allocator: std.mem.Allocator) !void {
+        std.debug.assert(self.log_probs.len == 0);
+        const n = self.transitions.items.len;
+        self.log_probs = try allocator.alloc(f64, n);
+        for (self.transitions.items, 0..) |maybe_t, i| {
+            self.log_probs[i] = if (maybe_t) |t| t.log_prob else mathutils.NEG_INF;
+        }
     }
 
     /// Reorder `transitions` to indexed order matching `state_indices` map.
@@ -403,7 +436,7 @@ test "State: normal state parse with emissions" {
     try std.testing.expectEqualStrings("state0", state.name);
     try std.testing.expectEqualStrings("A", state.germline_nuc);
     try std.testing.expectApproxEqAbs(@log(0.25), state.emissionLogprob(0), 1e-9);
-    // end transition stored in trans_to_end
+    // end_log_prob is set during parse() at the same site that creates trans_to_end
     try std.testing.expectApproxEqAbs(@log(1.0), state.endTransitionLogprob(), 1e-9);
 }
 


### PR DESCRIPTION
Issue #342 item 8: eliminate the pointer-chain dereference at the hottest data
access in the trellis DP.

## Change

`State.transitions` was `ArrayListUnmanaged(?*Transition)` — a flat array of heap
pointers to individually-allocated `Transition` objects. `transitionLogprob()` did
two dependent loads to reach `t.log_prob` (the only field used in the hot path):
`items[to_state] → *Transition → log_prob`.

This was the hottest data access in `MiddleViterbiVals`/`MiddleForwardVals` (called
once per (current_state, prev_state) pair per trellis position).

After every reader of `to_state_name` / `to_state_ptr` has run (`finalizeState`,
`reorderTransitions`, `checkTopology`, `addMaybeFasterFromStateStuff`),
`Model.finalize` now calls `State.materializeTransitionLogProbs()` which:

- allocates `log_probs: []f64` indexed by destination state (NEG_INF for absent)
- copies log_probs from `transitions.items[*].log_prob`

`transitionLogprob` reads from `log_probs[to_state]` (single load).
`endTransitionLogprob` reads from `end_log_prob` (set during `parse()`).

The original `*Transition` allocations remain alive so `print()` retains exact
parity (resolves destination names) — the wall-time win comes from the read
pattern, not from freeing. Memory cost: one extra f64 per state per slot
(~2 MB total across all loaded models, negligible vs GB-scale RSS).

## Validation

| Rung | Result |
|---|---|
| 0 (`zig build test`) | ✓ |
| 1 (`partis-test --quick --zig`) | ✓ |
| 2a (`partis-test --no-simu --zig`) | ✓ 0/40 naive seqs and 0/14 logprobs differ |
| 2b (`partis-test --paired --no-simu --zig`) | ✓ same pre-existing `subset-partition` failure as on main; not introduced |
| 3 (500-seq paired) | ✓ identical |
| 4 (5k-seq paired clean) | ✓ identical to baseline (5:06 vs 5:10, RSS 466 MB unchanged) |
| pre-merge (30k-seq paired) | ✓ identical to baseline, **1:17:05 wall (vs 1:31:11 baseline = 15.5% faster)**, RSS 3.0 GB unchanged; 10802 igh + 10861 igk events |
| 50k-collision | deferred — topic-branch 50k baseline pinned at `/tmp/zig-50kcoll-baseline`; 50k will be run as topic→main acceptance test, not per sub-PR |

Validation harness: `/tmp/zig-compare.py` (events + naive seq + V/D/J fields + insertions + cdr3 length).

## Performance

The DP hot path optimization shows a meaningful improvement at 30k scale:

| Workload | Baseline | This PR | Δ wall |
|---|---|---|---|
| 5k paired (clean) | 5:10 | 5:06 | within noise |
| 30k paired (clean) | 1:31:11 | 1:17:05 | **−15.5%** |

5k is dominated by IO + glomerator cache management; 30k is where the deeper
DP loops dominate and the pointer-chain elimination pays off.

RSS unchanged at every scale.

Refs #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)