### PR TITLE
fix simulation UID hash collision at scale

### DIFF
--- a/partis/event.py
+++ b/partis/event.py
@@ -96,7 +96,7 @@ class RecombinationEvent(object):
     def set_reco_id(self, line, irandom=None):
         reco_id_columns = [r + '_gene' for r in utils.regions] + [b + '_insertion' for b in utils.boundaries] + [e + '_del' for e in utils.all_erosions]
         reco_id_str = ''.join([str(line[c]) for c in reco_id_columns]) + self.randstr(irandom)  # NOTE this used to give the same reco id for the same rearrangement parameters, even if they come from a separate rearrangement event (until we added the randstr() call)
-        line['reco_id'] = utils.uidhashstr(reco_id_str)
+        line['reco_id'] = utils.uidhashstr(reco_id_str, max_len=20)
         return reco_id_str
 
     # ----------------------------------------------------------------------------------------
@@ -104,7 +104,7 @@ class RecombinationEvent(object):
         unique_id_columns = ['seqs', 'input_seqs']
         uidstrs = [''.join([str(line[c][iseq]) for c in unique_id_columns]) for iseq in range(len(line['input_seqs']))]
         uidstrs = [reco_id_str + uidstrs[iseq] + self.randstr(irandom) + str(iseq) for iseq in range(len(uidstrs))]  # NOTE i'm not sure I really like having the str(iseq), but it mimics the way things used to be by accident/bug (i.e. identical sequences in the same simulated rearrangement event get different uids), so I'm leaving it in for the moment to ease transition after a rewrite
-        line['unique_ids'] = [utils.uidhashstr(ustr) for ustr in uidstrs]
+        line['unique_ids'] = [utils.uidhashstr(ustr, max_len=20) for ustr in uidstrs]
 
     # ----------------------------------------------------------------------------------------
     def set_ids(self, line, irandom=None):


### PR DESCRIPTION
#### Simulation UID collision at 137K events

Running paired simulation with 137K events (`--n-sim-events 137000 --paired-loci`) hits a UID collision during paired merging. The per-locus simulation files write successfully, but `check_for_cross_locus_duplicates` crashes on a duplicate UID within a single locus.

Observed on two different seeds:
- seed 1: `7f20fc4f2c` duplicated in igh
- seed 11: `3b25054b58` duplicated in igl

Changing the random seed did not fix it.

The collision comes from `uidhashstr` in `event.py` truncating to 10 hex characters. At 137K events this hash space is too small to avoid collisions reliably. The subcluster annotation hash collision fix (`4a5f6fe83`) already increased `max_len` to 20 for that call site.

This PR applies the same fix to simulation UID generation in `event.py:99` and `event.py:107`.