### PR TITLE
zig: borrow seqs through the DP pipeline (#342 item 2)

### DIFF
--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -516,7 +516,6 @@ pub const DPHandler = struct {
             errdefer fresh.deinit();
 
             const entry = TrellisEntry{ .query_seqs = stored_seqs, .trellis = fresh };
-            origin = "scratch";
             if (self.scratch_cachefo.getPtr(gene)) |cache_list| {
                 try cache_list.append(allocator, entry);
                 break :blk &cache_list.items[cache_list.items.len - 1].trellis;
@@ -734,9 +733,14 @@ pub const DPHandler = struct {
             defer query_seqs.deinit(allocator);
 
             // Borrow the undigitized strings (slice headers only — no string copies).
+            // Only the args.debug == 2 paths consume this slice (the region-display
+            // block below and printPath); skip the allocation otherwise.
             // Lifetime is bounded by query_seqs above.
-            const query_strs = try borrowQueryStrs(allocator, &query_seqs);
-            defer allocator.free(query_strs);
+            const query_strs: [][]const u8 = if (self.args.debug == 2)
+                try borrowQueryStrs(allocator, &query_seqs)
+            else
+                &.{};
+            defer if (self.args.debug == 2) allocator.free(query_strs);
 
             // Debug: region query display
             if (self.args.debug == 2) {

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -33,9 +33,19 @@ const GeneKSetKey = struct {
     kset: KSet,
 };
 
-/// Cached trellis entry: query strings → Trellis
+/// Cached trellis entry. Owns the Sequences the trellis was built over.
+///
+/// `query_seqs` is heap-allocated separately so its address is stable across
+/// reallocations of the enclosing `cache_list: ArrayListUnmanaged(TrellisEntry)`.
+/// `Trellis.seqs` borrows this stable pointer; appending more entries may
+/// relocate the entry struct, but the heap-allocated Sequences (and its
+/// inner Sequence buffers) stays put.
+///
+/// Prefix-match for chunk-cache hits reads
+/// `query_seqs.seqs.items[i].undigitized` — there is no separate `query_strs`
+/// list (item 2 of issue #342).
 const TrellisEntry = struct {
-    query_strs: std.ArrayListUnmanaged([]u8),
+    query_seqs: *Sequences,
     trellis: Trellis,
 };
 
@@ -85,14 +95,17 @@ pub const DPHandler = struct {
     pub fn clear(self: *DPHandler) void {
         const allocator = self.allocator;
 
-        // Free scratch_cachefo
+        // Free scratch_cachefo. Each TrellisEntry owns a heap-allocated Sequences
+        // (borrowed by the entry's trellis). Deinit the trellis BEFORE freeing
+        // the Sequences so that any debug assertions inside trellis.deinit() can
+        // still observe a valid borrow target if needed.
         var cit = self.scratch_cachefo.iterator();
         while (cit.next()) |entry| {
             allocator.free(entry.key_ptr.*);
             for (entry.value_ptr.items) |*te| {
-                for (te.query_strs.items) |s| allocator.free(s);
-                te.query_strs.deinit(allocator);
                 te.trellis.deinit();
+                te.query_seqs.deinit(allocator);
+                allocator.destroy(te.query_seqs);
             }
             entry.value_ptr.deinit(allocator);
         }
@@ -128,6 +141,8 @@ pub const DPHandler = struct {
 
     /// Run the DP for a single Sequence.
     /// Corresponds to C++ `DPHandler::Run(Sequence, ...)`.
+    /// The Sequence's heap buffers (name/header/undigitized/seqq) are borrowed
+    /// for the duration of the call; the caller retains ownership.
     pub fn runSeq(
         self: *DPHandler,
         seq: Sequence,
@@ -136,15 +151,16 @@ pub const DPHandler = struct {
         overall_mute_freq: f64,
         clear_cache: bool,
     ) !Result {
-        // Clone into a Sequences container (single sequence)
-        var seqvec: std.ArrayListUnmanaged(Sequence) = .{};
-        defer seqvec.deinit(self.allocator);
-        try seqvec.append(self.allocator, try seq.clone(self.allocator));
-        return self.run(seqvec.items, kbounds, only_gene_list, overall_mute_freq, clear_cache);
+        const seqvec = [_]Sequence{seq};
+        return self.run(&seqvec, kbounds, only_gene_list, overall_mute_freq, clear_cache);
     }
 
     /// Run the DP over a vector of sequences.
     /// Corresponds to C++ `DPHandler::Run(vector<Sequence>, ...)`.
+    /// `seqvector` is borrowed: each Sequence's heap buffers must outlive the
+    /// call; the internal Sequences container holds shallow struct-copies that
+    /// share those buffers (item 2 of issue #342). The container's items are
+    /// not deinit'd at function end — only the backing array is freed.
     pub fn run(
         self: *DPHandler,
         seqvector: []const Sequence,
@@ -156,10 +172,21 @@ pub const DPHandler = struct {
         const allocator = self.allocator;
         const run_start = std.time.milliTimestamp();
 
+        // Build a Sequences container that borrows from `seqvector`.
+        // Each Sequence is a shallow struct-copy: slice headers are duplicated,
+        // but the underlying name/header/undigitized/seqq buffers are shared
+        // with `seqvector`. We must not deinit the items at end-of-call —
+        // only the backing array allocation is freed.
         var seqs = Sequences.init();
-        defer seqs.deinit(allocator);
-        for (seqvector) |*sq| {
-            try seqs.addSeq(allocator, try sq.clone(allocator));
+        defer seqs.seqs.deinit(allocator);
+        try seqs.seqs.ensureTotalCapacityPrecise(allocator, seqvector.len);
+        for (seqvector) |sq| {
+            if (seqs.seqs.items.len == 0) {
+                seqs.sequence_length = sq.size();
+            } else if (sq.size() != seqs.sequence_length) {
+                return error.SequenceLengthMismatch;
+            }
+            seqs.seqs.appendAssumeCapacity(sq);
         }
 
         // Build only_genes map: region → set of gene names
@@ -357,21 +384,15 @@ pub const DPHandler = struct {
         return result;
     }
 
-    /// Collect undigitized strings for the given region's subsequences.
-    fn getQueryStrs(self: *DPHandler, seqs: *const Sequences, kset: KSet, region: Region) !std.ArrayListUnmanaged([]u8) {
-        const allocator = self.allocator;
-        var query_seqs = try self.getSubSeqs(seqs, kset, region);
-        defer query_seqs.deinit(allocator);
-
-        var strs: std.ArrayListUnmanaged([]u8) = .{};
-        errdefer {
-            for (strs.items) |s| allocator.free(s);
-            strs.deinit(allocator);
-        }
-        for (query_seqs.seqs.items) |*sq| {
-            try strs.append(allocator, try allocator.dupe(u8, sq.undigitized));
-        }
-        return strs;
+    /// Borrow the undigitized strings of `seqs` into a freshly-allocated slice
+    /// of `[]const u8` (slice-of-slices, no string copies). The returned slice
+    /// is allocated with `allocator` and must be `free`d by the caller; the
+    /// individual strings borrow into `seqs.seqs.items[i].undigitized` and
+    /// must not outlive `seqs`.
+    fn borrowQueryStrs(allocator: std.mem.Allocator, seqs: *const Sequences) ![][]const u8 {
+        const out = try allocator.alloc([]const u8, seqs.seqs.items.len);
+        for (seqs.seqs.items, 0..) |*sq, i| out[i] = sq.undigitized;
+        return out;
     }
 
     /// Ensure per-gene caches are initialised for `gene`.
@@ -431,25 +452,31 @@ pub const DPHandler = struct {
 
     /// Fill the trellis for the given (gene, kset, query_seqs).
     /// Stores result in scores_[gene][kset] and (for viterbi) paths_[gene][kset].
+    /// `query_seqs` is borrowed; its lifetime must span the call. For the
+    /// fresh path (no chunk-cache hit), the trellis is stored in
+    /// `scratch_cachefo[gene]` and a clone of `query_seqs` is heap-allocated
+    /// to give the stored trellis a stable, long-lived borrow target.
     fn fillTrellis(
         self: *DPHandler,
         kset: KSet,
-        query_seqs: Sequences,
-        query_strs: []const []const u8,
+        query_seqs: *const Sequences,
         gene: []const u8,
     ) ![]const u8 {
         const allocator = self.allocator;
 
-        // Look for a chunk-cached trellis
+        // Look for a chunk-cached trellis. Prefix-match is on undigitized
+        // strings of the cached trellis's stored query_seqs.
         var cached_trellis: ?*const Trellis = null;
         if (!self.args.no_chunk_cache) {
             if (self.scratch_cachefo.getPtr(gene)) |cache_list| {
                 for (cache_list.items) |*te| {
-                    if (te.query_strs.items.len != query_strs.len) continue;
+                    const cached_seqs = te.query_seqs.seqs.items;
+                    const current_seqs = query_seqs.seqs.items;
+                    if (cached_seqs.len != current_seqs.len) continue;
                     var all_match = true;
-                    for (te.query_strs.items, query_strs) |cached, current| {
+                    for (cached_seqs, current_seqs) |*cached, *current| {
                         // cached must START WITH current (prefix match)
-                        if (!std.mem.startsWith(u8, cached, current)) {
+                        if (!std.mem.startsWith(u8, cached.undigitized, current.undigitized)) {
                             all_match = false;
                             break;
                         }
@@ -471,16 +498,6 @@ pub const DPHandler = struct {
         // This is critical: when no cache, do NOT create a second trellis that borrows from
         // the (empty) scratch — the scratch itself is the working trellis.
 
-        // Build the TrellisEntry query strings (needed if storing a new scratch).
-        var qstrs: std.ArrayListUnmanaged([]u8) = .{};
-        defer {
-            for (qstrs.items) |s| allocator.free(s);
-            qstrs.deinit(allocator);
-        }
-        for (query_strs) |s| {
-            try qstrs.append(allocator, try allocator.dupe(u8, s));
-        }
-
         // trell_ptr points to the trellis on which the algorithm is run.
         // tmptrell is only used when borrowing from a cached trellis.
         var tmptrell: ?Trellis = null;
@@ -488,11 +505,17 @@ pub const DPHandler = struct {
 
         var origin: []const u8 = "scratch";
         const trell_ptr: *Trellis = if (cached_trellis == null) blk: {
-            // No cache: create scratch WITHOUT cached_trellis, store it, use it directly.
-            var fresh = try Trellis.initWithSeqs(allocator, model, query_seqs, null);
+            // No cache: clone query_seqs into a stable heap home so the stored
+            // trellis can borrow from it for its full lifetime in scratch_cachefo.
+            const stored_seqs = try allocator.create(Sequences);
+            errdefer allocator.destroy(stored_seqs);
+            stored_seqs.* = try query_seqs.clone(allocator);
+            errdefer stored_seqs.deinit(allocator);
+
+            var fresh = try Trellis.initWithSeqs(allocator, model, stored_seqs, null);
             errdefer fresh.deinit();
-            const entry = TrellisEntry{ .query_strs = qstrs, .trellis = fresh };
-            qstrs = .{}; // ownership transferred to entry
+
+            const entry = TrellisEntry{ .query_seqs = stored_seqs, .trellis = fresh };
             origin = "scratch";
             if (self.scratch_cachefo.getPtr(gene)) |cache_list| {
                 try cache_list.append(allocator, entry);
@@ -500,13 +523,14 @@ pub const DPHandler = struct {
             } else {
                 // gene not in scratch_cachefo (shouldn't happen after initCache), discard
                 var e = entry;
-                for (e.query_strs.items) |s| allocator.free(s);
-                e.query_strs.deinit(allocator);
                 e.trellis.deinit();
+                e.query_seqs.deinit(allocator);
+                allocator.destroy(e.query_seqs);
                 return error.GeneNotInScratchCache;
             }
         } else blk: {
-            // Have cache: create temp trellis that borrows from the cached scratch.
+            // Have cache: temp trellis borrows from the caller's query_seqs
+            // (no clone — lifetime is just this call).
             tmptrell = try Trellis.initWithSeqs(allocator, model, query_seqs, cached_trellis);
             origin = "chunk";
             break :blk &tmptrell.?;
@@ -706,14 +730,13 @@ pub const DPHandler = struct {
             try regional_best.put(allocator, region, mathutils.NEG_INF);
             try regional_total.put(allocator, region, mathutils.NEG_INF);
 
-            var query_strs = try self.getQueryStrs(seqs, kset, region);
-            defer {
-                for (query_strs.items) |s| allocator.free(s);
-                query_strs.deinit(allocator);
-            }
-
             var query_seqs = try self.getSubSeqs(seqs, kset, region);
             defer query_seqs.deinit(allocator);
+
+            // Borrow the undigitized strings (slice headers only — no string copies).
+            // Lifetime is bounded by query_seqs above.
+            const query_strs = try borrowQueryStrs(allocator, &query_seqs);
+            defer allocator.free(query_strs);
 
             // Debug: region query display
             if (self.args.debug == 2) {
@@ -722,24 +745,20 @@ pub const DPHandler = struct {
                     // Get ambiguous char from args (matches C++ hmms_.track()->ambiguous_char())
                     const ambig = self.args.ambig_base;
                     const ambig_ch: u8 = if (ambig.len > 0) ambig[0] else 0;
-                    if (query_strs.items.len > 0) {
+                    if (query_strs.len > 0) {
                         const colored = if (ambig_ch != 0)
-                            try TermColors.colorChars(allocator, ambig_ch, "light_blue", query_strs.items[0])
+                            try TermColors.colorChars(allocator, ambig_ch, "light_blue", query_strs[0])
                         else
-                            try allocator.dupe(u8, query_strs.items[0]);
+                            try allocator.dupe(u8, query_strs[0]);
                         defer allocator.free(colored);
                         const line = try std.fmt.allocPrint(allocator, "                {s} query {s}\n", .{ rs, colored });
                         defer allocator.free(line);
                         try std.fs.File.stdout().writeAll(line);
                     }
                     // Additional query strings colored as mutants relative to first
-                    if (query_strs.items.len > 1) {
-                        // Build const slice for colorMutants
-                        const const_strs = try allocator.alloc([]const u8, query_strs.items.len);
-                        defer allocator.free(const_strs);
-                        for (query_strs.items, 0..) |s, i| const_strs[i] = s;
-                        for (query_strs.items[1..]) |qs| {
-                            const mutant = try TermColors.colorMutants(allocator, "purple", qs, "", const_strs, ambig);
+                    if (query_strs.len > 1) {
+                        for (query_strs[1..]) |qs| {
+                            const mutant = try TermColors.colorMutants(allocator, "purple", qs, "", query_strs, ambig);
                             defer allocator.free(mutant);
                             const colored2 = if (ambig_ch != 0)
                                 try TermColors.colorChars(allocator, ambig_ch, "light_blue", mutant)
@@ -795,18 +814,14 @@ pub const DPHandler = struct {
                     }
                     origin = "cached";
                 } else {
-                    origin = try self.fillTrellis(kset, query_seqs, query_strs.items, gene);
+                    origin = try self.fillTrellis(kset, &query_seqs, gene);
                 }
 
                 const gene_score = if (self.scores.getPtr(gene)) |gs| gs.get(kset) orelse mathutils.NEG_INF else mathutils.NEG_INF;
 
                 // Debug: per-gene viterbi output
                 if (self.args.debug == 2 and std.mem.eql(u8, self.algorithm, "viterbi")) {
-                    // Build const slice for printPath
-                    const const_strs = try allocator.alloc([]const u8, query_strs.items.len);
-                    defer allocator.free(const_strs);
-                    for (query_strs.items, 0..) |s, i| const_strs[i] = s;
-                    try self.printPath(kset, const_strs, gene, gene_score, origin);
+                    try self.printPath(kset, query_strs, gene, gene_score, origin);
                 }
 
                 // Update regional totals
@@ -927,12 +942,10 @@ pub const DPHandler = struct {
                 return event;
             };
 
-            var query_strs = try self.getQueryStrs(seqs, kset, region);
-            defer {
-                for (query_strs.items) |s| allocator.free(s);
-                query_strs.deinit(allocator);
-            }
-            if (query_strs.items.len == 0) {
+            // The original C++ path called GetQueryStrs and checked items.len > 0;
+            // in practice that's always equal to seqs.nSeqs(), so check directly
+            // and skip the unused string list.
+            if (seqs.nSeqs() == 0) {
                 event.setScore(mathutils.NEG_INF);
                 return event;
             }

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -115,6 +115,10 @@ pub const Trellis = struct {
         const allocator = self.allocator;
         const seq_len = self.seq_len;
         const n_states = self.hmm.nStates();
+        // Cache the borrowed seqs pointer in a local so the inner DP loop reads
+        // it from a register rather than re-loading `self.seqs` (a heap-pointer
+        // member after #357) on every emission lookup.
+        const seqs = self.seqs;
 
         if (self.cached_trellis) |ct| {
             // Poach scalar values from cached trellis; array data accessed via accessors.
@@ -152,7 +156,7 @@ pub const Trellis = struct {
         // Reset next_seen before populating position 0
         self.next_seen = state_mod.StateBitset.initEmpty();
         for (init_st.to_state_indices.items) |i_st| {
-            const emission_val = self.hmm.stateByIndex(i_st).emissionLogprobSeqs(self.seqs, 0);
+            const emission_val = self.hmm.stateByIndex(i_st).emissionLogprobSeqs(seqs, 0);
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
@@ -194,6 +198,8 @@ pub const Trellis = struct {
         const allocator = self.allocator;
         const seq_len = self.seq_len;
         const n_states = self.hmm.nStates();
+        // See viterbi(): cache borrowed seqs pointer in a local for the inner DP loop.
+        const seqs = self.seqs;
 
         if (self.cached_trellis) |ct| {
             self.ending_forward_log_prob = ct.endingForwardLogProbAt(seq_len);
@@ -218,7 +224,7 @@ pub const Trellis = struct {
         // Reset next_seen before populating position 0
         self.next_seen = state_mod.StateBitset.initEmpty();
         for (init_st.to_state_indices.items) |i_st| {
-            const emission_val = self.hmm.stateByIndex(i_st).emissionLogprobSeqs(self.seqs, 0);
+            const emission_val = self.hmm.stateByIndex(i_st).emissionLogprobSeqs(seqs, 0);
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
@@ -317,9 +323,11 @@ pub const Trellis = struct {
         next_states: *std.ArrayListUnmanaged(usize),
         position: usize,
     ) !void {
+        // See viterbi(): cache borrowed seqs pointer in a local for the inner loop.
+        const seqs = self.seqs;
         for (current_states.items) |i_st_cur| {
             const st_cur = self.hmm.stateByIndex(i_st_cur);
-            const emission_val = st_cur.emissionLogprobSeqs(self.seqs, position);
+            const emission_val = st_cur.emissionLogprobSeqs(seqs, position);
             if (std.math.isNegativeInf(emission_val)) continue;
             for (st_cur.from_state_indices.items) |i_st_prev| {
                 const prev_val = self.scoring_previous[i_st_prev];
@@ -349,9 +357,11 @@ pub const Trellis = struct {
         next_states: *std.ArrayListUnmanaged(usize),
         position: usize,
     ) !void {
+        // See viterbi(): cache borrowed seqs pointer in a local for the inner loop.
+        const seqs = self.seqs;
         for (current_states.items) |i_st_cur| {
             const st_cur = self.hmm.stateByIndex(i_st_cur);
-            const emission_val = st_cur.emissionLogprobSeqs(self.seqs, position);
+            const emission_val = st_cur.emissionLogprobSeqs(seqs, position);
             if (std.math.isNegativeInf(emission_val)) continue;
             for (st_cur.from_state_indices.items) |i_st_prev| {
                 const prev_val = self.scoring_previous[i_st_prev];

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -23,8 +23,17 @@ pub const Int2D = std.ArrayListUnmanaged([]i16);
 pub const Trellis = struct {
     /// HMM model (not owned).
     hmm: *const Model,
-    /// Sequences to run DP over (owned copy).
-    seqs: Sequences,
+    /// Sequences to run DP over (BORROWED; not owned).
+    /// The pointee must outlive this Trellis. For trellises stored in
+    /// `DPHandler.scratch_cachefo`, the owning Sequences lives in the
+    /// enclosing TrellisEntry and is freed alongside the trellis.
+    /// For temporary chunk-borrowing trellises, the pointee is the caller's
+    /// stack-local `query_seqs` and lives only for the duration of fillTrellis.
+    seqs: *const Sequences,
+    /// Cached at init from `seqs.sequence_length`. Read by `traceback`,
+    /// `viterbi`, and `forward`; valid even if the borrowed seqs is no longer
+    /// being read post-DP.
+    seq_len: usize,
 
     /// Traceback table [position][state] → previous state (-1 if none).
     traceback_table: Int2D,
@@ -52,33 +61,25 @@ pub const Trellis = struct {
 
     allocator: std.mem.Allocator,
 
-    /// Create a Trellis for a single Sequence.
-    /// The sequence is copied into an internal Sequences object.
-    /// Corresponds to C++ `Trellis(Model*, Sequence, Trellis*)`.
-    pub fn initWithSeq(allocator: std.mem.Allocator, hmm: *const Model, seq: Sequence, cached: ?*const Trellis) !Trellis {
-        var seqs = Sequences.init();
-        try seqs.addSeq(allocator, try seq.clone(allocator));
-        return initImpl(allocator, hmm, seqs, cached);
-    }
-
-    /// Create a Trellis for a Sequences object.
-    /// Clones `seqs` so the caller retains ownership of the original
-    /// (matches C++ Trellis(Model*, Sequences, Trellis*) copy-by-value semantics).
-    pub fn initWithSeqs(allocator: std.mem.Allocator, hmm: *const Model, seqs: Sequences, cached: ?*const Trellis) !Trellis {
-        const seqs_copy = try seqs.clone(allocator);
-        return initImpl(allocator, hmm, seqs_copy, cached);
-    }
-
-    fn initImpl(allocator: std.mem.Allocator, hmm: *const Model, seqs: Sequences, cached: ?*const Trellis) !Trellis {
+    /// Create a Trellis borrowing the given Sequences.
+    /// The caller retains ownership; `seqs` must outlive this Trellis.
+    /// Corresponds to C++ `Trellis(Model*, Sequences, Trellis*)`, but without
+    /// the C++ copy-by-value clone — the borrow is sufficient for DP read
+    /// access, and for cached/stored trellises only the result arrays are
+    /// re-read.
+    pub fn initWithSeqs(allocator: std.mem.Allocator, hmm: *const Model, seqs: *const Sequences, cached: ?*const Trellis) !Trellis {
         const n = hmm.nStates();
         const scoring_current = try allocator.alloc(f64, n);
+        errdefer allocator.free(scoring_current);
         const scoring_previous = try allocator.alloc(f64, n);
+        errdefer allocator.free(scoring_previous);
         @memset(scoring_current, mathutils.NEG_INF);
         @memset(scoring_previous, mathutils.NEG_INF);
 
-        const t = Trellis{
+        return Trellis{
             .hmm = hmm,
             .seqs = seqs,
+            .seq_len = seqs.sequence_length,
             .traceback_table = .{},
             .cached_trellis = cached,
             .ending_viterbi_pointer = -1,
@@ -92,12 +93,11 @@ pub const Trellis = struct {
             .next_seen = state_mod.StateBitset.initEmpty(),
             .allocator = allocator,
         };
-        return t;
     }
 
     pub fn deinit(self: *Trellis) void {
         const allocator = self.allocator;
-        self.seqs.deinit(allocator);
+        // seqs is borrowed; not freed here.
         // Free traceback table rows
         for (self.traceback_table.items) |row| allocator.free(row);
         self.traceback_table.deinit(allocator);
@@ -113,7 +113,7 @@ pub const Trellis = struct {
     /// Corresponds to C++ `Trellis::Viterbi()`.
     pub fn viterbi(self: *Trellis) !void {
         const allocator = self.allocator;
-        const seq_len = self.seqs.sequence_length;
+        const seq_len = self.seq_len;
         const n_states = self.hmm.nStates();
 
         if (self.cached_trellis) |ct| {
@@ -152,7 +152,7 @@ pub const Trellis = struct {
         // Reset next_seen before populating position 0
         self.next_seen = state_mod.StateBitset.initEmpty();
         for (init_st.to_state_indices.items) |i_st| {
-            const emission_val = self.hmm.stateByIndex(i_st).emissionLogprobSeqs(&self.seqs, 0);
+            const emission_val = self.hmm.stateByIndex(i_st).emissionLogprobSeqs(self.seqs, 0);
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
@@ -192,7 +192,7 @@ pub const Trellis = struct {
     /// Corresponds to C++ `Trellis::Forward()`.
     pub fn forward(self: *Trellis) !void {
         const allocator = self.allocator;
-        const seq_len = self.seqs.sequence_length;
+        const seq_len = self.seq_len;
         const n_states = self.hmm.nStates();
 
         if (self.cached_trellis) |ct| {
@@ -218,7 +218,7 @@ pub const Trellis = struct {
         // Reset next_seen before populating position 0
         self.next_seen = state_mod.StateBitset.initEmpty();
         for (init_st.to_state_indices.items) |i_st| {
-            const emission_val = self.hmm.stateByIndex(i_st).emissionLogprobSeqs(&self.seqs, 0);
+            const emission_val = self.hmm.stateByIndex(i_st).emissionLogprobSeqs(self.seqs, 0);
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
@@ -253,14 +253,14 @@ pub const Trellis = struct {
     /// Traceback to produce a path.
     /// Corresponds to C++ `Trellis::Traceback(TracebackPath&)`.
     pub fn traceback(self: *const Trellis, path: *TracebackPath) !void {
-        std.debug.assert(self.seqs.sequence_length != 0);
+        std.debug.assert(self.seq_len != 0);
         path.setModel(self.hmm);
         if (std.math.isNegativeInf(self.ending_viterbi_log_prob)) return;
         path.setScore(self.ending_viterbi_log_prob);
         try path.pushBack(self.allocator, self.ending_viterbi_pointer);
 
         var pointer: i16 = self.ending_viterbi_pointer;
-        var position: usize = self.seqs.sequence_length - 1;
+        var position: usize = self.seq_len - 1;
         const tbl_items = self.tracebackTableItems() orelse return;
         while (position > 0) : (position -= 1) {
             pointer = tbl_items[position][@intCast(pointer)];
@@ -319,7 +319,7 @@ pub const Trellis = struct {
     ) !void {
         for (current_states.items) |i_st_cur| {
             const st_cur = self.hmm.stateByIndex(i_st_cur);
-            const emission_val = st_cur.emissionLogprobSeqs(&self.seqs, position);
+            const emission_val = st_cur.emissionLogprobSeqs(self.seqs, position);
             if (std.math.isNegativeInf(emission_val)) continue;
             for (st_cur.from_state_indices.items) |i_st_prev| {
                 const prev_val = self.scoring_previous[i_st_prev];
@@ -351,7 +351,7 @@ pub const Trellis = struct {
     ) !void {
         for (current_states.items) |i_st_cur| {
             const st_cur = self.hmm.stateByIndex(i_st_cur);
-            const emission_val = st_cur.emissionLogprobSeqs(&self.seqs, position);
+            const emission_val = st_cur.emissionLogprobSeqs(self.seqs, position);
             if (std.math.isNegativeInf(emission_val)) continue;
             for (st_cur.from_state_indices.items) |i_st_prev| {
                 const prev_val = self.scoring_previous[i_st_prev];
@@ -441,7 +441,12 @@ test "Trellis: forward on real IGHV3-15 model" {
     var seq = try Sequence.initFromString(allocator, trk, "test_seq", "ACGT");
     defer seq.deinit(allocator);
 
-    var trellis = try Trellis.initWithSeq(allocator, &model, seq, null);
+    // Trellis borrows the Sequences; the caller retains ownership.
+    var seqs = Sequences.init();
+    defer seqs.deinit(allocator);
+    try seqs.addSeq(allocator, try seq.clone(allocator));
+
+    var trellis = try Trellis.initWithSeqs(allocator, &model, &seqs, null);
     defer trellis.deinit();
 
     try trellis.forward();


### PR DESCRIPTION
## Summary

Eliminate redundant Sequence cloning along the path from `DPHandler.run` →
`runKSet` → `fillTrellis` → `Trellis`. The trellis only reads sequences
during DP, so it doesn't need to own them; the DP pipeline can flow
borrowed references end-to-end.

This is **item 2** of #342.

## What changed

**Trellis (`trellis.zig`)**
- `Trellis.seqs` becomes `*const Sequences` (borrowed). The pointee must
  outlive the trellis. For trellises stored in `scratch_cachefo`, the
  enclosing `TrellisEntry` owns a heap-allocated `Sequences` whose address
  stays stable across cache-list reallocations. For temp chunk-borrow
  trellises, the pointee is the caller's stack-local `query_seqs`.
- Cache `seq_len` at init for `traceback` (which only needs the length, not
  the data) and the inner DP loops.
- `viterbi`/`forward`/`middleViterbiVals`/`middleForwardVals` cache the
  borrowed seqs pointer in a function-local at entry to force the inner
  DP loop to read it from a register (no measurable wall effect — see
  validation; the compiler appears to already hoist).
- `initWithSeqs` no longer clones; `initWithSeq` is folded into callers
  constructing a `Sequences` explicitly (one test).
- `Trellis.deinit` no longer frees seqs.

**DPHandler (`dp_handler.zig`)**
- `TrellisEntry` drops the `query_strs: ArrayListUnmanaged([]u8)` field.
  Prefix-match for chunk-cache hits reads
  `te.query_seqs.seqs.items[i].undigitized` directly. `query_seqs: *Sequences`
  is heap-allocated separately so the trellis's borrow target stays stable
  across `cache_list.append` reallocations of the entry struct.
- `fillTrellis` takes `query_seqs: *const Sequences` (borrowed). Fresh path
  clones once into the heap-allocated `stored_seqs` for the cache; chunk
  path borrows directly from the caller. Drops the per-call `qstrs` dupe
  loop entirely.
- `getQueryStrs` (5N allocs/region) replaced by `borrowQueryStrs`,
  returning a borrowed `[][]const u8`. Allocation is gated behind
  `args.debug == 2` since both consumers are debug-guarded.
- `runKSet` builds `query_seqs` once per region and passes it by pointer
  to `fillTrellis`.
- `run` no longer deep-clones each input `Sequence`. It builds a
  `Sequences` container with shallow struct-copies and frees only the
  backing array at end-of-call.
- `runSeq` drops its leak-prone clone-into-temporary-vec dance and just
  wraps a single-element array.
- `fillRecoEvent` reads `seqs.nSeqs()` directly instead of round-tripping
  through `getQueryStrs` for a length check.

## Validation

| Rung | Result |
|---|---|
| 0 — `zig build test` | ✅ |
| 1 — `partis-test.py --quick --zig` | ✅ |
| 2a — `partis-test.py --no-simu --zig` | ✅ same diffs as topic-tip baseline (pre-existing) |
| 2b — `partis-test.py --paired --no-simu --zig` | ✅ same diffs as topic-tip baseline |
| 4 — 5k paired partition byte-equality vs `/tmp/zig-5k-baseline` | ✅ **identical** (3797 igh + 3802 igk) |

5k clean wall: 5:05–5:07 vs 5:10 baseline; peak RSS 466 MB vs 467 MB. Within noise.

### Pre-merge 30k gate

| Metric | Pinned baseline (main d40bc889a) | After #355 (topic tip pre-this) | This PR (n=2) |
|---|---|---|---|
| Wall | 1:31:11 (n=1) | 1:16:19 (n=1) | **1:19:54** then **1:20:18** |
| Peak RSS | 3.0 GB | 1.84 GB | **1.78 GB** then **1.84 GB** |
| Events | 10802 igh + 10861 igk | — | **byte-identical** ✅ |

Output is byte-identical to baseline (md5sum-verified). RSS is unchanged
vs the #355 topic tip. Wall is consistently +3:35 to +4:00 vs the single
#355 measurement of 1:16:19 — across two runs of this PR with the
pointer-hoisting fix in place. Either the +4 min is real and has a
mechanism other than the inner-loop pointer load (e.g., `TrellisEntry.query_seqs`
heap indirection during prefix-match scan, or shallow-copy locality), or
#355's single 1:16:19 was on the lucky end of an unmeasured noise
distribution. We don't have n>1 on the #355 baseline to distinguish; n=1
vs n=2 with consistent results from this side suggests it's likely real
but small.

The PR is shipping for **cleaner data flow** + **fewer allocator calls per
query** (eliminates 5N+ per-region allocs in `getQueryStrs`, the
per-stored-entry `qstrs` clone, and the `Trellis.initWithSeqs` clone on
the chunk-cache path). RSS holds at 1.84 GB. The ~4 min wall delta is
documented honestly, not papered over.

## Test plan

- [x] Rungs 0, 1, 2a, 2b clean
- [x] 5k paired partition byte-identical to baseline
- [x] 30k paired partition byte-identical to baseline (n=2 measurements)
- [x] 30k peak RSS within noise of #355 topic tip
- [ ] (Topic→main only) 50k-collision byte-equality + wall/RSS

## Notes for reviewers

- `errdefer` chain in `fillTrellis`'s fresh path is **lexically block-scoped**
  to the `if (cached_trellis == null) blk: { ... }` block. After
  `try cache_list.append` succeeds, `break :blk` exits the block normally
  and the errdefers are forgotten — they cannot fire on subsequent
  function-scope errors. Verified by zig-code-reviewer.
- The stable-borrow contract for `TrellisEntry.query_seqs` is on the type
  declaration in `dp_handler.zig`, following the precedent set by #355's
  `single_seqs` field comment.
- Future fragility flag (advisory, not addressed): `Sequences` now
  flows through `DPHandler.run` as a borrowed-only container — calling
  `seqs.deinit(allocator)` instead of `seqs.seqs.deinit(allocator)` on
  the run-internal container would double-free the caller's buffers.
  Worth adding a `SequencesView` type or borrowed/owned flag the next
  time someone touches that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)