### PR TITLE
zig: trellis hot-path pointer cleanup (items 9, 13, 19)

### DIFF
--- a/packages/zig-core/src/ham/model.zig
+++ b/packages/zig-core/src/ham/model.zig
@@ -131,18 +131,22 @@ pub const Model = struct {
         }
         for (td.symbols.items) |sym| try trk.addSymbol(allocator, sym);
 
-        // Collect state names for transition validation
+        // Collect state names for transition validation, and count non-init
+        // states so we can reserve flat-slice capacity in one shot. The capacity
+        // reservation is what makes `&states.items[i]` pointers stable — without
+        // it, addOneAssumeCapacity below would assert.
         var state_names: std.ArrayListUnmanaged([]const u8) = .{};
         defer state_names.deinit(allocator);
-        for (data.states.items) |*sd| try state_names.append(allocator, sd.name);
-
-        // Reserve flat-slice capacity for non-init states up front so addOne
-        // never reallocates — that's what makes `&states.items[i]` stable.
         var n_non_init: usize = 0;
         for (data.states.items) |*sd| {
+            try state_names.append(allocator, sd.name);
             if (!std.mem.eql(u8, sd.name, "init")) n_non_init += 1;
         }
-        if (n_non_init >= @import("state.zig").STATE_MAX) return error.TooManyStates;
+        // Match the C++/old behavior of allowing exactly STATE_MAX non-init
+        // states. The old code checked `items.len >= STATE_MAX` immediately
+        // before each append, so the (N+1)-th append (when items.len was
+        // already N==STATE_MAX) was the one that errored.
+        if (n_non_init > @import("state.zig").STATE_MAX) return error.TooManyStates;
         try self.states.ensureTotalCapacityPrecise(allocator, n_non_init);
 
         // Parse each state
@@ -199,6 +203,14 @@ pub const Model = struct {
                 try self.states_by_name.put(slot.name, slot);
             }
         }
+
+        // Make the stable-pointer invariant machine-checkable: any future code
+        // that accidentally appends to self.states would reallocate the slice
+        // and silently invalidate every *State held by states_by_name and by
+        // Transition.to_state_ptr. The capacity reservation above sized the
+        // slice to exactly n_non_init; if items.len ever drifts from capacity,
+        // the invariant has been broken.
+        std.debug.assert(self.states.items.len == self.states.capacity);
 
         try self.finalize(allocator);
     }

