### PR TITLE
zig: borrow cluster Query.seqs as *const Sequence (#342 item 16)

### DIFF
--- a/packages/zig-core/src/ham/bcr_utils/utils.zig
+++ b/packages/zig-core/src/ham/bcr_utils/utils.zig
@@ -69,7 +69,7 @@ pub fn streamErrorput(
     writer: anytype,
     algorithm: []const u8,
     allocator: std.mem.Allocator,
-    seqs: []const Sequence,
+    seqs: []const *const Sequence,
     errors: []const u8,
 ) !void {
     const names = try seqNameStr(allocator, seqs, ":");
@@ -90,7 +90,7 @@ pub fn streamViterbiOutput(
     writer: anytype,
     allocator: std.mem.Allocator,
     event: *const RecoEvent,
-    seqs: []const Sequence,
+    seqs: []const *const Sequence,
     errors: []const u8,
 ) !void {
     const names = try seqNameStr(allocator, seqs, ":");
@@ -139,7 +139,7 @@ pub fn streamViterbiOutput(
 pub fn streamForwardOutput(
     writer: anytype,
     allocator: std.mem.Allocator,
-    seqs: []const Sequence,
+    seqs: []const *const Sequence,
     total_score: f64,
     errors: []const u8,
 ) !void {
@@ -156,12 +156,12 @@ pub fn streamForwardOutput(
 /// Corresponds to C++ `ham::SeqStr`.
 pub fn seqStr(
     allocator: std.mem.Allocator,
-    seqs: []const Sequence,
+    seqs: []const *const Sequence,
     delimiter: []const u8,
 ) ![]u8 {
     var buf: std.ArrayListUnmanaged(u8) = .{};
     defer buf.deinit(allocator);
-    for (seqs, 0..) |*seq, i| {
+    for (seqs, 0..) |seq, i| {
         if (i > 0) try buf.appendSlice(allocator, delimiter);
         try buf.appendSlice(allocator, seq.undigitized);
     }
@@ -172,12 +172,12 @@ pub fn seqStr(
 /// Corresponds to C++ `ham::SeqNameStr`.
 pub fn seqNameStr(
     allocator: std.mem.Allocator,
-    seqs: []const Sequence,
+    seqs: []const *const Sequence,
     delimiter: []const u8,
 ) ![]u8 {
     var buf: std.ArrayListUnmanaged(u8) = .{};
     defer buf.deinit(allocator);
-    for (seqs, 0..) |*seq, i| {
+    for (seqs, 0..) |seq, i| {
         if (i > 0) try buf.appendSlice(allocator, delimiter);
         try buf.appendSlice(allocator, seq.name);
     }

--- a/packages/zig-core/src/ham/bcrham.zig
+++ b/packages/zig-core/src/ham/bcrham.zig
@@ -89,18 +89,23 @@ pub fn runAlgorithm(
         defer allocator.free(only_genes);
         for (qrow.only_genes.items, only_genes) |g, *out| out.* = g;
 
+        // Build pointer view into qseqs for the DP and stream calls (item 16).
+        const qseq_ptrs = try allocator.alloc(*const Sequence, qseqs.items.len);
+        defer allocator.free(qseq_ptrs);
+        for (qseqs.items, qseq_ptrs) |*sq, *out| out.* = sq;
+
         var dph = try DPHandler.init(allocator, args.algorithm, args, gl, hmms);
         defer dph.deinit();
 
-        var result = try dph.run(qseqs.items, kbounds, only_genes, @floatCast(qrow.mut_freq), true);
+        var result = try dph.run(qseq_ptrs, kbounds, only_genes, @floatCast(qrow.mut_freq), true);
         defer result.deinit();
 
         if (result.no_path) {
-            try bcr_text.streamErrorput(writer, args.algorithm, allocator, qseqs.items, "no_path");
+            try bcr_text.streamErrorput(writer, args.algorithm, allocator, qseq_ptrs, "no_path");
         } else if (std.mem.eql(u8, args.algorithm, "viterbi")) {
-            try bcr_text.streamViterbiOutput(writer, allocator, &result.best_event.?, qseqs.items, "");
+            try bcr_text.streamViterbiOutput(writer, allocator, &result.best_event.?, qseq_ptrs, "");
         } else if (std.mem.eql(u8, args.algorithm, "forward")) {
-            try bcr_text.streamForwardOutput(writer, allocator, qseqs.items, result.total_score, "");
+            try bcr_text.streamForwardOutput(writer, allocator, qseq_ptrs, result.total_score, "");
         } else {
             return error.UnknownAlgorithm;
         }

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -197,25 +197,26 @@ pub const DPHandler = struct {
     /// for the duration of the call; the caller retains ownership.
     pub fn runSeq(
         self: *DPHandler,
-        seq: Sequence,
+        seq: *const Sequence,
         kbounds: KBounds,
         only_gene_list: []const []const u8,
         overall_mute_freq: f64,
         clear_cache: bool,
     ) !Result {
-        const seqvec = [_]Sequence{seq};
+        const seqvec = [_]*const Sequence{seq};
         return self.run(&seqvec, kbounds, only_gene_list, overall_mute_freq, clear_cache);
     }
 
     /// Run the DP over a vector of sequences.
     /// Corresponds to C++ `DPHandler::Run(vector<Sequence>, ...)`.
-    /// `seqvector` is borrowed: each Sequence's heap buffers must outlive the
-    /// call; the internal Sequences container holds shallow struct-copies that
-    /// share those buffers (item 2 of issue #342). The container's items are
-    /// not deinit'd at function end — only the backing array is freed.
+    /// `seqvector` is borrowed: each pointed-to Sequence's heap buffers must
+    /// outlive the call; the internal Sequences container holds shallow
+    /// struct-copies that share those buffers (items 2 + 16 of issue #342).
+    /// The container's items are not deinit'd at function end — only the
+    /// backing array allocation is freed.
     pub fn run(
         self: *DPHandler,
-        seqvector: []const Sequence,
+        seqvector: []const *const Sequence,
         kbounds: KBounds,
         only_gene_list: []const []const u8,
         overall_mute_freq: f64,
@@ -241,7 +242,8 @@ pub const DPHandler = struct {
         var seqs = Sequences.init();
         defer seqs.seqs.deinit(allocator);
         try seqs.seqs.ensureTotalCapacityPrecise(allocator, seqvector.len);
-        for (seqvector) |sq| {
+        for (seqvector) |sq_ptr| {
+            const sq = sq_ptr.*;
             if (seqs.seqs.items.len == 0) {
                 seqs.sequence_length = sq.size();
             } else if (sq.size() != seqs.sequence_length) {
@@ -1211,7 +1213,7 @@ pub const DPHandler = struct {
     pub fn handleFishyAnnotations(
         self: *DPHandler,
         multi_seq_result: *Result,
-        qry_seqs: []const Sequence,
+        qry_seqs: []const *const Sequence,
         kbounds: KBounds,
         only_gene_list: []const []const u8,
         overall_mute_freq: f64,
@@ -1236,7 +1238,7 @@ pub const DPHandler = struct {
         var naive_seq = try Sequence.initFromString(parent, first_track, "naive-seq", best_ev.naive_seq);
         defer naive_seq.deinit(parent);
 
-        const naive_seqs = [_]Sequence{naive_seq};
+        const naive_seqs = [_]*const Sequence{&naive_seq};
         var naive_result = try self.run(&naive_seqs, kbounds, only_gene_list, overall_mute_freq, true);
         defer naive_result.deinit();
 

--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -1172,6 +1172,11 @@ pub const Glomerator = struct {
             key_seq_ptrs.appendAssumeCapacity(sq_ptr);
             n_names += 1;
         }
+        // Defensive: an all-colon `queries` would yield no non-empty parts and
+        // would otherwise produce NaN from the mute_freq division below. Real
+        // cluster keys derive from non-empty UIDs, so this is not reachable on
+        // valid input — but the explicit error is cheaper than tracing NaN.
+        if (n_names == 0) return error.MissingSeqCache;
 
         var only_genes_list: std.ArrayListUnmanaged([]const u8) = .{};
         defer only_genes_list.deinit(self.allocator);

--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -46,10 +46,12 @@ pub const Glomerator = struct {
     /// All actual sequences, keyed by sequence name.
     ///
     /// Write-once during `init`; **frozen** thereafter (no inserts, no
-    /// removals, no replacements). Per issue #342 item 6, every other
-    /// `Query.seqs` in the glomerator borrows from these buffers via
-    /// shallow copies, so mutating this map post-init would invalidate
-    /// those borrows and produce use-after-free on the slice fields.
+    /// removals, no replacements). Per issue #342 items 6 and 16, every
+    /// other `Query.seqs` in the glomerator stores `*const Sequence`
+    /// pointers into this map's value slots. Mutating this map post-init
+    /// (or growing it past its `ensureTotalCapacity` bound during init)
+    /// can rehash and invalidate those pointers — `init` populates this
+    /// map fully in a first pass before any cachefo Query is built.
     /// Adding any write to this map outside `init` requires reworking
     /// the borrowed-Sequence contract (see Query struct doc).
     single_seqs: std.StringHashMapUnmanaged(Sequence),
@@ -143,6 +145,26 @@ pub const Glomerator = struct {
 
         try self.readCacheFile();
 
+        // Pass 1: populate `single_seqs` fully. Item 16 stores `*const Sequence`
+        // pointers into this map's value slots in `single_seq_cachefo` and
+        // `cachefo` `Query.seqs`; those pointers must be taken only after the
+        // map is stable, since `put` on a growing map can rehash and invalidate
+        // pointers returned by earlier `getPtr` calls.
+        var total_seqs: usize = 0;
+        for (qry_seq_lists) |seq_list| total_seqs += seq_list.len;
+        try self.single_seqs.ensureTotalCapacity(allocator, @intCast(total_seqs));
+        for (qry_seq_lists) |seq_list| {
+            for (seq_list) |*sq| {
+                if (self.single_seqs.contains(sq.name)) continue;
+                const name_key = try allocator.dupe(u8, sq.name);
+                errdefer allocator.free(name_key);
+                try self.single_seqs.put(allocator, name_key, try sq.clone(allocator));
+            }
+        }
+
+        // Pass 2: build cachefo / single_seq_cachefo / initial_partition.
+        // `single_seqs` is now frozen; `getPtr` results are stable for the
+        // remaining lifetime of the Glomerator.
         for (qry_seq_lists, 0..) |seq_list, iqry| {
             // Build the colon-separated key for this query group
             var names: std.ArrayListUnmanaged([]const u8) = .{};
@@ -152,17 +174,6 @@ pub const Glomerator = struct {
             }
             const key = try ham_text.joinStrings(allocator, names.items, ":");
             defer allocator.free(key);
-
-            // Stash all sequences in single_seqs
-            for (seq_list) |*sq| {
-                const name_key = try allocator.dupe(u8, sq.name);
-                errdefer allocator.free(name_key);
-                if (!self.single_seqs.contains(name_key)) {
-                    try self.single_seqs.put(allocator, name_key, try sq.clone(allocator));
-                } else {
-                    allocator.free(name_key);
-                }
-            }
 
             // Build bounds from args queries
             const qrow = &args.queries.items[iqry];
@@ -182,52 +193,41 @@ pub const Glomerator = struct {
                 try only_genes.append(allocator, g);
             }
 
-            // Build single_seq_cachefo entries
-            const names_in_key = try splitName(allocator, key);
-            defer {
-                for (names_in_key.items) |n| allocator.free(n);
-                var nl = names_in_key;
-                nl.deinit(allocator);
-            }
-            for (names_in_key.items) |uid| {
-                if (!self.single_seq_cachefo.contains(uid)) {
-                    const uid_seqs = try self.getSeqs(uid);
-                    defer {
-                        // uid_seqs items are borrowed (item 6); only free the list.
-                        var s = uid_seqs;
-                        s.deinit(allocator);
-                    }
-                    const is_seed_missing = !ham_text.inString(args.seed_unique_id, uid, ":");
-                    var uid_q = try Query.create(
-                        allocator,
-                        uid,
-                        uid_seqs.items,
-                        is_seed_missing,
-                        only_genes.items,
-                        kbounds,
-                        @floatCast(qrow.mut_freq),
-                        @intCast(@max(0, qrow.cdr3_length)),
-                        null, null,
-                    );
-                    errdefer uid_q.deinit(allocator);
-                    const uid_key = try allocator.dupe(u8, uid);
-                    errdefer allocator.free(uid_key);
-                    try self.single_seq_cachefo.put(allocator, uid_key, uid_q);
-                }
+            // Build single_seq_cachefo entries. `key` outlives this block, so
+            // we iterate splitScalar without duping the names (item 16).
+            var key_iter = std.mem.splitScalar(u8, key, ':');
+            while (key_iter.next()) |uid| {
+                if (uid.len == 0) continue;
+                if (self.single_seq_cachefo.contains(uid)) continue;
+                const sq_ptr = self.single_seqs.getPtr(uid) orelse return error.SequenceNotFound;
+                const uid_seq_ptrs = [_]*const Sequence{sq_ptr};
+                const is_seed_missing = !ham_text.inString(args.seed_unique_id, uid, ":");
+                var uid_q = try Query.create(
+                    allocator,
+                    uid,
+                    &uid_seq_ptrs,
+                    is_seed_missing,
+                    only_genes.items,
+                    kbounds,
+                    @floatCast(qrow.mut_freq),
+                    @intCast(@max(0, qrow.cdr3_length)),
+                    null, null,
+                );
+                errdefer uid_q.deinit(allocator);
+                const uid_key = try allocator.dupe(u8, uid);
+                errdefer allocator.free(uid_key);
+                try self.single_seq_cachefo.put(allocator, uid_key, uid_q);
             }
 
             // Build cachefo entry for the full query group
-            const key_seqs = try self.getSeqs(key);
-            defer {
-                // key_seqs items are borrowed (item 6); only free the list.
-                var ksl = key_seqs;
-                ksl.deinit(allocator);
-            }
+            var key_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
+            defer key_seq_ptrs.deinit(allocator);
+            try self.appendSeqPtrsForQuery(&key_seq_ptrs, allocator, key);
             const is_seed_missing = !ham_text.inString(args.seed_unique_id, key, ":");
             var q = try Query.create(
                 allocator,
                 key,
-                key_seqs.items,
+                key_seq_ptrs.items,
                 is_seed_missing,
                 only_genes.items,
                 kbounds,
@@ -253,9 +253,10 @@ pub const Glomerator = struct {
         self.initial_partition.deinit(allocator);
 
         // Free Query maps before single_seqs: Query.seqs borrows from
-        // single_seqs (item 6). Query.deinit no longer touches sequence
-        // buffers, so the order is not load-bearing for correctness, but
-        // freeing borrowers before owners keeps the invariant explicit.
+        // single_seqs (items 6 and 16 — `*const Sequence` pointers into the
+        // map's value slots). Query.deinit no longer touches Sequence values,
+        // so the order is not load-bearing for correctness, but freeing
+        // borrowers before owners keeps the invariant explicit.
         freeQueryMap(allocator, &self.single_seq_cachefo);
         freeQueryMap(allocator, &self.cachefo);
         freeQueryMap(allocator, &self.tmp_cachefo);
@@ -804,7 +805,7 @@ pub const Glomerator = struct {
         const only_genes_slice = try self.geneListToSlice(cacheref.only_genes.items);
         defer self.allocator.free(only_genes_slice);
 
-        var result = try dph.run(cacheref.seqs.items, cacheref.kbounds, only_genes_slice, cacheref.mute_freq, true);
+        var result = try dph.run(cacheref.seqs, cacheref.kbounds, only_genes_slice, cacheref.mute_freq, true);
         defer result.deinit();
 
         if (result.no_path) {
@@ -921,7 +922,7 @@ pub const Glomerator = struct {
         const only_genes_slice = try self.geneListToSlice(cacheref.only_genes.items);
         defer self.allocator.free(only_genes_slice);
 
-        var result = try dph.run(cacheref.seqs.items, cacheref.kbounds, only_genes_slice, cacheref.mute_freq, true);
+        var result = try dph.run(cacheref.seqs, cacheref.kbounds, only_genes_slice, cacheref.mute_freq, true);
         defer result.deinit();
 
         if (result.no_path) {
@@ -1129,7 +1130,10 @@ pub const Glomerator = struct {
         if (self.cachefo.getPtr(queries)) |q| return q;
         if (self.tmp_cachefo.getPtr(queries)) |q| return q;
 
-        // Build on the fly from single_seq_cachefo
+        // Build on the fly from single_seq_cachefo. Single splitScalar pass
+        // over `queries` (item 16): the same iteration drives only_gene_set
+        // / kbounds / mute_freq and the seqs-pointer list, with no name dupes
+        // and no intermediate ArrayList from a separate getSeqs call.
         var only_gene_set: std.StringHashMapUnmanaged(void) = .{};
         defer {
             var it = only_gene_set.iterator();
@@ -1141,21 +1145,21 @@ pub const Glomerator = struct {
         var mute_freq_total: f64 = 0.0;
         var cdr3_length: usize = 0;
 
-        const names = try splitName(self.allocator, queries);
-        defer {
-            for (names.items) |n| self.allocator.free(n);
-            var nl = names;
-            nl.deinit(self.allocator);
-        }
+        var key_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
+        defer key_seq_ptrs.deinit(self.allocator);
+        try key_seq_ptrs.ensureUnusedCapacity(self.allocator, @intCast(countMembers(queries)));
 
-        for (names.items, 0..) |uid, is| {
+        var n_names: usize = 0;
+        var name_it = std.mem.splitScalar(u8, queries, ':');
+        while (name_it.next()) |uid| {
+            if (uid.len == 0) continue;
             const scache = self.single_seq_cachefo.getPtr(uid) orelse return error.MissingSeqCache;
             for (scache.only_genes.items) |g| {
                 if (!only_gene_set.contains(g)) {
                     try only_gene_set.put(self.allocator, try self.allocator.dupe(u8, g), {});
                 }
             }
-            if (is == 0) {
+            if (n_names == 0) {
                 kbounds = scache.kbounds;
                 cdr3_length = scache.cdr3_length;
             } else {
@@ -1163,6 +1167,10 @@ pub const Glomerator = struct {
                 if (cdr3_length != scache.cdr3_length) return error.Cdr3LengthMismatch;
             }
             mute_freq_total += scache.mute_freq;
+
+            const sq_ptr = self.single_seqs.getPtr(uid) orelse return error.SequenceNotFound;
+            key_seq_ptrs.appendAssumeCapacity(sq_ptr);
+            n_names += 1;
         }
 
         var only_genes_list: std.ArrayListUnmanaged([]const u8) = .{};
@@ -1180,22 +1188,15 @@ pub const Glomerator = struct {
             }
         }.lessThan);
 
-        const key_seqs = try self.getSeqs(queries);
-        defer {
-            // key_seqs items are borrowed (item 6); only free the list.
-            var ks = key_seqs;
-            ks.deinit(self.allocator);
-        }
-
         const is_seed_missing = !ham_text.inString(self.args.seed_unique_id, queries, ":");
         var new_q = try Query.create(
             self.allocator,
             queries,
-            key_seqs.items,
+            key_seq_ptrs.items,
             is_seed_missing,
             only_genes_list.items,
             kbounds,
-            @floatCast(mute_freq_total / @as(f64, @floatFromInt(names.items.len))),
+            @floatCast(mute_freq_total / @as(f64, @floatFromInt(n_names))),
             cdr3_length,
             null, null,
         );
@@ -1263,17 +1264,14 @@ pub const Glomerator = struct {
         const joint_mute_freq: f32 = @floatCast((n_a_f64 * @as(f64, ref_a.mute_freq) + n_b_f64 * @as(f64, ref_b.mute_freq)) / n_total_f64);
         const is_seed_missing = !ham_text.inString(self.args.seed_unique_id, joint_name, ":");
 
-        const key_seqs = try self.getSeqs(joint_name);
-        defer {
-            // key_seqs items are borrowed (item 6); only free the list.
-            var ksl = key_seqs;
-            ksl.deinit(self.allocator);
-        }
+        var key_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
+        defer key_seq_ptrs.deinit(self.allocator);
+        try self.appendSeqPtrsForQuery(&key_seq_ptrs, self.allocator, joint_name);
 
         var q = try Query.create(
             self.allocator,
             joint_name,
-            key_seqs.items,
+            key_seq_ptrs.items,
             is_seed_missing,
             genes_list.items,
             joint_kbounds,
@@ -1448,17 +1446,14 @@ pub const Glomerator = struct {
         // merge cascade truncation) must be used for consistency with C++.
         const cacheref = try self.getCachefo(queries);
         {
-            const sub_seqs = try self.getSeqs(subqueries);
-            defer {
-                // sub_seqs items are borrowed (item 6); only free the list.
-                var ss = sub_seqs;
-                ss.deinit(self.allocator);
-            }
+            var sub_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
+            defer sub_seq_ptrs.deinit(self.allocator);
+            try self.appendSeqPtrsForQuery(&sub_seq_ptrs, self.allocator, subqueries);
             const is_seed_missing = !ham_text.inString(self.args.seed_unique_id, subqueries, ":");
             var sub_q = try Query.create(
                 self.allocator,
                 subqueries,
-                sub_seqs.items,
+                sub_seq_ptrs.items,
                 is_seed_missing,
                 cacheref.only_genes.items,
                 cacheref.kbounds,
@@ -1587,17 +1582,14 @@ pub const Glomerator = struct {
             try self.cachefo.put(self.allocator, key, val);
         } else {
             const supercache = try self.getCachefo(superquery);
-            const key_seqs = try self.getSeqs(translated_query);
-            defer {
-                // key_seqs items are borrowed (item 6); only free the list.
-                var ks = key_seqs;
-                ks.deinit(self.allocator);
-            }
+            var key_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
+            defer key_seq_ptrs.deinit(self.allocator);
+            try self.appendSeqPtrsForQuery(&key_seq_ptrs, self.allocator, translated_query);
             const is_seed_missing = !ham_text.inString(self.args.seed_unique_id, translated_query, ":");
             var q = try Query.create(
                 self.allocator,
                 translated_query,
-                key_seqs.items,
+                key_seq_ptrs.items,
                 is_seed_missing,
                 supercache.only_genes.items,
                 supercache.kbounds,
@@ -1614,28 +1606,26 @@ pub const Glomerator = struct {
 
     // ── Utility helpers ───────────────────────────────────────────────────────
 
-    /// C++: Glomerator::GetSeqs() — glomerator.cc:850
-    ///
-    /// Returns borrowed shallow copies of Sequence values from `single_seqs`.
-    /// The buffers (`name`, `undigitized`, `seqq`, ...) are not duplicated;
-    /// callers must not call `Sequence.deinit` on the returned items, and the
-    /// returned slice must not outlive `single_seqs`. Issue #342, item 6.
-    fn getSeqs(self: *Glomerator, query: []const u8) !std.ArrayListUnmanaged(Sequence) {
-        const names = try splitName(self.allocator, query);
-        defer {
-            for (names.items) |n| self.allocator.free(n);
-            var nl = names;
-            nl.deinit(self.allocator);
-        }
-
-        var result: std.ArrayListUnmanaged(Sequence) = .{};
-        errdefer result.deinit(self.allocator);
-        try result.ensureUnusedCapacity(self.allocator, names.items.len);
-        for (names.items) |uid| {
+    /// Append `*const Sequence` pointers into `single_seqs` to `dst`, one per
+    /// colon-separated UID in `query`. Iterates `splitScalar` directly — no
+    /// per-name `dupe`, no intermediate ArrayList. The pointed-to Sequences
+    /// must outlive any consumer that holds these pointers.
+    /// C++: corresponds to the `Glomerator::GetSeqs()` callers' inline build
+    /// pattern (glomerator.cc:850 + the lookup loop in cachefo()).
+    /// Issue #342, items 6 + 16.
+    fn appendSeqPtrsForQuery(
+        self: *Glomerator,
+        dst: *std.ArrayListUnmanaged(*const Sequence),
+        allocator: std.mem.Allocator,
+        query: []const u8,
+    ) !void {
+        try dst.ensureUnusedCapacity(allocator, @intCast(countMembers(query)));
+        var it = std.mem.splitScalar(u8, query, ':');
+        while (it.next()) |uid| {
+            if (uid.len == 0) continue;
             const sq = self.single_seqs.getPtr(uid) orelse return error.SequenceNotFound;
-            result.appendAssumeCapacity(sq.*);
+            dst.appendAssumeCapacity(sq);
         }
-        return result;
     }
 
     /// C++: Glomerator::AddFailedQuery() — glomerator.cc:776
@@ -1887,7 +1877,7 @@ fn cloneQuery(allocator: std.mem.Allocator, q: *const Query) !Query {
     return Query.create(
         allocator,
         q.name,
-        q.seqs.items,
+        q.seqs,
         q.seed_missing,
         q.only_genes.items,
         q.kbounds,

--- a/packages/zig-core/src/ham/glomerator/query.zig
+++ b/packages/zig-core/src/ham/glomerator/query.zig
@@ -9,16 +9,16 @@ const KBounds = @import("../bcr_utils/k_bounds.zig").KBounds;
 
 /// Corresponds to C++ `ham::Query`.
 ///
-/// Sequence ownership (issue #342, item 6): `seqs` holds **borrowed** Sequence
-/// values — shallow copies whose slice fields (`name`, `header`, `undigitized`,
-/// `seqq`) point at buffers owned by `Glomerator.single_seqs`. The Query must
-/// not outlive the Glomerator that owns those buffers, and `Query.deinit` must
-/// not call `Sequence.deinit` on its entries.
+/// Sequence ownership (issue #342, items 6 and 16): `seqs` holds **borrowed**
+/// `*const Sequence` pointers into buffers owned by `Glomerator.single_seqs`.
+/// The Query must not outlive the Glomerator that owns those buffers, and
+/// `Query.deinit` must not call `Sequence.deinit` on the pointed-to values —
+/// only the pointer slice itself is owned.
 pub const Query = struct {
     name: []u8,
-    /// Borrowed shallow copies of Sequences. Buffers are owned by
-    /// `Glomerator.single_seqs`; do not free per-item in deinit.
-    seqs: std.ArrayListUnmanaged(Sequence),
+    /// Borrowed pointers into `Glomerator.single_seqs`. Allocated as a single
+    /// slice at create-time; never grown. Must not be deinit'd per-item.
+    seqs: []*const Sequence,
     seed_missing: bool,
     only_genes: std.ArrayListUnmanaged([]u8),
     kbounds: KBounds,
@@ -31,7 +31,7 @@ pub const Query = struct {
         _ = allocator;
         return Query{
             .name = &.{},
-            .seqs = .{},
+            .seqs = &.{},
             .seed_missing = false,
             .only_genes = .{},
             .kbounds = .{},
@@ -41,13 +41,13 @@ pub const Query = struct {
         };
     }
 
-    /// Create a fully-specified Query. `seqs` is borrowed: each Sequence is
-    /// stored as a shallow copy (slice descriptors), and the buffers must
-    /// outlive this Query. See struct doc comment.
+    /// Create a fully-specified Query. `seqs` is borrowed: each pointer is
+    /// stored verbatim, and the pointed-to Sequences must outlive this Query.
+    /// See struct doc comment.
     pub fn create(
         allocator: std.mem.Allocator,
         name: []const u8,
-        seqs: []const Sequence,
+        seqs: []const *const Sequence,
         seed_missing: bool,
         only_genes: []const []const u8,
         kbounds: KBounds,
@@ -58,7 +58,7 @@ pub const Query = struct {
     ) !Query {
         var q = Query{
             .name = try allocator.dupe(u8, name),
-            .seqs = .{},
+            .seqs = &.{},
             .seed_missing = seed_missing,
             .only_genes = .{},
             .kbounds = kbounds,
@@ -68,9 +68,10 @@ pub const Query = struct {
         };
         errdefer q.deinit(allocator);
 
-        try q.seqs.ensureUnusedCapacity(allocator, seqs.len);
-        for (seqs) |sq| {
-            q.seqs.appendAssumeCapacity(sq);
+        if (seqs.len > 0) {
+            const seqs_buf = try allocator.alloc(*const Sequence, seqs.len);
+            @memcpy(seqs_buf, seqs);
+            q.seqs = seqs_buf;
         }
         for (only_genes) |g| {
             try q.only_genes.append(allocator, try allocator.dupe(u8, g));
@@ -86,9 +87,9 @@ pub const Query = struct {
 
     pub fn deinit(self: *Query, allocator: std.mem.Allocator) void {
         if (self.name.len > 0) allocator.free(self.name);
-        // seqs entries are borrowed shallow copies (see struct doc); do not
-        // call Sequence.deinit here. Only the ArrayList itself is owned.
-        self.seqs.deinit(allocator);
+        // seqs entries are borrowed pointers (see struct doc); do not call
+        // Sequence.deinit on them. Only the pointer slice itself is owned.
+        if (self.seqs.len > 0) allocator.free(self.seqs);
         for (self.only_genes.items) |g| allocator.free(g);
         self.only_genes.deinit(allocator);
         if (self.parents) |*ps| {
@@ -99,6 +100,6 @@ pub const Query = struct {
 
     /// Return number of sequences.
     pub fn nSeqs(self: *const Query) usize {
-        return self.seqs.items.len;
+        return self.seqs.len;
     }
 };


### PR DESCRIPTION
Sub-PR against the long-lived topic branch `342-zig-perf-cleanup`. Item 16 from issue #342. Design comment: [issue-comment-4377651744](https://github.com/psathyrella/partis/issues/342#issuecomment-4377651744).

## Summary

- `Query.seqs` becomes `[]*const Sequence` (single-allocation slice of pointers into `Glomerator.single_seqs`) instead of `ArrayListUnmanaged(Sequence)` (struct-copies of slice headers). Cascade through the DP pipeline borrow boundary: `dph.run`, `runSeq`, `handleFishyAnnotations`, and the `bcr_utils` stream / `seqStr` / `seqNameStr` helpers all take `[]const *const Sequence`.
- `getSeqs` is removed; a private `appendSeqPtrsForQuery` helper iterates `splitScalar` directly with no per-name `dupe` and no intermediate ArrayList. `getCachefo`'s leading loop absorbs the seqs-pointer build into the existing single pass over names — no second `splitName` call.
- `init` is split into two passes: pass 1 fully populates `single_seqs` with `ensureTotalCapacity` precomputed from the input seq count; pass 2 builds `cachefo` / `single_seq_cachefo` / `initial_partition`. Required because `*const Sequence` pointers taken from `single_seqs.getPtr` would be invalidated by a subsequent `put()` that rehashes the map.

Per-fresh-entry allocator traffic in the Glomerator cluster-Query construction sites collapses:
| Path | Before | After |
|---|---|---|
| `getCachefo` cache miss | `splitName + splitName(via getSeqs) + getSeqs ArrayList + Query.create ArrayList` = `4 + 2N` | `Query.seqs slice + cf_key dupe` = `2` |
| `getMergedQuery` / `chooseSubsetOfNames` / `copyToPermanentCache` cache miss | `2 + N` | `2` |

(Where N is cluster size. `Glomerator.allocator` is `c_allocator`, not on item 4's per-query arena, so these are real glibc round trips.)

Storage: `Query.seqs` is 8 B per slot instead of 72 B per slot (4 slice headers + optional Track pointer per Sequence). At 30k that's a few MB across cached cluster Queries — marginal.

## Test plan

Standard iteration gate per [cold-start handoff](https://github.com/psathyrella/partis/issues/342#issuecomment-4360930507):

- [x] **rung 0** `zig build test`: pass
- [x] **rung 1** `partis-test.py --quick --zig`: pass
- [x] **rung 2a** `partis-test.py --no-simu --zig`: pass
- [x] **rung 2b** `partis-test.py --paired --no-simu --zig`: pass
- [x] **rung 4** 5k paired partition byte-equality vs `/tmp/zig-5k-baseline`:
  ```
  igh: 3797 events identical
  igk: 3802 events identical
  OK: identical
  ```
  md5: `65f2720cbcc59cb2d3f89ad1f5a0b2cb partition-igh.yaml`, `7ad6b1f3b0b9833fb7d11240bdc332d6 partition-igk.yaml` (matches baseline).
  Wall 5:01.55 / Peak RSS 466 MB (n=1, vs pinned baseline 5:10 / 467 MB — within wall noise; not a controlled comparison).

**30k pre-merge gate skipped** per #363's policy when wall delta is predicted sub-noise. Per the design comment, the upper bound on wall recovery from c_allocator round-trip elimination at 30k is ~50–500 ms over a 73-min run, well below the noise floor; rung-4 byte-equality is the parity gate. Happy to run 30k n=2 each side if a reviewer wants the controlled measurement (~3 hours).

Refs #342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
