### PR TITLE
zig: borrow seqs from single_seqs in glomerator (#342 item 6)

### DIFF
--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -44,6 +44,14 @@ pub const Glomerator = struct {
     initial_partition: Partition,
 
     /// All actual sequences, keyed by sequence name.
+    ///
+    /// Write-once during `init`; **frozen** thereafter (no inserts, no
+    /// removals, no replacements). Per issue #342 item 6, every other
+    /// `Query.seqs` in the glomerator borrows from these buffers via
+    /// shallow copies, so mutating this map post-init would invalidate
+    /// those borrows and produce use-after-free on the slice fields.
+    /// Adding any write to this map outside `init` requires reworking
+    /// the borrowed-Sequence contract (see Query struct doc).
     single_seqs: std.StringHashMapUnmanaged(Sequence),
     /// Single-sequence cache entries.
     single_seq_cachefo: std.StringHashMapUnmanaged(Query),

--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -185,7 +185,7 @@ pub const Glomerator = struct {
                 if (!self.single_seq_cachefo.contains(uid)) {
                     const uid_seqs = try self.getSeqs(uid);
                     defer {
-                        for (uid_seqs.items) |*sq| sq.deinit(allocator);
+                        // uid_seqs items are borrowed (item 6); only free the list.
                         var s = uid_seqs;
                         s.deinit(allocator);
                     }
@@ -211,7 +211,7 @@ pub const Glomerator = struct {
             // Build cachefo entry for the full query group
             const key_seqs = try self.getSeqs(key);
             defer {
-                for (key_seqs.items) |*ks| ks.deinit(allocator);
+                // key_seqs items are borrowed (item 6); only free the list.
                 var ksl = key_seqs;
                 ksl.deinit(allocator);
             }
@@ -244,17 +244,21 @@ pub const Glomerator = struct {
         for (self.initial_partition.items) |s| allocator.free(s);
         self.initial_partition.deinit(allocator);
 
-        // Free single_seqs
+        // Free Query maps before single_seqs: Query.seqs borrows from
+        // single_seqs (item 6). Query.deinit no longer touches sequence
+        // buffers, so the order is not load-bearing for correctness, but
+        // freeing borrowers before owners keeps the invariant explicit.
+        freeQueryMap(allocator, &self.single_seq_cachefo);
+        freeQueryMap(allocator, &self.cachefo);
+        freeQueryMap(allocator, &self.tmp_cachefo);
+
+        // Free single_seqs (the unique owner of Sequence buffers).
         var ssit = self.single_seqs.iterator();
         while (ssit.next()) |e| {
             allocator.free(e.key_ptr.*);
             e.value_ptr.deinit(allocator);
         }
         self.single_seqs.deinit(allocator);
-
-        freeQueryMap(allocator, &self.single_seq_cachefo);
-        freeQueryMap(allocator, &self.cachefo);
-        freeQueryMap(allocator, &self.tmp_cachefo);
 
         freeStringF64Map(allocator, &self.log_probs);
         freeStringF64Map(allocator, &self.naive_hfracs);
@@ -1170,6 +1174,7 @@ pub const Glomerator = struct {
 
         const key_seqs = try self.getSeqs(queries);
         defer {
+            // key_seqs items are borrowed (item 6); only free the list.
             var ks = key_seqs;
             ks.deinit(self.allocator);
         }
@@ -1252,7 +1257,7 @@ pub const Glomerator = struct {
 
         const key_seqs = try self.getSeqs(joint_name);
         defer {
-            for (key_seqs.items) |*ks| ks.deinit(self.allocator);
+            // key_seqs items are borrowed (item 6); only free the list.
             var ksl = key_seqs;
             ksl.deinit(self.allocator);
         }
@@ -1437,6 +1442,7 @@ pub const Glomerator = struct {
         {
             const sub_seqs = try self.getSeqs(subqueries);
             defer {
+                // sub_seqs items are borrowed (item 6); only free the list.
                 var ss = sub_seqs;
                 ss.deinit(self.allocator);
             }
@@ -1575,6 +1581,7 @@ pub const Glomerator = struct {
             const supercache = try self.getCachefo(superquery);
             const key_seqs = try self.getSeqs(translated_query);
             defer {
+                // key_seqs items are borrowed (item 6); only free the list.
                 var ks = key_seqs;
                 ks.deinit(self.allocator);
             }
@@ -1600,6 +1607,11 @@ pub const Glomerator = struct {
     // ── Utility helpers ───────────────────────────────────────────────────────
 
     /// C++: Glomerator::GetSeqs() — glomerator.cc:850
+    ///
+    /// Returns borrowed shallow copies of Sequence values from `single_seqs`.
+    /// The buffers (`name`, `undigitized`, `seqq`, ...) are not duplicated;
+    /// callers must not call `Sequence.deinit` on the returned items, and the
+    /// returned slice must not outlive `single_seqs`. Issue #342, item 6.
     fn getSeqs(self: *Glomerator, query: []const u8) !std.ArrayListUnmanaged(Sequence) {
         const names = try splitName(self.allocator, query);
         defer {
@@ -1609,13 +1621,11 @@ pub const Glomerator = struct {
         }
 
         var result: std.ArrayListUnmanaged(Sequence) = .{};
-        errdefer {
-            for (result.items) |*sq| sq.deinit(self.allocator);
-            result.deinit(self.allocator);
-        }
+        errdefer result.deinit(self.allocator);
+        try result.ensureUnusedCapacity(self.allocator, names.items.len);
         for (names.items) |uid| {
             const sq = self.single_seqs.getPtr(uid) orelse return error.SequenceNotFound;
-            try result.append(self.allocator, try sq.clone(self.allocator));
+            result.appendAssumeCapacity(sq.*);
         }
         return result;
     }

--- a/packages/zig-core/src/ham/glomerator/query.zig
+++ b/packages/zig-core/src/ham/glomerator/query.zig
@@ -8,9 +8,16 @@ const Sequence = @import("../sequences.zig").Sequence;
 const KBounds = @import("../bcr_utils/k_bounds.zig").KBounds;
 
 /// Corresponds to C++ `ham::Query`.
+///
+/// Sequence ownership (issue #342, item 6): `seqs` holds **borrowed** Sequence
+/// values — shallow copies whose slice fields (`name`, `header`, `undigitized`,
+/// `seqq`) point at buffers owned by `Glomerator.single_seqs`. The Query must
+/// not outlive the Glomerator that owns those buffers, and `Query.deinit` must
+/// not call `Sequence.deinit` on its entries.
 pub const Query = struct {
     name: []u8,
-    /// Owned copies of sequences belonging to this query/cluster.
+    /// Borrowed shallow copies of Sequences. Buffers are owned by
+    /// `Glomerator.single_seqs`; do not free per-item in deinit.
     seqs: std.ArrayListUnmanaged(Sequence),
     seed_missing: bool,
     only_genes: std.ArrayListUnmanaged([]u8),
@@ -34,11 +41,13 @@ pub const Query = struct {
         };
     }
 
-    /// Create a fully-specified Query.
+    /// Create a fully-specified Query. `seqs` is borrowed: each Sequence is
+    /// stored as a shallow copy (slice descriptors), and the buffers must
+    /// outlive this Query. See struct doc comment.
     pub fn create(
         allocator: std.mem.Allocator,
         name: []const u8,
-        seqs: []Sequence,
+        seqs: []const Sequence,
         seed_missing: bool,
         only_genes: []const []const u8,
         kbounds: KBounds,
@@ -59,8 +68,9 @@ pub const Query = struct {
         };
         errdefer q.deinit(allocator);
 
-        for (seqs) |*sq| {
-            try q.seqs.append(allocator, try sq.clone(allocator));
+        try q.seqs.ensureUnusedCapacity(allocator, seqs.len);
+        for (seqs) |sq| {
+            q.seqs.appendAssumeCapacity(sq);
         }
         for (only_genes) |g| {
             try q.only_genes.append(allocator, try allocator.dupe(u8, g));
@@ -76,7 +86,8 @@ pub const Query = struct {
 
     pub fn deinit(self: *Query, allocator: std.mem.Allocator) void {
         if (self.name.len > 0) allocator.free(self.name);
-        for (self.seqs.items) |*sq| sq.deinit(allocator);
+        // seqs entries are borrowed shallow copies (see struct doc); do not
+        // call Sequence.deinit here. Only the ArrayList itself is owned.
         self.seqs.deinit(allocator);
         for (self.only_genes.items) |g| allocator.free(g);
         self.only_genes.deinit(allocator);


### PR DESCRIPTION
## Summary

Implements item 6 from #342: `Query.seqs` in glomerator now holds **borrowed**
shallow Sequence copies (slice descriptors only) into `Glomerator.single_seqs`
instead of owning per-cluster clones.

`Glomerator.single_seqs` already kept the master copy of every input sequence,
owned for the Glomerator's lifetime. `single_seq_cachefo` and `cachefo` Query
objects held additional clones, and every per-merge `getCachefo`,
`mergedQuery`, and `subClusterAnnotation` call cloned via `getSeqs` only to
clone again inside `Query.create`.

### What changed

- `Query.seqs` documented as borrowed shallow copies; `Query.create` takes
  `[]const Sequence` and stores values directly (no `clone`); `Query.deinit`
  no longer calls `Sequence.deinit` on its items.
- `Glomerator.getSeqs` returns borrowed shallow copies; matching call-site
  `defer`s no longer iterate the list to free items. The previous
  `getCachefo` and `subClusterAnnotation` defers were latent leaks (freed only
  the list, not the cloned Sequence buffers) — they become correct under the
  borrowed contract.
- `Glomerator.deinit` reordered to free Query maps before `single_seqs`.
  With `Query.deinit` no longer touching sequence buffers the order isn't
  load-bearing for correctness, but freeing borrowers before owners makes
  the invariant explicit.

### Stable-pointer invariant

`single_seqs` is mutated only inside `Glomerator.init` and never has entries
removed thereafter, so the heap-allocated Sequence buffers it owns are stable
for the Glomerator's lifetime. Hash-map rehashes during init move the
`Sequence` value structs to new slots, but the slice descriptors inside those
structs continue to point to the same underlying buffers, so shallow copies
taken during init remain valid.

### Validation

| Rung | Result |
|---|---|
| 0 (`zig build test`) | pass |
| 1 (`partis-test.py --quick --zig`) | pass |
| 2a (`partis-test.py --no-simu --zig`) | pass |
| 2b (`partis-test.py --paired --no-simu --zig`) | pass |
| 4 (5k-seq paired byte-equality) | identical (3797 igh + 3802 igk) |
| Pre-merge (30k-seq paired byte-equality) | identical (10802 igh + 10861 igk) |

### Measurements (30k paper, pax, /tmp, n_procs 10, no-time-based-n-proc-reduction)

| | Wall | Peak RSS |
|---|---|---|
| `main` baseline (`d40bc889a`) | 1:31:11 | 3.0 GB |
| topic tip (after #354) | 1:16:33 | 3.04 GB |
| **this PR on topic** | **1:16:19** | **1.84 GB** |

- Wall time: within noise vs topic tip (-0.3%).
- Peak RSS: **-39% vs topic tip** (3.04 GB → 1.84 GB) and -39% vs main.

This is the memory win predicted for items 7 and 9 that did not materialize
there — triple sequence storage was the dominant memory consumer at 30k, not
the glomerator caches (item 7) or `Model.states` pointers (item 9). The
issue's lesson holds: predicted impacts can land on a different item than
the one they were filed under.

### Eliminated allocations

For the singleton-dominated 30k case (~60k input UIDs, two loci):

- init `single_seq_cachefo` + `cachefo`: 2 × 4 dupes/seq × N seqs ≈ 480k
  small allocations removed.
- each runtime `getCachefo` / `mergedQuery` / `subClusterAnnotation`: 8
  dupes/seq × |query| (one round in `getSeqs`, one in `Query.create`) — all
  removed; called O(N²) times during clustering.

### What still owns sequence buffers

`Glomerator.single_seqs` is the unique owner. `DPHandler.run` still clones
its input sequences into a private `Sequences` container at
`dp_handler.zig:161-163` — that's item 2's territory and stays untouched
here.

### Note on 50k

Per the issue / handoff guidance for memory items, 50k was not re-run in
this PR (the pre-merge gate is 30k). Given the 30k RSS reduction is
substantial, the 50k effect is expected to be at least proportional and
should be verified before topic → main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)