### PR TITLE
zig: per-query and per-kset arena allocators (#342 item 4)

### DIFF
--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -56,12 +56,29 @@ pub const DPHandler = struct {
     args: *Args,
     gl: *GermLines,
     hmms: *HMMHolder,
-    allocator: std.mem.Allocator,
+
+    /// Caller-supplied allocator. Used **only** for allocations that
+    /// outlive the DPHandler — Result, RecoEvent and any owned strings
+    /// reachable from them (gene names on RecoEvent, naive_seq, deletion
+    /// keys, insertion seqs). See item 4 of issue #342 for the lifetime
+    /// table; any allocation that lands in `parent_allocator` rather than
+    /// `scratchAllocator()` is a deliberate cross-boundary write.
+    parent_allocator: std.mem.Allocator,
+
+    /// Per-query arena, lives for the full DPHandler lifetime. Backs every
+    /// internal scratch allocation: scratch_cachefo, paths, scores,
+    /// per_gene_support, and the run()-local maps (only_genes,
+    /// best_scores, total_scores, best_genes). On `clear()`,
+    /// reset(.retain_capacity) drops every dependent allocation in O(1)
+    /// and reuses the backing pages for the next call. Item 4, #342.
+    query_arena: std.heap.ArenaAllocator,
 
     /// scratch_cachefo_: gene → list of *TrellisEntry. Entries are
     /// individually heap-allocated for stable address (the trellis at each
     /// entry borrows `&entry.query_seqs` and that pointer must stay valid
-    /// across appends to the same gene's list).
+    /// across appends to the same gene's list). Address stability is
+    /// preserved under the per-query arena because arenas only grow —
+    /// past allocations are never relocated.
     scratch_cachefo: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(*TrellisEntry)),
     /// paths_: gene → (KSet → TracebackPath)
     paths: std.StringHashMapUnmanaged(std.AutoHashMapUnmanaged(KSet, TracebackPath)),
@@ -82,7 +99,8 @@ pub const DPHandler = struct {
             .args = args,
             .gl = gl,
             .hmms = hmms,
-            .allocator = allocator,
+            .parent_allocator = allocator,
+            .query_arena = std.heap.ArenaAllocator.init(allocator),
             .scratch_cachefo = .{},
             .paths = .{},
             .scores = .{},
@@ -90,14 +108,31 @@ pub const DPHandler = struct {
         };
     }
 
+    /// Per-query scratch allocator. **Always re-derive at the use site** —
+    /// caching `arena.allocator()` in a struct field would silently break
+    /// after a DPHandler move, since the returned `Allocator.ptr` points
+    /// at the arena's address at call time. (Item 4, #342.)
+    pub inline fn scratchAllocator(self: *DPHandler) std.mem.Allocator {
+        return self.query_arena.allocator();
+    }
+
     pub fn deinit(self: *DPHandler) void {
         self.clear();
+        self.query_arena.deinit();
     }
 
     /// Clear all cached trellis data.
     /// Corresponds to C++ `DPHandler::Clear`.
+    ///
+    /// Under the per-query arena (item 4, #342), every individual `free` /
+    /// `destroy` / `deinit` below is a no-op — the arena reset at the end
+    /// reclaims everything in one shot. The explicit cleanup loops are kept
+    /// as documentation and as a safety belt: they make the ownership
+    /// graph readable, and if a future change ever pulls one of these
+    /// allocations off the arena and back onto a real allocator, the
+    /// existing `free` will keep doing the right thing.
     pub fn clear(self: *DPHandler) void {
-        const allocator = self.allocator;
+        const allocator = self.scratchAllocator();
 
         // Free scratch_cachefo. Each *TrellisEntry is heap-allocated and the
         // entry's trellis borrows from the inline `query_seqs`. Deinit the
@@ -141,6 +176,11 @@ pub const DPHandler = struct {
         while (pgit.next()) |entry| allocator.free(entry.key_ptr.*);
         self.per_gene_support.deinit(allocator);
         self.per_gene_support = .{};
+
+        // Reset the per-query arena: this is what actually reclaims memory
+        // (the loops above are no-ops on the arena). Retains capacity so
+        // the next run() in handleFishyAnnotations reuses the backing pages.
+        _ = self.query_arena.reset(.retain_capacity);
     }
 
     /// Run the DP for a single Sequence.
@@ -173,7 +213,16 @@ pub const DPHandler = struct {
         overall_mute_freq: f64,
         clear_cache: bool,
     ) !Result {
-        const allocator = self.allocator;
+        // Per-query scratch arena: every internal allocation routes here.
+        // `parent` is reserved for the returned Result and any RecoEvent
+        // strings the caller will read after run() exits. Item 4, #342.
+        //
+        // `clear_cache` MUST run before any per-call scratch allocations.
+        // `clear()` resets the arena, which would invalidate any seqs /
+        // only_genes / etc. already built off `scratchAllocator()`.
+        if (clear_cache) self.clear();
+        const allocator = self.scratchAllocator();
+        const parent = self.parent_allocator;
         const run_start = std.time.milliTimestamp();
 
         // Build a Sequences container that borrows from `seqvector`.
@@ -239,8 +288,6 @@ pub const DPHandler = struct {
             kbounds.vmax <= kbounds.vmin or kbounds.dmax <= kbounds.dmin)
             return error.TrivialKBounds;
 
-        if (clear_cache) self.clear();
-
         var best_scores: std.AutoHashMapUnmanaged(KSet, f64) = .{};
         defer best_scores.deinit(allocator);
         var total_scores: std.AutoHashMapUnmanaged(KSet, f64) = .{};
@@ -262,7 +309,7 @@ pub const DPHandler = struct {
             try self.hmms.rescaleOverallMuteFreqs(&only_genes, overall_mute_freq);
         }
 
-        var result = try Result.init(allocator, kbounds, self.args.locus);
+        var result = try Result.init(parent, kbounds, self.args.locus);
 
         var best_score: f64 = mathutils.NEG_INF;
         var best_kset = KSet{ .v = 0, .d = 0 };
@@ -362,8 +409,13 @@ pub const DPHandler = struct {
 
     /// Get subsequences for one region.
     /// Corresponds to C++ `DPHandler::GetSubSeqs(seqs, kset, region)`.
-    fn getSubSeqs(self: *DPHandler, seqs: *const Sequences, kset: KSet, region: Region) !Sequences {
-        const allocator = self.allocator;
+    ///
+    /// `allocator` is taken explicitly so the caller (`runKSet`) can route
+    /// the per-region clones through its per-kset arena rather than the
+    /// per-query arena. The clone strings live only for the region's
+    /// inner loop. (Item 4, #342.)
+    fn getSubSeqs(self: *DPHandler, allocator: std.mem.Allocator, seqs: *const Sequences, kset: KSet, region: Region) !Sequences {
+        _ = self;
         var result = Sequences.init();
         errdefer result.deinit(allocator);
 
@@ -404,17 +456,18 @@ pub const DPHandler = struct {
     fn initCache(self: *DPHandler, gene: []const u8) !void {
         if (self.scores.contains(gene)) return;
 
-        const key = try self.allocator.dupe(u8, gene);
-        errdefer self.allocator.free(key);
-        try self.scratch_cachefo.put(self.allocator, key, .{});
+        const allocator = self.scratchAllocator();
+        const key = try allocator.dupe(u8, gene);
+        errdefer allocator.free(key);
+        try self.scratch_cachefo.put(allocator, key, .{});
 
-        const key2 = try self.allocator.dupe(u8, gene);
-        errdefer self.allocator.free(key2);
-        try self.paths.put(self.allocator, key2, .{});
+        const key2 = try allocator.dupe(u8, gene);
+        errdefer allocator.free(key2);
+        try self.paths.put(allocator, key2, .{});
 
-        const key3 = try self.allocator.dupe(u8, gene);
-        errdefer self.allocator.free(key3);
-        try self.scores.put(self.allocator, key3, .{});
+        const key3 = try allocator.dupe(u8, gene);
+        errdefer allocator.free(key3);
+        try self.scores.put(allocator, key3, .{});
     }
 
     /// Look for a cached kset whose region sequences are a prefix of `query_strs`.
@@ -460,13 +513,21 @@ pub const DPHandler = struct {
     /// fresh path (no chunk-cache hit), the trellis is stored in
     /// `scratch_cachefo[gene]` and a clone of `query_seqs` is heap-allocated
     /// to give the stored trellis a stable, long-lived borrow target.
+    /// `kset_alloc` is the per-kset arena. Used **only** for the chunk-cache
+    /// temp trellis (its scoring buffers and traceback_table are reset at
+    /// end-of-kset). Everything that lives across ksets — `scratch_cachefo`
+    /// entries, `paths`, `scores` — uses `scratchAllocator()`. The
+    /// traceback path's items are explicitly routed through `scratch` even
+    /// when the temp trellis runs viterbi: they are stored in `self.paths`
+    /// and outlive the kset. (Item 4, #342.)
     fn fillTrellis(
         self: *DPHandler,
+        kset_alloc: std.mem.Allocator,
         kset: KSet,
         query_seqs: *const Sequences,
         gene: []const u8,
     ) ![]const u8 {
-        const allocator = self.allocator;
+        const allocator = self.scratchAllocator();
 
         // Look for a chunk-cached trellis. Prefix-match is on undigitized
         // strings of the cached trellis's stored query_seqs.
@@ -533,8 +594,16 @@ pub const DPHandler = struct {
             }
         } else blk: {
             // Have cache: temp trellis borrows from the caller's query_seqs
-            // (no clone — lifetime is just this call).
-            tmptrell = try Trellis.initWithSeqs(allocator, model, query_seqs, cached_trellis);
+            // (no clone — lifetime is just this call). Backed by the per-kset
+            // arena (`kset_alloc`): scoring buffers + traceback_table are
+            // reset at end-of-kset rather than accumulating across ksets in
+            // the per-query arena. Worst case under the per-query arena
+            // would be n_genes × n_ksets × seq_len × n_states × 2 bytes per
+            // viterbi-mode query — hundreds of MB on annotation workloads.
+            // The path items below are explicitly routed through `allocator`
+            // (per-query scratch), not `kset_alloc`, since they're stored in
+            // `self.paths` and outlive the kset. (Item 4, #342.)
+            tmptrell = try Trellis.initWithSeqs(kset_alloc, model, query_seqs, cached_trellis);
             origin = "chunk";
             break :blk &tmptrell.?;
         };
@@ -547,7 +616,9 @@ pub const DPHandler = struct {
             var path = TracebackPath.initWithModel(model);
             errdefer path.deinit(allocator);
             if (sc != mathutils.NEG_INF) {
-                try trell_ptr.traceback(&path);
+                // Explicitly pass `allocator` (per-query scratch) so the path's
+                // items don't capture the temp trellis's per-kset arena.
+                try trell_ptr.traceback(allocator, &path);
             }
             if (self.paths.getPtr(gene)) |gene_paths| {
                 try gene_paths.put(allocator, kset, path);
@@ -573,7 +644,7 @@ pub const DPHandler = struct {
     /// Print colored germline alignment for a gene path (debug==2 viterbi output).
     /// Corresponds to C++ `DPHandler::PrintPath`.
     fn printPath(self: *DPHandler, kset: KSet, query_strs: []const []const u8, gene: []const u8, score: f64, extra_str: []const u8) !void {
-        const allocator = self.allocator;
+        const allocator = self.scratchAllocator();
         if (score == mathutils.NEG_INF) return;
 
         const path_names_list = try self.getPathNames(gene, kset, allocator);
@@ -689,6 +760,18 @@ pub const DPHandler = struct {
     }
 
     /// Run all genes for one kset.
+    ///
+    /// Two arenas are in play here (item 4, #342):
+    ///   - `scratch` (per-query): backs the maps that outlive this kset —
+    ///     `best_scores` / `total_scores` / `best_genes` (passed in, owned
+    ///     by `run()`), the `gene_val` dupe written into `best_genes[kset]`,
+    ///     the cached-path copy stored in `self.paths`, and updates to
+    ///     `self.scores` / `self.per_gene_support`.
+    ///   - `kset_alloc` (per-kset): backs everything that dies at end of
+    ///     this function — `regional_best/total`, `per_gene_support_this_kset`,
+    ///     per-region sub-seq clones, debug-output buffers, sorted-gene
+    ///     slices, and the chunk-cache temp trellis routed through
+    ///     `fillTrellis`. `kset_arena.deinit()` reclaims it all in one shot.
     fn runKSet(
         self: *DPHandler,
         seqs: *Sequences,
@@ -698,12 +781,15 @@ pub const DPHandler = struct {
         total_scores: *std.AutoHashMapUnmanaged(KSet, f64),
         best_genes: *std.AutoHashMapUnmanaged(KSet, std.AutoHashMapUnmanaged(Region, []u8)),
     ) !void {
-        const allocator = self.allocator;
+        const scratch = self.scratchAllocator();
+        var kset_arena = std.heap.ArenaAllocator.init(self.parent_allocator);
+        defer kset_arena.deinit();
+        const allocator = kset_arena.allocator();
 
-        try best_scores.put(allocator, kset, mathutils.NEG_INF);
-        try total_scores.put(allocator, kset, mathutils.NEG_INF);
+        try best_scores.put(scratch, kset, mathutils.NEG_INF);
+        try total_scores.put(scratch, kset, mathutils.NEG_INF);
         const bg_entry: std.AutoHashMapUnmanaged(Region, []u8) = .{};
-        try best_genes.put(allocator, kset, bg_entry);
+        try best_genes.put(scratch, kset, bg_entry);
 
         // Debug: kset header
         if (self.args.debug == 2) {
@@ -733,7 +819,7 @@ pub const DPHandler = struct {
             try regional_best.put(allocator, region, mathutils.NEG_INF);
             try regional_total.put(allocator, region, mathutils.NEG_INF);
 
-            var query_seqs = try self.getSubSeqs(seqs, kset, region);
+            var query_seqs = try self.getSubSeqs(allocator, seqs, kset, region);
             defer query_seqs.deinit(allocator);
 
             // Borrow the undigitized strings (slice headers only — no string copies).
@@ -805,24 +891,26 @@ pub const DPHandler = struct {
                 var origin: []const u8 = "";
                 const partial_match = self.findPartialCacheMatch(region, gene, kset);
                 if (!partial_match.isNull()) {
-                    // Copy path and score from cached kset
+                    // Copy path and score from cached kset. Both go into
+                    // `self.paths` / `self.scores`, which outlive the kset
+                    // — route through `scratch`, not `allocator`.
                     if (self.paths.getPtr(gene)) |gp| {
                         if (gp.get(partial_match)) |cached_path| {
                             var path_copy = TracebackPath.init();
-                            errdefer path_copy.deinit(allocator);
-                            try path_copy.path.appendSlice(allocator, cached_path.path.items);
+                            errdefer path_copy.deinit(scratch);
+                            try path_copy.path.appendSlice(scratch, cached_path.path.items);
                             path_copy.setScore(cached_path.score);
                             path_copy.setModel(cached_path.hmm.?);
-                            try gp.put(allocator, kset, path_copy);
+                            try gp.put(scratch, kset, path_copy);
                         }
                     }
                     if (self.scores.getPtr(gene)) |gs| {
                         const cached_score = gs.get(partial_match) orelse mathutils.NEG_INF;
-                        try gs.put(allocator, kset, cached_score);
+                        try gs.put(scratch, kset, cached_score);
                     }
                     origin = "cached";
                 } else {
-                    origin = try self.fillTrellis(kset, &query_seqs, gene);
+                    origin = try self.fillTrellis(allocator, kset, &query_seqs, gene);
                 }
 
                 const gene_score = if (self.scores.getPtr(gene)) |gs| gs.get(kset) orelse mathutils.NEG_INF else mathutils.NEG_INF;
@@ -847,17 +935,21 @@ pub const DPHandler = struct {
                     try std.fs.File.stdout().writeAll(fwd_line);
                 }
 
-                // Update regional best + best_genes for this kset
+                // Update regional best + best_genes for this kset.
+                // `regional_best` is kset-local but `best_genes` is owned by
+                // `run()` and read in `fillRecoEvent` after this kset
+                // returns — its `gene_val` dupe must live on `scratch`,
+                // not the per-kset arena.
                 const reg_best = regional_best.get(region) orelse mathutils.NEG_INF;
                 if (gene_score > reg_best) {
                     if (regional_best.getPtr(region)) |rb| rb.* = gene_score;
                     if (best_genes.getPtr(kset)) |bg_map| {
-                        const gene_val = try allocator.dupe(u8, gene);
-                        errdefer allocator.free(gene_val);
+                        const gene_val = try scratch.dupe(u8, gene);
+                        errdefer scratch.free(gene_val);
                         if (bg_map.fetchRemove(region)) |old| {
-                            allocator.free(old.value);
+                            scratch.free(old.value);
                         }
-                        try bg_map.put(allocator, region, gene_val);
+                        try bg_map.put(scratch, region, gene_val);
                     }
                 }
 
@@ -888,8 +980,8 @@ pub const DPHandler = struct {
         const rt_d = regional_total.get(.d) orelse mathutils.NEG_INF;
         const rt_j = regional_total.get(.j) orelse mathutils.NEG_INF;
 
-        try best_scores.put(allocator, kset, mathutils.addWithMinusInfinities(rb_v, mathutils.addWithMinusInfinities(rb_d, rb_j)));
-        try total_scores.put(allocator, kset, mathutils.addWithMinusInfinities(rt_v, mathutils.addWithMinusInfinities(rt_d, rt_j)));
+        try best_scores.put(scratch, kset, mathutils.addWithMinusInfinities(rb_v, mathutils.addWithMinusInfinities(rb_d, rb_j)));
+        try total_scores.put(scratch, kset, mathutils.addWithMinusInfinities(rt_v, mathutils.addWithMinusInfinities(rt_d, rt_j)));
 
         // Compute per_gene_support across ksets
         for (bcr.germ_lines.regions) |region| {
@@ -922,9 +1014,9 @@ pub const DPHandler = struct {
                     if (self.per_gene_support.contains(gene)) {
                         self.per_gene_support.getPtr(gene).?.* = score_this_kset;
                     } else {
-                        const pg_key = try self.allocator.dupe(u8, gene);
-                        errdefer self.allocator.free(pg_key);
-                        try self.per_gene_support.put(self.allocator, pg_key, score_this_kset);
+                        const pg_key = try scratch.dupe(u8, gene);
+                        errdefer scratch.free(pg_key);
+                        try self.per_gene_support.put(scratch, pg_key, score_this_kset);
                     }
                 }
             }
@@ -932,6 +1024,13 @@ pub const DPHandler = struct {
     }
 
     /// Build a RecoEvent for the given kset and best gene assignments.
+    ///
+    /// The returned `RecoEvent` is pushed into `Result.events` (and possibly
+    /// `Result.best_event`), which is handed back to the caller of `run()`.
+    /// All allocations that end up owned by the event (gene names,
+    /// deletion keys, insertion seqs, naive_seq) therefore route through
+    /// `parent_allocator`. Transient workspace (path_names_list, del_3p/
+    /// del_5p format strings) uses `scratchAllocator()`. (Item 4, #342.)
     fn fillRecoEvent(
         self: *DPHandler,
         seqs: *Sequences,
@@ -939,9 +1038,10 @@ pub const DPHandler = struct {
         best_genes_for_kset: *const std.AutoHashMapUnmanaged(Region, []u8),
         score: f64,
     ) !RecoEvent {
-        const allocator = self.allocator;
-        var event = try RecoEvent.init(allocator);
-        errdefer event.deinit(allocator);
+        const parent = self.parent_allocator;
+        const scratch = self.scratchAllocator();
+        var event = try RecoEvent.init(parent);
+        errdefer event.deinit(parent);
 
         for (bcr.germ_lines.regions) |region| {
             const rs = regionStr(region);
@@ -958,12 +1058,12 @@ pub const DPHandler = struct {
                 return event;
             }
 
-            // Get traceback path names
-            const path_names_list = try self.getPathNames(gene, kset, allocator);
+            // Get traceback path names — transient workspace, scratch alloc.
+            const path_names_list = try self.getPathNames(gene, kset, scratch);
             defer {
-                for (path_names_list.items) |s| allocator.free(s);
+                for (path_names_list.items) |s| scratch.free(s);
                 var pl = path_names_list;
-                pl.deinit(allocator);
+                pl.deinit(scratch);
             }
 
             if (path_names_list.items.len == 0) {
@@ -971,18 +1071,18 @@ pub const DPHandler = struct {
                 return event;
             }
 
-            try event.setGene(allocator, rs, gene);
-            const del_3p = try std.fmt.allocPrint(allocator, "{s}_3p", .{rs});
-            defer allocator.free(del_3p);
-            const del_5p = try std.fmt.allocPrint(allocator, "{s}_5p", .{rs});
-            defer allocator.free(del_5p);
-            try event.setDeletion(allocator, del_3p, self.getErosionLength("right", path_names_list.items, gene));
-            try event.setDeletion(allocator, del_5p, self.getErosionLength("left", path_names_list.items, gene));
+            try event.setGene(parent, rs, gene);
+            const del_3p = try std.fmt.allocPrint(scratch, "{s}_3p", .{rs});
+            defer scratch.free(del_3p);
+            const del_5p = try std.fmt.allocPrint(scratch, "{s}_5p", .{rs});
+            defer scratch.free(del_5p);
+            try event.setDeletion(parent, del_3p, self.getErosionLength("right", path_names_list.items, gene));
+            try event.setDeletion(parent, del_5p, self.getErosionLength("left", path_names_list.items, gene));
             try self.setInsertions(region, path_names_list.items, &event);
         }
 
         event.setScore(score);
-        try event.setNaiveSeq(allocator, self.gl);
+        try event.setNaiveSeq(parent, self.gl);
         return event;
     }
 
@@ -1001,7 +1101,9 @@ pub const DPHandler = struct {
     /// Set insertions on `event` based on path state names for `region`.
     /// Corresponds to C++ `DPHandler::SetInsertions`.
     fn setInsertions(self: *DPHandler, region: Region, path_names: []const []const u8, event: *RecoEvent) !void {
-        const allocator = self.allocator;
+        // Insertion seqs are dupe'd onto the event, which lives in
+        // Result returned to the caller — parent_allocator. (Item 4, #342.)
+        const allocator = self.parent_allocator;
         const ins = Insertions{};
         for (ins.forRegion(region)) |insertion| {
             const side: []const u8 = if (std.mem.eql(u8, insertion, "jf")) "right" else "left";
@@ -1104,13 +1206,19 @@ pub const DPHandler = struct {
         only_gene_list: []const []const u8,
         overall_mute_freq: f64,
     ) !void {
-        const allocator = self.allocator;
+        // `multi_seq_result` was built by an earlier `run()` call with
+        // `parent_allocator`; mutating its `best_event` here must use the
+        // same allocator so the existing entries' frees match. The local
+        // `naive_seq` is transient (only feeds the inner `run()`'s borrow
+        // contract) and uses scratch. (Item 4, #342.)
+        const parent = self.parent_allocator;
+        const scratch = self.scratchAllocator();
         const best_ev = multi_seq_result.best_event orelse return;
 
         // Create naive sequence (use first query's track)
         const first_track = qry_seqs[0].track orelse return;
-        var naive_seq = try Sequence.initFromString(allocator, first_track, "naive-seq", best_ev.naive_seq);
-        defer naive_seq.deinit(allocator);
+        var naive_seq = try Sequence.initFromString(scratch, first_track, "naive-seq", best_ev.naive_seq);
+        defer naive_seq.deinit(scratch);
 
         const naive_seqs = [_]Sequence{naive_seq};
         var naive_result = try self.run(&naive_seqs, kbounds, only_gene_list, overall_mute_freq, true);
@@ -1121,17 +1229,17 @@ pub const DPHandler = struct {
             for (bcr.germ_lines.regions) |region| {
                 const rs = regionStr(region);
                 const ng = naive_ev.genes.get(rs) orelse continue;
-                try me.setGene(allocator, rs, ng);
+                try me.setGene(parent, rs, ng);
             }
             const all_dels = [_][]const u8{ "v_5p", "v_3p", "d_5p", "d_3p", "j_5p", "j_3p" };
             for (all_dels) |delname| {
                 const nd = naive_ev.deletions.get(delname) orelse 0;
-                try me.setDeletion(allocator, delname, nd);
+                try me.setDeletion(parent, delname, nd);
             }
             const all_ins = [_][]const u8{ "fv", "vd", "dj", "jf" };
             for (all_ins) |ins_name| {
                 const ni = naive_ev.insertions.get(ins_name) orelse "";
-                try me.setInsertion(allocator, ins_name, ni);
+                try me.setInsertion(parent, ins_name, ni);
             }
         }
     }

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -414,8 +414,9 @@ pub const DPHandler = struct {
     /// the per-region clones through its per-kset arena rather than the
     /// per-query arena. The clone strings live only for the region's
     /// inner loop. (Item 4, #342.)
-    fn getSubSeqs(self: *DPHandler, allocator: std.mem.Allocator, seqs: *const Sequences, kset: KSet, region: Region) !Sequences {
-        _ = self;
+    ///
+    /// Free function (no `self` access): nothing here reads DPHandler state.
+    fn getSubSeqs(allocator: std.mem.Allocator, seqs: *const Sequences, kset: KSet, region: Region) !Sequences {
         var result = Sequences.init();
         errdefer result.deinit(allocator);
 
@@ -819,7 +820,7 @@ pub const DPHandler = struct {
             try regional_best.put(allocator, region, mathutils.NEG_INF);
             try regional_total.put(allocator, region, mathutils.NEG_INF);
 
-            var query_seqs = try self.getSubSeqs(allocator, seqs, kset, region);
+            var query_seqs = try getSubSeqs(allocator, seqs, kset, region);
             defer query_seqs.deinit(allocator);
 
             // Borrow the undigitized strings (slice headers only — no string copies).
@@ -1208,17 +1209,23 @@ pub const DPHandler = struct {
     ) !void {
         // `multi_seq_result` was built by an earlier `run()` call with
         // `parent_allocator`; mutating its `best_event` here must use the
-        // same allocator so the existing entries' frees match. The local
-        // `naive_seq` is transient (only feeds the inner `run()`'s borrow
-        // contract) and uses scratch. (Item 4, #342.)
+        // same allocator so the existing entries' frees match. (Item 4, #342.)
+        //
+        // `naive_seq` MUST also use `parent_allocator`, NOT scratch: the
+        // inner `self.run(... clear_cache=true)` call on the line below
+        // calls `self.clear()` as its first action, which resets the
+        // per-query arena. Any naive_seq buffers (`name`/`header`/
+        // `undigitized`/`seqq`) allocated on scratch would be reclaimed
+        // before the inner DP loop reads `seqq[i]` in `emissionLogprobSeqs`,
+        // producing a use-after-reset. The fix is to keep naive_seq's
+        // backing on the caller's long-lived allocator.
         const parent = self.parent_allocator;
-        const scratch = self.scratchAllocator();
         const best_ev = multi_seq_result.best_event orelse return;
 
         // Create naive sequence (use first query's track)
         const first_track = qry_seqs[0].track orelse return;
-        var naive_seq = try Sequence.initFromString(scratch, first_track, "naive-seq", best_ev.naive_seq);
-        defer naive_seq.deinit(scratch);
+        var naive_seq = try Sequence.initFromString(parent, first_track, "naive-seq", best_ev.naive_seq);
+        defer naive_seq.deinit(parent);
 
         const naive_seqs = [_]Sequence{naive_seq};
         var naive_result = try self.run(&naive_seqs, kbounds, only_gene_list, overall_mute_freq, true);

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -67,6 +67,13 @@ pub const Trellis = struct {
     /// Scratch bitset for deduplicating next_states additions.
     next_seen: state_mod.StateBitset,
 
+    /// Captured at `initWithSeqs` time. For trellises stored in
+    /// `DPHandler.scratch_cachefo`, this is `dph.scratchAllocator()`,
+    /// whose `Allocator.ptr` aliases `&dph.query_arena`. The DPHandler
+    /// must therefore not be moved after a Trellis is constructed against
+    /// it, or every stored `allocator.ptr` would dangle. All current
+    /// callers bind `dph` to a stack-local `var` and never reassign,
+    /// which preserves the invariant. (Item 4, #342.)
     allocator: std.mem.Allocator,
 
     /// Create a Trellis borrowing the given Sequences.

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -282,12 +282,20 @@ pub const Trellis = struct {
 
     /// Traceback to produce a path.
     /// Corresponds to C++ `Trellis::Traceback(TracebackPath&)`.
-    pub fn traceback(self: *const Trellis, path: *TracebackPath) !void {
+    ///
+    /// `path_alloc` backs the path's growing item list, which may have a
+    /// different lifetime than the trellis itself: in the chunk-cache-hit
+    /// path of `DPHandler.fillTrellis`, the temp trellis lives on the
+    /// per-kset arena but the path is stored in `DPHandler.paths` (per
+    /// query). Passing the allocator explicitly avoids the use-after-free
+    /// that would otherwise come from `self.allocator` capturing a
+    /// shorter-lived arena. (Item 4, #342.)
+    pub fn traceback(self: *const Trellis, path_alloc: std.mem.Allocator, path: *TracebackPath) !void {
         std.debug.assert(self.seq_len != 0);
         path.setModel(self.hmm);
         if (std.math.isNegativeInf(self.ending_viterbi_log_prob)) return;
         path.setScore(self.ending_viterbi_log_prob);
-        try path.pushBack(self.allocator, self.ending_viterbi_pointer);
+        try path.pushBack(path_alloc, self.ending_viterbi_pointer);
 
         // Resolve the traceback source once: cached trellis if it has a
         // populated table, else self. If neither does, there's nothing to
@@ -301,7 +309,7 @@ pub const Trellis = struct {
                 std.debug.print("No valid path at position {d}\n", .{position});
                 return;
             }
-            try path.pushBack(self.allocator, pointer);
+            try path.pushBack(path_alloc, pointer);
         }
         std.debug.assert(path.size() > 0);
     }
@@ -616,7 +624,7 @@ test "Trellis: viterbi traceback walks through flat table consistently" {
 
     var path = TracebackPath.initWithModel(&model);
     defer path.deinit(allocator);
-    try trellis.traceback(&path);
+    try trellis.traceback(allocator, &path);
 
     // Path length should equal seq_len: traceback pushes ending pointer, then
     // one entry per position from seq_len-1 down to 1.


### PR DESCRIPTION
## Summary

- Sub-PR for #342 item 4. Design comment: https://github.com/psathyrella/partis/issues/342#issuecomment-4370363878.
- Adds a per-query `ArenaAllocator` to `DPHandler` (backs `scratch_cachefo`, `paths`, `scores`, `per_gene_support`, `run()`-local maps) and a per-kset arena inside `runKSet` (backs region sub-seq clones, kset-local maps, and the chunk-cache temp trellis). `parent_allocator` is reserved for `Result` / `RecoEvent` and anything the caller reads after `run()` exits.
- `Trellis.traceback` takes an explicit `path_alloc` parameter so the chunk-cache-hit path can run the temp trellis on the per-kset arena without the path's items capturing that shorter-lived arena (would otherwise UAF when the kset arena resets).
- The previous `clear()` cleanup loops are kept as safety belts (no-op on the arena); the arena reset at the bottom of `clear()` is what actually reclaims memory.
- `run()` calls `if (clear_cache) self.clear();` as its first action so the arena reset doesn't invalidate scratch built for the current call (seqs container, only_genes).

## Test plan

- [x] **rung 0** — `zig build test` (Debug + ReleaseSafe) passes.
- [x] **rung 1** — `partis-test.py --quick --zig` passes under ReleaseFast and ReleaseSafe (latter is the use-after-free check called out in the design comment for the `parent`/`scratch` boundary).
- [x] **rung 2a** — `partis-test.py --no-simu --zig` matches topic-tip (`824129fea`); only pre-existing test-framework noise (stale ref times, the `3 only in ref version` naive_seqs delta which also appears on topic-tip).
- [x] **rung 2b** — `partis-test.py --paired --no-simu --zig` matches topic-tip; same pre-existing notes.
- [x] **rung 4** — 5k paired partition byte-identical vs `/tmp/zig-5k-baseline`:

  ```
  65f2720cbcc59cb2d3f89ad1f5a0b2cb  /tmp/zig-5k-arena/igh+igk/partition-igh.yaml
  7ad6b1f3b0b9833fb7d11240bdc332d6  /tmp/zig-5k-arena/igh+igk/partition-igk.yaml
  ```
  matches the baseline md5s exactly. Wall 4:55 vs 5:10 baseline (n=1, suggestive only); peak RSS 467 MB unchanged.

- [ ] **30k pre-merge gate** — pending. Plan: n=2 both sides on pax (this branch + topic tip `824129fea`), report wall + user-CPU + peak RSS. Per the design comment, n≥2 is required to call any sub-2% wall delta given #360's lesson.
- [ ] 50k validation — deferred per matsen, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)