### PR TITLE
zig: prune dead cluster caches in glomerator after each merge

### DIFF
--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -1646,20 +1646,18 @@ pub const Glomerator = struct {
     fn keyHasParent(key: []const u8, parent: []const u8) bool {
         if (key.len <= parent.len) return false;
         if (std.mem.startsWith(u8, key, parent) and key[parent.len] == ':') return true;
+        // key[key.len - parent.len - 1] is the byte immediately before the suffix match
+        // (i.e. the colon separator). The bounds check above guarantees this is in range.
         if (std.mem.endsWith(u8, key, parent) and key[key.len - parent.len - 1] == ':') return true;
         return false;
     }
 
-    /// Drop a single-cluster-keyed f64 entry, freeing the duped key.
-    fn pruneSingleKeyF64(self: *Glomerator, map: *std.StringHashMapUnmanaged(f64), key: []const u8) void {
-        if (map.fetchRemove(key)) |kv| self.allocator.free(kv.key);
-    }
-
-    /// Drop a single-cluster-keyed []u8 entry, freeing both key and value.
-    fn pruneSingleKeyU8(self: *Glomerator, map: *std.StringHashMapUnmanaged([]u8), key: []const u8) void {
+    /// Drop a single-cluster-keyed entry, freeing the duped key (and the duped value
+    /// when V == []u8). The `if (V == []u8)` branch is comptime-evaluated.
+    fn pruneSingleKey(self: *Glomerator, comptime V: type, map: *std.StringHashMapUnmanaged(V), key: []const u8) void {
         if (map.fetchRemove(key)) |kv| {
             self.allocator.free(kv.key);
-            self.allocator.free(kv.value);
+            if (V == []u8) self.allocator.free(kv.value);
         }
     }
 
@@ -1690,12 +1688,12 @@ pub const Glomerator = struct {
     /// (translation lookup paths). initial_* are read-only ingest-time guards
     /// for `--only-cache-new-vals` and must not be touched.
     fn pruneMergedParentCaches(self: *Glomerator, p1: []const u8, p2: []const u8) !void {
-        self.pruneSingleKeyF64(&self.log_probs, p1);
-        self.pruneSingleKeyF64(&self.log_probs, p2);
-        self.pruneSingleKeyU8(&self.naive_seqs, p1);
-        self.pruneSingleKeyU8(&self.naive_seqs, p2);
-        self.pruneSingleKeyU8(&self.errors, p1);
-        self.pruneSingleKeyU8(&self.errors, p2);
+        self.pruneSingleKey(f64, &self.log_probs, p1);
+        self.pruneSingleKey(f64, &self.log_probs, p2);
+        self.pruneSingleKey([]u8, &self.naive_seqs, p1);
+        self.pruneSingleKey([]u8, &self.naive_seqs, p2);
+        self.pruneSingleKey([]u8, &self.errors, p1);
+        self.pruneSingleKey([]u8, &self.errors, p2);
         try self.pruneParentPairsF64(&self.lratios, p1, p2);
         try self.pruneParentPairsF64(&self.naive_hfracs, p1, p2);
     }

--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -735,6 +735,10 @@ pub const Glomerator = struct {
         }
         self.tmp_cachefo.clearRetainingCapacity();
 
+        // Issue #342 item 7: parents p1 and p2 are no longer in the partition;
+        // drop their entries from the per-cluster and pair-keyed scoring caches.
+        try self.pruneMergedParentCaches(p1, p2);
+
         // Check if we're done
         const new_size = path.currentPartition().items.len;
         const new_largest = largestClusterSize(path.currentPartition());
@@ -1632,6 +1636,68 @@ pub const Glomerator = struct {
         }
         try self.errors.put(self.allocator, try self.allocator.dupe(u8, queries), new_err);
         try self.failed_queries.put(self.allocator, key, {});
+    }
+
+    // ── Cache pruning after merge (issue #342, item 7) ────────────────────────
+
+    /// True iff `key` is a pair-key (joinNames result, "name1:name2") with `parent`
+    /// occupying one whole side. Anchors at colon boundaries to avoid substring
+    /// false positives between distinct UID names (e.g. "u1" vs "u11").
+    fn keyHasParent(key: []const u8, parent: []const u8) bool {
+        if (key.len <= parent.len) return false;
+        if (std.mem.startsWith(u8, key, parent) and key[parent.len] == ':') return true;
+        if (std.mem.endsWith(u8, key, parent) and key[key.len - parent.len - 1] == ':') return true;
+        return false;
+    }
+
+    /// Drop a single-cluster-keyed f64 entry, freeing the duped key.
+    fn pruneSingleKeyF64(self: *Glomerator, map: *std.StringHashMapUnmanaged(f64), key: []const u8) void {
+        if (map.fetchRemove(key)) |kv| self.allocator.free(kv.key);
+    }
+
+    /// Drop a single-cluster-keyed []u8 entry, freeing both key and value.
+    fn pruneSingleKeyU8(self: *Glomerator, map: *std.StringHashMapUnmanaged([]u8), key: []const u8) void {
+        if (map.fetchRemove(key)) |kv| {
+            self.allocator.free(kv.key);
+            self.allocator.free(kv.value);
+        }
+    }
+
+    /// Drop every pair-keyed f64 entry whose key has p1 or p2 as one whole side.
+    /// Two-pass to avoid invalidating the map iterator: collect dead keys first,
+    /// then fetchRemove + free.
+    fn pruneParentPairsF64(self: *Glomerator, map: *std.StringHashMapUnmanaged(f64), p1: []const u8, p2: []const u8) !void {
+        var dead_keys: std.ArrayListUnmanaged([]const u8) = .{};
+        defer dead_keys.deinit(self.allocator);
+        var it = map.iterator();
+        while (it.next()) |e| {
+            const k = e.key_ptr.*;
+            if (keyHasParent(k, p1) or keyHasParent(k, p2)) {
+                try dead_keys.append(self.allocator, k);
+            }
+        }
+        for (dead_keys.items) |k| {
+            if (map.fetchRemove(k)) |kv| self.allocator.free(kv.key);
+        }
+    }
+
+    /// After a merge of (p1, p2) → AB, drop entries that are now unreachable:
+    ///   - log_probs[p1], log_probs[p2]
+    ///   - naive_seqs[p1], naive_seqs[p2]      (NOT naive_seqs[AB] — that's live)
+    ///   - errors[p1], errors[p2]
+    ///   - lratios[K] / naive_hfracs[K] for every K = joinNames(p1, _) or joinNames(p2, _)
+    /// Cachefo / single_seqs / single_seq_cachefo are intentionally retained
+    /// (translation lookup paths). initial_* are read-only ingest-time guards
+    /// for `--only-cache-new-vals` and must not be touched.
+    fn pruneMergedParentCaches(self: *Glomerator, p1: []const u8, p2: []const u8) !void {
+        self.pruneSingleKeyF64(&self.log_probs, p1);
+        self.pruneSingleKeyF64(&self.log_probs, p2);
+        self.pruneSingleKeyU8(&self.naive_seqs, p1);
+        self.pruneSingleKeyU8(&self.naive_seqs, p2);
+        self.pruneSingleKeyU8(&self.errors, p1);
+        self.pruneSingleKeyU8(&self.errors, p2);
+        try self.pruneParentPairsF64(&self.lratios, p1, p2);
+        try self.pruneParentPairsF64(&self.naive_hfracs, p1, p2);
     }
 
     /// C++: Glomerator::JoinNames() — glomerator.cc:404


### PR DESCRIPTION
Issue #342 item 7: after a merge of `(p1, p2) → AB`, parents `p1` and `p2` will never appear as separate clusters again (agglomerative clustering only merges, never splits). Their entries in the per-cluster scoring caches and pair-keyed scoring caches are unreachable.

## Change

Add `pruneMergedParentCaches()` and call it once per merge step at the natural hook point in `merge()` — right after the partition is rebuilt and `tmp_cachefo` is cleared, before the termination check.

**Single-cluster-keyed maps** (direct `fetchRemove` of `p1` and `p2`):
- `log_probs`
- `naive_seqs`
- `errors`

**Pair-keyed maps** (two-pass scan + `fetchRemove`):
- `lratios` — keyed by `joinNames(a, b) = sorted "a:b"`
- `naive_hfracs` — same key shape

Pair-keyed scan uses a colon-anchored prefix/suffix check (`startsWith parent ++ ":"` or `endsWith ":" ++ parent`) to avoid substring false positives between distinct UID names (e.g. `"u1"` vs `"u11"`). It also catches the just-finished pair entry `lratios[chosen.name]` since `chosen.name = joinNames(p1, p2)` necessarily starts with `"p1:"` or ends with `":p1"`.

## Caches deliberately left alone

- `cachefo`, `single_seq_cachefo`, `single_seqs` — translation lookup paths in `getNaiveSeqNameToCalculate` / `getLogProbPairOfNamesToCalculate` not yet audited (per issue spec).
- `initial_log_probs`, `initial_naive_hfracs`, `initial_naive_seqs` — read-only ingest-time guards used only for `--only-cache-new-vals` filtering during cache-file write. Pruning would corrupt the "is this entry from input cache?" check.
- `failed_queries` — out of issue spec.

## Subcluster-annotation audit

@psathyrella flagged that subcluster annotation may re-read caches for already-merged parents. Audited:

- All Zig-side annotation in glomerator is no-op (`WriteAnnotations is deprecated in C++; skip` at glomerator.zig:368-370).
- Subcluster annotation lives entirely on the Python side in `partitiondriver.py:1405+`. It takes the final partition, splits clusters into subclusters via `getsubclusters()`, and cyclically re-annotates and re-merges those sub-pieces. The relevant criterion for this PR is that it makes its annotations from scratch (fresh HMM runs per subcluster), **not** by reading the glomerator cache file or in-memory Zig caches. So whatever intermediate sub-cluster names it constructs, none of those queries route back to the maps this PR is pruning.

Safe to prune at merge time. (Thanks to @psathyrella for [the correction](https://github.com/psathyrella/partis/pull/353#issuecomment-4353558880) on the audit framing — the \"never queries intermediate names\" framing was wrong; \"doesn't read the glomerator cache\" is the right criterion.)

## Validation

| Rung | Result |
|---|---|
| 0 (\`zig build test\`) | ✓ |
| 1 (\`partis-test --quick --zig\`) | ✓ |
| 2a (\`partis-test --no-simu --zig\`) | ✓ live-entry naive seqs and logprobs identical (0/37 and 0/14 differ); test framework reports \"3 only in ref version\" naive_seqs keys in the persistent cache file — those are dead intermediate entries that the baseline persisted; this is the cleanup item 7 was designed to do |
| 2b (\`partis-test --paired --no-simu --zig\`) | ✓ same pre-existing \`subset-partition\` crash as on \`main\` (per [handoff comment](https://github.com/psathyrella/partis/issues/342#issuecomment-4351817709)); not introduced |
| 4 (5k paired clean) | ✓ identical to baseline (3797 igh + 3802 igk events); wall 5:02 vs baseline 5:10 (within noise); RSS 466 MB unchanged |
| pre-merge (30k paired clean) | ✓ identical to baseline (10802 igh + 10861 igk events); wall **1:15:35** vs baseline 1:31:11; RSS **3.04 GB unchanged** |

Validation harness: `/tmp/zig-compare.py` (events + naive seq + V/D/J fields + insertions + cdr3 length).

## Performance

| Workload | Baseline | This PR | Δ wall | Δ peak RSS |
|---|---|---|---|---|
| 5k paired (clean) | 5:10 | 5:02 | within noise | 467 → 466 MB |
| 30k paired (clean) | 1:31:11 | 1:15:35 | within noise vs topic-after-#352 (1:17:05) | 3.0 → 3.04 GB |

**Honest report on memory impact:** the issue called item 7 the \"single largest memory win,\" but **30k peak RSS is essentially unchanged**. Likely reasons:

1. The five target caches store small entries (f64 values + ~50–200-byte string keys). Even at hundreds of thousands of entries, total bytes are tens of MB — negligible vs 3 GB peak driven by DPHandler matrices, `single_seqs`, and `cachefo`.
2. `c_allocator` (glibc malloc) rarely returns freed memory to the OS, so freeing key strings allows internal reuse but doesn't deduct from RSS unless the freed slots service later same-size allocations.
3. Peak RSS likely occurs during DP matrix allocation, not during glomerator cache growth.

The PR is still worth landing: the prune prevents unbounded cache growth in long-running configurations (per the issue's stated motivation), reduces the persistent cache file size, and is byte-identical on output. The benefit may be larger on the 50k-collision workload — to be measured at topic→main acceptance.

This continues the pattern noted in the [handoff comment](https://github.com/psathyrella/partis/issues/342#issuecomment-4351817709): \"the predictions can be wrong (item 1 is the example). Always measure.\"

## Side effect

Persistent partition cache file no longer contains entries for intermediate (merged-away) clusters. Future runs that reuse this cache file lose potential hits on those entries — but they're hits on clusters that don't exist as candidates at runtime, so likely zero impact on cache reuse.

Refs #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)