--- a/packages/zig-core/src/ham/model.zig
+++ b/packages/zig-core/src/ham/model.zig
@@ -173,9 +173,14 @@ pub const Model = struct {
                 // never reallocates and the &slot pointer is stable.
                 const slot = self.states.addOneAssumeCapacity();
                 slot.* = State.init();
-                // Roll back the addOne if parse or put fails — pop() removes the
-                // slot so deinit doesn't try to free a partially-built State that
-                // is also handled by the local cleanup here.
+                // Roll back the addOne if parse or states_by_name.put fails.
+                // Order matters: `slot.deinit` must precede `pop`, because after
+                // pop the slot index is past states.items.len and a later
+                // model.deinit would not see it. Conversely, without pop, the
+                // slot would still live in states.items and model.deinit would
+                // re-deinit it (double free). If states_by_name.put is the
+                // failing call, no key was stored (put is failure-atomic), so
+                // freeing slot.name in deinit doesn't dangle a map entry.
                 errdefer {
                     slot.deinit(allocator);
                     _ = self.states.pop();

--- a/packages/zig-core/src/ham/model.zig
+++ b/packages/zig-core/src/ham/model.zig
@@ -32,9 +32,19 @@ pub const Model = struct {
     /// Track (alphabet). Owned by this Model.
     track: ?*Track,
 
-    /// All non-init states in model order. Each pointer is heap-allocated and owned.
-    states: std.ArrayListUnmanaged(*State),
-    /// Map from state name to State pointer (pointers owned via `states` or `initial`).
+    /// All non-init states in model order. Stored as values in a flat slice so the
+    /// hot path (Trellis.middleViterbi/Forward, which call `stateByIndex` once per
+    /// (current, prev) pair per position) does a single index instead of an extra
+    /// pointer dereference. Capacity is reserved once in `parse` from the YAML
+    /// state count and never grown afterward, so `*State` pointers obtained via
+    /// `&states.items[i]` remain stable for the lifetime of the Model — that
+    /// invariant is what lets `states_by_name` and Transition.to_state_ptr keep
+    /// holding `*State` directly.
+    states: std.ArrayListUnmanaged(State),
+    /// Map from state name to State pointer. Non-init pointers reference into
+    /// `states.items`; the init pointer references the separately heap-allocated
+    /// `initial`. The Model never grows `states` after parse, so these pointers
+    /// stay valid for the Model's lifetime.
     states_by_name: std.StringHashMap(*State),
     /// The "init" state. Owned.
     initial: ?*State,
@@ -66,15 +76,20 @@ pub const Model = struct {
     pub fn deinit(self: *Model, allocator: std.mem.Allocator) void {
         allocator.free(self.name);
         allocator.free(self.ambiguous_char);
-        // Free all states via states_by_name (owns all State pointers)
-        var it = self.states_by_name.valueIterator();
-        while (it.next()) |st_ptr| {
-            st_ptr.*.deinit(allocator);
-            allocator.destroy(st_ptr.*);
-        }
-        self.states_by_name.deinit();
+        // Non-init states live as values in the flat slice — deinit each in place,
+        // then free the slice's backing storage. No allocator.destroy: the State
+        // values were never individually heap-allocated.
+        for (self.states.items) |*st| st.deinit(allocator);
         self.states.deinit(allocator);
-        // ending is separate
+        // states_by_name pointers reference into states.items / initial / ending.
+        // Just free the map's own storage.
+        self.states_by_name.deinit();
+        // init and ending are separately heap-allocated (init is not in
+        // states.items by construction; ending is synthetic and never indexed).
+        if (self.initial) |init_st| {
+            init_st.deinit(allocator);
+            allocator.destroy(init_st);
+        }
         self.ending.deinit(allocator);
         allocator.destroy(self.ending);
         if (self.track) |t| {
@@ -121,34 +136,63 @@ pub const Model = struct {
         defer state_names.deinit(allocator);
         for (data.states.items) |*sd| try state_names.append(allocator, sd.name);
 
+        // Reserve flat-slice capacity for non-init states up front so addOne
+        // never reallocates — that's what makes `&states.items[i]` stable.
+        var n_non_init: usize = 0;
+        for (data.states.items) |*sd| {
+            if (!std.mem.eql(u8, sd.name, "init")) n_non_init += 1;
+        }
+        if (n_non_init >= @import("state.zig").STATE_MAX) return error.TooManyStates;
+        try self.states.ensureTotalCapacityPrecise(allocator, n_non_init);
+
         // Parse each state
         for (data.states.items) |*sd| {
-            const st = try allocator.create(State);
-            errdefer {
-                st.deinit(allocator);
-                allocator.destroy(st);
-            }
-            st.* = State.init();
-
-            try st.parse(
-                allocator,
-                sd.name,
-                sd.germline_nuc,
-                sd.ambiguous_emission_prob,
-                sd.ambiguous_char,
-                sd.transitions,
-                if (sd.emissions) |*em| em.probs else null,
-                state_names.items,
-                trk,
-            );
-
             if (std.mem.eql(u8, sd.name, "init")) {
+                // init stays in its own heap allocation (one per Model, not indexed).
+                const st = try allocator.create(State);
+                errdefer {
+                    st.deinit(allocator);
+                    allocator.destroy(st);
+                }
+                st.* = State.init();
+                try st.parse(
+                    allocator,
+                    sd.name,
+                    sd.germline_nuc,
+                    sd.ambiguous_emission_prob,
+                    sd.ambiguous_char,
+                    sd.transitions,
+                    if (sd.emissions) |*em| em.probs else null,
+                    state_names.items,
+                    trk,
+                );
                 self.initial = st;
+                try self.states_by_name.put(st.name, st);
             } else {
-                if (self.states.items.len >= @import("state.zig").STATE_MAX) return error.TooManyStates;
-                try self.states.append(allocator, st);
+                // Grow the flat slice by one slot; capacity reserved above so this
+                // never reallocates and the &slot pointer is stable.
+                const slot = self.states.addOneAssumeCapacity();
+                slot.* = State.init();
+                // Roll back the addOne if parse or put fails — pop() removes the
+                // slot so deinit doesn't try to free a partially-built State that
+                // is also handled by the local cleanup here.
+                errdefer {
+                    slot.deinit(allocator);
+                    _ = self.states.pop();
+                }
+                try slot.parse(
+                    allocator,
+                    sd.name,
+                    sd.germline_nuc,
+                    sd.ambiguous_emission_prob,
+                    sd.ambiguous_char,
+                    sd.transitions,
+                    if (sd.emissions) |*em| em.probs else null,
+                    state_names.items,
+                    trk,
+                );
+                try self.states_by_name.put(slot.name, slot);
             }
-            try self.states_by_name.put(st.name, st);
         }
 
         try self.finalize(allocator);
@@ -160,14 +204,14 @@ pub const Model = struct {
         std.debug.assert(!self.finalized);
 
         // Assign indices to all non-init states
-        for (self.states.items, 0..) |st, i| st.setIndex(i);
+        for (self.states.items, 0..) |*st, i| st.setIndex(i);
 
         // Set to/from connectivity for each non-init state
-        for (self.states.items) |st| try self.finalizeState(st);
+        for (self.states.items) |*st| try self.finalizeState(st);
         if (self.initial) |init_st| try self.finalizeState(init_st);
 
         // Reorder transitions in index order
-        for (self.states.items) |st| try st.reorderTransitions(allocator, &self.states_by_name);
+        for (self.states.items) |*st| try st.reorderTransitions(allocator, &self.states_by_name);
         if (self.initial) |init_st| try init_st.reorderTransitions(allocator, &self.states_by_name);
 
         // Check topology
@@ -179,7 +223,7 @@ pub const Model = struct {
         // Materialize flat log_probs and free *Transition allocations. Must run
         // after every reader of to_state_name/to_state_ptr (finalizeState,
         // reorderTransitions, checkTopology, addMaybeFasterFromStateStuff).
-        for (self.states.items) |st| try st.materializeTransitionLogProbs(allocator);
+        for (self.states.items) |*st| try st.materializeTransitionLogProbs(allocator);
         if (self.initial) |init_st| try init_st.materializeTransitionLogProbs(allocator);
 
         self.finalized = true;
@@ -208,7 +252,7 @@ pub const Model = struct {
             try init_st.setFromStateIndices(allocator);
             try init_st.setToStateIndices(allocator);
         }
-        for (self.states.items) |st| {
+        for (self.states.items) |*st| {
             try st.setFromStateIndices(allocator);
             try st.setToStateIndices(allocator);
         }
@@ -236,7 +280,7 @@ pub const Model = struct {
 
             var tmp: std.ArrayListUnmanaged(u16) = .{};
             defer tmp.deinit(allocator);
-            try self.addToStateIndicesHelper(allocator, self.states.items[icheck], &tmp);
+            try self.addToStateIndicesHelper(allocator, &self.states.items[icheck], &tmp);
             const num_visited = tmp.items.len;
 
             if (num_visited == 0) {
@@ -254,7 +298,7 @@ pub const Model = struct {
 
         // At least one transition to end
         var found_end = false;
-        for (self.states.items) |st| {
+        for (self.states.items) |*st| {
             if (st.trans_to_end != null) {
                 found_end = true;
                 break;
@@ -286,13 +330,13 @@ pub const Model = struct {
         std.debug.assert(!std.math.isNegativeInf(overall_mute_freq));
         if (self.original_overall_mute_freq == 0.0) return error.ZeroOriginalMuteFreq;
         const factor = @max(0.01, overall_mute_freq) / self.original_overall_mute_freq;
-        for (self.states.items) |st| try st.rescaleOverallMuteFreq(allocator, factor);
+        for (self.states.items) |*st| try st.rescaleOverallMuteFreq(allocator, factor);
     }
 
     /// Undo rescaling.
     /// Corresponds to C++ `Model::UnRescaleOverallMuteFreq()`.
     pub fn unRescaleOverallMuteFreq(self: *Model, allocator: std.mem.Allocator) void {
-        for (self.states.items) |st| st.unRescaleOverallMuteFreq(allocator);
+        for (self.states.items) |*st| st.unRescaleOverallMuteFreq(allocator);
     }
 
     pub fn nStates(self: *const Model) usize {
@@ -304,7 +348,7 @@ pub const Model = struct {
     }
 
     pub inline fn stateByIndex(self: *const Model, idx: usize) *State {
-        return self.states.items[idx];
+        return &self.states.items[idx];
     }
 
     pub fn initState(self: *const Model) ?*State {

--- a/packages/zig-core/src/ham/state.zig
+++ b/packages/zig-core/src/ham/state.zig
@@ -209,8 +209,11 @@ pub const State = struct {
     /// Accumulates log-probs for each sequence at that position.
     /// Corresponds to C++ `State::EmissionLogprob(Sequences*, size_t pos)`.
     pub inline fn emissionLogprobSeqs(self: *const State, seqs: *const Sequences, pos: usize) f64 {
-        // Single-sequence fast path. addWithMinusInfinities(0.0, x) == x for all
-        // x (including NEG_INF), so collapsing the one-iteration loop is exact.
+        // Single-sequence fast path. The general loop's first (and only)
+        // iteration computes addWithMinusInfinities(0.0, emissionLogprob(...)),
+        // which equals emissionLogprob(...) for every value including NEG_INF
+        // (addWithMinusInfinities propagates NEG_INF; for finite x, 0.0 + x == x).
+        // So the direct return is bit-identical to running the loop once.
         if (seqs.nSeqs() == 1) {
             return self.emissionLogprob(seqs.get(0).seqq[pos]);
         }

--- a/packages/zig-core/src/ham/state.zig
+++ b/packages/zig-core/src/ham/state.zig
@@ -211,9 +211,13 @@ pub const State = struct {
     pub inline fn emissionLogprobSeqs(self: *const State, seqs: *const Sequences, pos: usize) f64 {
         // Single-sequence fast path. The general loop's first (and only)
         // iteration computes addWithMinusInfinities(0.0, emissionLogprob(...)),
-        // which equals emissionLogprob(...) for every value including NEG_INF
-        // (addWithMinusInfinities propagates NEG_INF; for finite x, 0.0 + x == x).
-        // So the direct return is bit-identical to running the loop once.
+        // which equals emissionLogprob(...) for every value emissionLogprob can
+        // return: finite logprobs (0.0 + x == x) and NEG_INF (the function
+        // propagates -inf). emissionLogprob never returns NaN — its outputs come
+        // from the precomputed log-probability slice and the stored
+        // ambiguous_emission_logprob, both of which are seeded from log() of
+        // probabilities — so the fast path is value-identical to running the
+        // loop once.
         if (seqs.nSeqs() == 1) {
             return self.emissionLogprob(seqs.get(0).seqq[pos]);
         }

--- a/packages/zig-core/src/ham/state.zig
+++ b/packages/zig-core/src/ham/state.zig
@@ -208,7 +208,12 @@ pub const State = struct {
     /// Emission log-probability for a position in a Sequences object.
     /// Accumulates log-probs for each sequence at that position.
     /// Corresponds to C++ `State::EmissionLogprob(Sequences*, size_t pos)`.
-    pub fn emissionLogprobSeqs(self: *const State, seqs: *const Sequences, pos: usize) f64 {
+    pub inline fn emissionLogprobSeqs(self: *const State, seqs: *const Sequences, pos: usize) f64 {
+        // Single-sequence fast path. addWithMinusInfinities(0.0, x) == x for all
+        // x (including NEG_INF), so collapsing the one-iteration loop is exact.
+        if (seqs.nSeqs() == 1) {
+            return self.emissionLogprob(seqs.get(0).seqq[pos]);
+        }
         var logprob: f64 = 0.0;
         for (0..seqs.nSeqs()) |iseq| {
             const seq = seqs.get(iseq);

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -371,7 +371,7 @@ pub const Trellis = struct {
         }
     }
 
-    fn cacheViterbiVals(self: *Trellis, position: usize, dpval: f64, i_st_cur: usize) void {
+    inline fn cacheViterbiVals(self: *Trellis, position: usize, dpval: f64, i_st_cur: usize) void {
         const end_trans = self.hmm.stateByIndex(i_st_cur).endTransitionLogprob();
         const logprob = dpval + end_trans;
         if (logprob > self.viterbi_log_probs.items[position]) {
@@ -380,7 +380,7 @@ pub const Trellis = struct {
         }
     }
 
-    fn cacheForwardVals(self: *Trellis, position: usize, dpval: f64, i_st_cur: usize) void {
+    inline fn cacheForwardVals(self: *Trellis, position: usize, dpval: f64, i_st_cur: usize) void {
         const end_trans = self.hmm.stateByIndex(i_st_cur).endTransitionLogprob();
         const logprob = dpval + end_trans;
         self.forward_log_probs.items[position] = mathutils.addInLogSpace(logprob, self.forward_log_probs.items[position]);


### PR DESCRIPTION
## Summary

Three items from #342 bundled because they all touch the same trellis hot-path concern (reduce indirection per `(position, state, prev_state)` work) and share one validation gate. **The 30k wall-time win predicted by item 9 did not materialize in measurement** — see results below.

### Item 9 — flatten `Model.states` pointer-of-pointers to flat slice

`Model.states: ArrayListUnmanaged(*State)` → `ArrayListUnmanaged(State)`. `stateByIndex(i)` was a slice index plus a heap-pointer dereference; it's now a single `&self.states.items[i]`. Same theme as #352 did for transitions, one level up.

The non-trivial part is keeping `*State` pointers in `states_by_name` and `Transition.to_state_ptr` stable. Solution: count non-init states from the parsed YAML up front, `ensureTotalCapacityPrecise(allocator, n_non_init)`, then `addOneAssumeCapacity` per state. The slice never grows past its initial capacity, so `&states.items[i]` stays valid for the Model's lifetime. A `std.debug.assert(items.len == capacity)` after the parse loop makes the invariant machine-checkable so a future stray `states.append` trips a debug build immediately.

`init` and `ending` stay separately heap-allocated (they're not regular indexed states; specials avoiding hot-path branches). `deinit` reorganized: iterate `states.items` as values, free the slice's backing storage, then handle `init`/`ending` separately.

### Items 13 + 19 — inline trellis helpers, single-seq emission fast path

- `inline` keyword on `cacheViterbiVals`, `cacheForwardVals` (`trellis.zig`) and `emissionLogprobSeqs` (`state.zig`). Under ReleaseFast the compiler likely already inlined these; the keyword removes any doubt and signals "hot-path leaf" to future readers.
- Single-sequence fast path in `emissionLogprobSeqs`: bypasses the one-trip loop and `addWithMinusInfinities(0.0, x)` call when `nSeqs() == 1`. Value-identical for every input emissionLogprob can produce. Fires in annotate-mode single-cluster runs; not in partition's multi-seq cluster joins.

## Validation

| Rung | Result |
|---|---|
| 0 — `zig build test` | pass |
| 1 — `partis-test.py --quick --zig` | pass |
| 2a — `partis-test.py --no-simu --zig` | pass; 0/37 naive_seq diffs, 0/14 logprob diffs vs ref |
| 2b — `partis-test.py --paired --no-simu --zig` | pass (all steps green, including subset-partition with `--max-ccf-fail-frac 0.25`) |
| 3 — 5k paired clean | byte-identical to `/tmp/zig-5k-baseline` (3797 igh + 3802 igk events). Wall 5:05 vs 5:10 baseline (within noise). RSS 467 MB unchanged. |
| 4 — 30k paired clean | byte-identical to `/tmp/zig-30k-baseline` (10802 igh + 10861 igk events). **Wall 1:16:33 vs 1:15:35 topic-tip after #353 — within single-run noise but no measurable win.** RSS 3.04 GB unchanged. |

## Honest assessment of the perf result

Item 9 was predicted by the issue body to be a "Medium impact" win on top of #352. At 30k it didn't show. Likely reasons:

- After #352 already flattened the hottest data access (`State.log_probs[]`), the residual cost of `stateByIndex` pointer-chasing is small relative to other inner-loop work (emission lookup, `addInLogSpace`).
- Heap-allocated States likely sat near-sequentially in memory after `c_allocator` returned consecutive `mmap`'d pages, so the "pointer chase" was rarely a true cache miss.
- The compiler may have been inlining `stateByIndex` such that the indirection was already CSE'd in the inner loop.

This is exactly the scenario the handoff comment warns about: *"the predictions can be wrong (items 1 and 7 are the examples). Always measure."*

**Why ship anyway.** Code quality wins independent of wall-time:
- Replaces ~500 small allocations per `Model.parse()` (one per State) with a single slice allocation. Less alloc/free churn at startup; less work for the allocator's metadata structures.
- Simpler `deinit` (one loop over the flat slice, no per-State `destroy`).
- Eliminates a class of latent ownership bugs (the prior code required `states_by_name` to own `*State` pointers heap-allocated separately from the `states` array — easy to get wrong on extension). The capacity-reservation invariant replaces that with a single explicit assertion.
- Sets up future cache-locality work (item 21, etc.) that would want to iterate the flat State array directly, possibly with SIMD-friendly layouts.

**Tradeoff to acknowledge.** The new `parse()` loop has two structurally different branches (init heap-allocates and heap-destroys; non-init slot-writes into a pre-reserved slice with an order-dependent `errdefer` that must `deinit` before `pop`). That is a real complexity increase vs the old uniform "every state is heap-allocated the same way" pattern. The deinit improvement is genuine; the parse improvement is not — it's a tradeoff favoring lifetime simplicity (one slice owns everything) over construction-time symmetry. The asymmetric cleanup is documented at the call site; whether the tradeoff is worth it depends on how much weight you put on the resulting deinit clarity vs the parse-loop complexity.

If reviewers prefer to drop item 9 on the no-measurable-win basis, the commit is independent and easy to revert.

## Test plan

- [x] Rungs 0–3 (paired iteration gate) all green
- [x] 30k byte-equality vs `/tmp/zig-30k-baseline`
- [x] zig-code-reviewer pass; comments tightened on errdefer ordering invariant and single-seq fast-path identity argument
- [x] clean-code-reviewer pass; fixed STATE_MAX off-by-one, added capacity-invariant assertion, merged duplicate iteration over `data.states`, tightened "bit-identical" wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)