### PR TITLE
zig: phase-0 perf counters + diagnostics for #366

### DIFF
--- a/packages/zig-core/build.zig
+++ b/packages/zig-core/build.zig
@@ -4,6 +4,19 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    // -Dperf-counters: gate the issue-#366 phase-0 diagnostics counters in
+    // src/ham/perf_counters.zig. When false (default), every counter site
+    // is `if (enabled) { ... }` with `enabled = false`, so the inner-loop
+    // calls compile to nothing and bit-equal output is preserved.
+    const perf_counters = b.option(
+        bool,
+        "perf-counters",
+        "Enable Phase-0 perf counters (issue #366). Default false; counters compile out when off.",
+    ) orelse false;
+    const perf_opts = b.addOptions();
+    perf_opts.addOption(bool, "perf_counters", perf_counters);
+    const build_options_module = perf_opts.createModule();
+
     // ── partis-zig-core executable: bcrham-compatible CLI ────────────────
     // `zig build` produces this by default. No external library deps.
     const exe = b.addExecutable(.{
@@ -14,6 +27,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    exe.root_module.addImport("build_options", build_options_module);
     // Link libc so release builds can use std.heap.c_allocator (malloc/free),
     // which avoids GPA's per-allocation tracking overhead.
     exe.root_module.linkSystemLibrary("c", .{});
@@ -32,6 +46,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    compare.root_module.addImport("build_options", build_options_module);
     b.installArtifact(compare);
 
     // ── lib: C ABI shared library (requires ig-sw sources from partis) ───
@@ -45,6 +60,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    cabi_mod.addImport("build_options", build_options_module);
     if (igsw_src.len > 0) {
         cabi_mod.addIncludePath(.{ .cwd_relative = igsw_src });
     }
@@ -96,6 +112,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    ham_test_mod.addImport("build_options", build_options_module);
     // Link libc + glibc_math shim so tests that exercise mathutils.log/exp
     // resolve `glibc_log` / `glibc_exp`. Without these, unit tests linking
     // anything that uses the math hot path fail with "undefined symbol:

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -448,22 +448,6 @@ pub const DPHandler = struct {
         const name_str = try seqs.nameStr(allocator, ":");
         defer allocator.free(name_str);
 
-        // O_APPEND so concurrent bcrham processes (partis runs n-procs in
-        // parallel) writing to the same log file don't clobber each other.
-        // Linux guarantees atomic appends for writes <= PIPE_BUF (4 KiB);
-        // each PERFCOUNTER line stays well under that limit.
-        const log_path_z = try allocator.dupeZ(u8, log_path);
-        defer allocator.free(log_path_z);
-        const flags: std.posix.O = .{ .ACCMODE = .WRONLY, .APPEND = true, .CREAT = true };
-        const fd = try std.posix.openZ(log_path_z, flags, 0o644);
-        const file = std.fs.File{ .handle = fd };
-        defer file.close();
-
-        if (try perf_counters.formatPerfCounters(allocator, self.algorithm, name_str, seqs.seqs.items.len)) |line| {
-            defer allocator.free(line);
-            try file.writeAll(line);
-        }
-
         // cache_list length histogram across all genes in scratch_cachefo.
         // Buckets are log-ish (0,1,2,3,4,5,[6-9],[10-19],[20-49],[50-99],
         // [100-199],[200+]) — matches the order-of-magnitude questions the
@@ -476,13 +460,37 @@ pub const DPHandler = struct {
                 if (n == 0) 0 else if (n == 1) 1 else if (n == 2) 2 else if (n == 3) 3 else if (n == 4) 4 else if (n == 5) 5 else if (n < 10) 6 else if (n < 20) 7 else if (n < 50) 8 else if (n < 100) 9 else if (n < 200) 10 else 11;
             buckets[idx] += 1;
         }
+
+        // Build the PERFCOUNTER + PERFCOUNTER_CACHE block in one buffer
+        // and emit with a single writeAll. With multiple bcrham processes
+        // appending to the same log (`partis --n-procs N > 1`), splitting
+        // this into two writes would let another process slip a line
+        // between ours, separating the pair. Concatenated, the two lines
+        // share one O_APPEND atomic write.
+        const main_line = (try perf_counters.formatPerfCounters(allocator, self.algorithm, name_str, seqs.seqs.items.len)) orelse return;
+        defer allocator.free(main_line);
         const cache_line = try std.fmt.allocPrint(
             allocator,
             "PERFCOUNTER_CACHE alg={s} q={s} 0={d} 1={d} 2={d} 3={d} 4={d} 5={d} 6_9={d} 10_19={d} 20_49={d} 50_99={d} 100_199={d} 200p={d}\n",
             .{ self.algorithm, name_str, buckets[0], buckets[1], buckets[2], buckets[3], buckets[4], buckets[5], buckets[6], buckets[7], buckets[8], buckets[9], buckets[10], buckets[11] },
         );
         defer allocator.free(cache_line);
-        try file.writeAll(cache_line);
+        const blob = try std.mem.concat(allocator, u8, &.{ main_line, cache_line });
+        defer allocator.free(blob);
+
+        // O_APPEND on regular files: Linux serializes the
+        // seek-to-end-and-write pair at the syscall level, so each
+        // writeAll lands as one atomic append regardless of size — there
+        // is no PIPE_BUF-style upper bound for regular files. (PIPE_BUF
+        // applies to pipes, not files.) Concurrent bcrham processes
+        // therefore can't interleave the bytes of a single writeAll.
+        const log_path_z = try allocator.dupeZ(u8, log_path);
+        defer allocator.free(log_path_z);
+        const flags: std.posix.O = .{ .ACCMODE = .WRONLY, .APPEND = true, .CREAT = true };
+        const fd = try std.posix.openZ(log_path_z, flags, 0o644);
+        const file = std.fs.File{ .handle = fd };
+        defer file.close();
+        try file.writeAll(blob);
     }
 
     /// Get subsequences for one region.
@@ -615,7 +623,7 @@ pub const DPHandler = struct {
         // strings of the cached trellis's stored query_seqs.
         var cached_trellis: ?*const Trellis = null;
         if (!self.args.no_chunk_cache) {
-            perf_counters.bumpChunkCacheEntry();
+            perf_counters.bumpChunkCacheLookup();
             if (self.scratch_cachefo.getPtr(gene)) |cache_list| {
                 for (cache_list.items) |te| {
                     const cached_seqs = te.query_seqs.seqs.items;

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -14,6 +14,7 @@ const Model = @import("model.zig").Model;
 const Sequences = @import("sequences.zig").Sequences;
 const Sequence = @import("sequences.zig").Sequence;
 const mathutils = @import("mathutils.zig");
+const perf_counters = @import("perf_counters.zig");
 const Args = @import("args.zig").Args;
 const bcr = @import("bcr_utils/root.zig");
 const GermLines = bcr.GermLines;
@@ -234,6 +235,11 @@ pub const DPHandler = struct {
         const parent = self.parent_allocator;
         const run_start = std.time.milliTimestamp();
 
+        // Phase-0 diagnostics (#366): per-query counter reset. No-op when
+        // `-Dperf-counters=false` (default), so the bit-equal default build
+        // is unaffected.
+        perf_counters.reset();
+
         // Build a Sequences container that borrows from `seqvector`.
         // Each Sequence is a shallow struct-copy: slice headers are duplicated,
         // but the underlying name/header/undigitized/seqq buffers are shared
@@ -337,6 +343,7 @@ pub const DPHandler = struct {
                     n_too_long += 1;
                 } else {
                     const kset = KSet{ .v = k_v, .d = k_d };
+                    perf_counters.bumpKSet();
                     try self.runKSet(&seqs, kset, &only_genes, &best_scores, &total_scores, &best_genes);
                     n_run += 1;
                     const total_kset = total_scores.get(kset) orelse mathutils.NEG_INF;
@@ -382,6 +389,7 @@ pub const DPHandler = struct {
             if (!self.args.dont_rescale_emissions) {
                 try self.hmms.unRescaleOverallMuteFreqs(&only_genes);
             }
+            try self.dumpPerfCounters(&seqs);
             return result;
         }
 
@@ -414,7 +422,67 @@ pub const DPHandler = struct {
             try self.hmms.unRescaleOverallMuteFreqs(&only_genes);
         }
 
+        try self.dumpPerfCounters(&seqs);
         return result;
+    }
+
+    /// Phase-0 diagnostics dump (#366). No-op when `-Dperf-counters=false`.
+    /// Emits one PERFCOUNTER and one PERFCOUNTER_CACHE line per query.
+    ///
+    /// Output target: file path from `PARTIS_ZIG_PERF_LOG` env var (append).
+    /// Side-channel rather than stdout because partis captures bcrham stdout
+    /// and discards everything except recognised dbgstrs (utils.py:5896+);
+    /// the env-var redirect keeps the diagnostic output entirely outside
+    /// the partis input/output protocol so partis-test.py's parity checks
+    /// stay clean. When the env var is unset, the dump is silent.
+    fn dumpPerfCounters(self: *DPHandler, seqs: *const Sequences) !void {
+        if (!perf_counters.enabled) return;
+        const allocator = self.scratchAllocator();
+
+        const log_path = std.process.getEnvVarOwned(allocator, "PARTIS_ZIG_PERF_LOG") catch |err| switch (err) {
+            error.EnvironmentVariableNotFound => return,
+            else => return err,
+        };
+        defer allocator.free(log_path);
+
+        const name_str = try seqs.nameStr(allocator, ":");
+        defer allocator.free(name_str);
+
+        // O_APPEND so concurrent bcrham processes (partis runs n-procs in
+        // parallel) writing to the same log file don't clobber each other.
+        // Linux guarantees atomic appends for writes <= PIPE_BUF (4 KiB);
+        // each PERFCOUNTER line stays well under that limit.
+        const log_path_z = try allocator.dupeZ(u8, log_path);
+        defer allocator.free(log_path_z);
+        const flags: std.posix.O = .{ .ACCMODE = .WRONLY, .APPEND = true, .CREAT = true };
+        const fd = try std.posix.openZ(log_path_z, flags, 0o644);
+        const file = std.fs.File{ .handle = fd };
+        defer file.close();
+
+        if (try perf_counters.formatPerfCounters(allocator, self.algorithm, name_str, seqs.seqs.items.len)) |line| {
+            defer allocator.free(line);
+            try file.writeAll(line);
+        }
+
+        // cache_list length histogram across all genes in scratch_cachefo.
+        // Buckets are log-ish (0,1,2,3,4,5,[6-9],[10-19],[20-49],[50-99],
+        // [100-199],[200+]) — matches the order-of-magnitude questions the
+        // issue asks about chunk-cache state.
+        var buckets = [_]u64{0} ** 12;
+        var it = self.scratch_cachefo.iterator();
+        while (it.next()) |entry| {
+            const n = entry.value_ptr.items.len;
+            const idx: usize =
+                if (n == 0) 0 else if (n == 1) 1 else if (n == 2) 2 else if (n == 3) 3 else if (n == 4) 4 else if (n == 5) 5 else if (n < 10) 6 else if (n < 20) 7 else if (n < 50) 8 else if (n < 100) 9 else if (n < 200) 10 else 11;
+            buckets[idx] += 1;
+        }
+        const cache_line = try std.fmt.allocPrint(
+            allocator,
+            "PERFCOUNTER_CACHE alg={s} q={s} 0={d} 1={d} 2={d} 3={d} 4={d} 5={d} 6_9={d} 10_19={d} 20_49={d} 50_99={d} 100_199={d} 200p={d}\n",
+            .{ self.algorithm, name_str, buckets[0], buckets[1], buckets[2], buckets[3], buckets[4], buckets[5], buckets[6], buckets[7], buckets[8], buckets[9], buckets[10], buckets[11] },
+        );
+        defer allocator.free(cache_line);
+        try file.writeAll(cache_line);
     }
 
     /// Get subsequences for one region.
@@ -541,11 +609,13 @@ pub const DPHandler = struct {
         gene: []const u8,
     ) ![]const u8 {
         const allocator = self.scratchAllocator();
+        perf_counters.bumpFillTrellis();
 
         // Look for a chunk-cached trellis. Prefix-match is on undigitized
         // strings of the cached trellis's stored query_seqs.
         var cached_trellis: ?*const Trellis = null;
         if (!self.args.no_chunk_cache) {
+            perf_counters.bumpChunkCacheEntry();
             if (self.scratch_cachefo.getPtr(gene)) |cache_list| {
                 for (cache_list.items) |te| {
                     const cached_seqs = te.query_seqs.seqs.items;
@@ -561,6 +631,7 @@ pub const DPHandler = struct {
                     }
                     if (all_match) {
                         cached_trellis = &te.trellis;
+                        perf_counters.bumpChunkCacheHit();
                         break;
                     }
                 }

--- a/packages/zig-core/src/ham/mathutils.zig
+++ b/packages/zig-core/src/ham/mathutils.zig
@@ -68,6 +68,10 @@ pub fn addInLogSpace(first: f64, second: f64) f64 {
     perf_counters.bumpAddInLogSpace();
     if (first == NEG_INF) return second;
     if (second == NEG_INF) return first;
+    // Past both early-outs: this call does exactly 1 log + 1 exp. Bump
+    // the work counter separately so item-3.2 cost predictions can be
+    // priced against actual transcendental work, not call rate.
+    perf_counters.bumpAddInLogSpaceLogExp();
     if (first > second) {
         return first + log(1.0 + exp(second - first));
     } else {

--- a/packages/zig-core/src/ham/mathutils.zig
+++ b/packages/zig-core/src/ham/mathutils.zig
@@ -13,6 +13,7 @@
 
 const std = @import("std");
 const math = std.math;
+const perf_counters = @import("perf_counters.zig");
 
 // Use glibc log/exp via C wrapper (glibc_math.c) to match C++ bcrham bit-for-bit.
 // Zig's `extern fn log/exp` resolves to compiler-rt (bundled as local 't' symbols),
@@ -64,6 +65,7 @@ pub fn addWithMinusInfinities(first: f64, second: f64) f64 {
 /// Implements the log-space *or* operation (a OR b = a + b in probability space).
 /// Corresponds to C++ `ham::AddInLogSpace<T>(T first, T second)`.
 pub fn addInLogSpace(first: f64, second: f64) f64 {
+    perf_counters.bumpAddInLogSpace();
     if (first == NEG_INF) return second;
     if (second == NEG_INF) return first;
     if (first > second) {

--- a/packages/zig-core/src/ham/perf_counters.zig
+++ b/packages/zig-core/src/ham/perf_counters.zig
@@ -8,17 +8,36 @@
 ///
 /// Counters cover the metrics requested in #366 phase 0.1 / 0.2:
 ///
-///   - addInLogSpace_calls       — `mathutils.zig:addInLogSpace`
-///   - fillTrellis_calls         — `dp_handler.zig:fillTrellis` entry
-///   - n_ksets                   — `dp_handler.zig:run` kset loop
-///   - chunk_cache_entries/hits  — `dp_handler.zig:fillTrellis` cache branch
-///   - active_state_hist[count]  — `trellis.zig` middleViterbiVals/middleForwardVals
+///   - addInLogSpace_calls          — `mathutils.zig:addInLogSpace` entry
+///   - addInLogSpace_log_exp_calls  — calls past both NEG_INF early-outs
+///                                    (each = 1 log + 1 exp of work)
+///   - fillTrellis_calls            — `dp_handler.zig:fillTrellis` entry
+///   - n_ksets                      — `dp_handler.zig:run` kset loop
+///   - chunk_cache_lookups/hits     — `dp_handler.zig:fillTrellis` cache
+///                                    branch entry / prefix-match success
+///   - active_state_hist[count]     — `trellis.zig` middleViterbiVals/
+///                                    middleForwardVals
+///
+/// The `_calls` vs `_log_exp_calls` split for `addInLogSpace` matters for
+/// item-3.2 costing: at function entry the call may still hit a cheap
+/// `NEG_INF` short-circuit and do zero transcendental work. The first
+/// counter is the call rate; the second is the rate of work that an
+/// item-3.2 log/exp approximation would actually replace.
 ///
 /// State is process-global and reset at start of each `DPHandler.run()`.
-/// `formatPerfCounters` returns one structured PERFCOUNTER line per query;
-/// caller writes to stdout. Single-threaded by design (issue says
-/// `--n-procs 1`), so no atomics needed.
-
+/// `formatPerfCounters` returns one heap-allocated PERFCOUNTER line per
+/// query; caller writes it to the destination it picks (current dump site
+/// is the file at `PARTIS_ZIG_PERF_LOG`, opened O_APPEND to keep parallel
+/// bcrham processes non-clobbering — see `dp_handler.zig:dumpPerfCounters`).
+///
+/// SAFETY: the counters below are plain `pub var` globals, NOT atomics.
+/// Every caller must run single-threaded within a process. bcrham is
+/// single-threaded by design (#342 item 1 investigated and rejected
+/// `smp_allocator`); cross-process parallelism via `partis --n-procs N`
+/// runs each bcrham in its own address space, so the globals stay
+/// per-process. If a future caller introduces threading inside a single
+/// bcrham process, this module must grow atomic counters or per-thread
+/// shadow state.
 const std = @import("std");
 const build_options = @import("build_options");
 
@@ -29,18 +48,20 @@ pub const enabled: bool = build_options.perf_counters;
 const HIST_LEN: usize = 501;
 
 pub var addInLogSpace_calls: u64 = 0;
+pub var addInLogSpace_log_exp_calls: u64 = 0;
 pub var fillTrellis_calls: u64 = 0;
 pub var n_ksets: u64 = 0;
-pub var chunk_cache_entries: u64 = 0;
+pub var chunk_cache_lookups: u64 = 0;
 pub var chunk_cache_hits: u64 = 0;
 pub var active_state_hist: [HIST_LEN]u64 = [_]u64{0} ** HIST_LEN;
 
 pub fn reset() void {
     if (!enabled) return;
     addInLogSpace_calls = 0;
+    addInLogSpace_log_exp_calls = 0;
     fillTrellis_calls = 0;
     n_ksets = 0;
-    chunk_cache_entries = 0;
+    chunk_cache_lookups = 0;
     chunk_cache_hits = 0;
     // NB: explicit loop instead of `@memset(&active_state_hist, 0)` —
     // Zig 0.15.2 hits an x86_64 codegen bug ("no encoding found for:
@@ -55,6 +76,10 @@ pub inline fn bumpAddInLogSpace() void {
     if (enabled) addInLogSpace_calls += 1;
 }
 
+pub inline fn bumpAddInLogSpaceLogExp() void {
+    if (enabled) addInLogSpace_log_exp_calls += 1;
+}
+
 pub inline fn bumpFillTrellis() void {
     if (enabled) fillTrellis_calls += 1;
 }
@@ -63,8 +88,8 @@ pub inline fn bumpKSet() void {
     if (enabled) n_ksets += 1;
 }
 
-pub inline fn bumpChunkCacheEntry() void {
-    if (enabled) chunk_cache_entries += 1;
+pub inline fn bumpChunkCacheLookup() void {
+    if (enabled) chunk_cache_lookups += 1;
 }
 
 pub inline fn bumpChunkCacheHit() void {
@@ -104,8 +129,12 @@ fn activeStateStats() struct { median: usize, p95: usize, max: usize, total: u64
 /// Returns null when counters are disabled (caller skips the write).
 /// Format is intentionally trivial-to-grep:
 ///   PERFCOUNTER alg=... q=... n_seqs=... ksets=... fillTrellis=... \
-///       chunk_hits=H/E addInLogSpace=... \
-///       active_states_med=... active_states_p95=... active_states_max=... active_states_positions=...
+///       chunk_hits=H/L addInLogSpace=... addInLogSpace_log_exp=... \
+///       active_states_med=... active_states_p95=... active_states_max=... \
+///       active_states_positions=...
+///
+/// `chunk_hits=H/L`: H = prefix-match successes, L = lookup attempts (the
+/// `if (!no_chunk_cache)` branch entries in fillTrellis). Hit rate is H/L.
 pub fn formatPerfCounters(
     allocator: std.mem.Allocator,
     algorithm: []const u8,
@@ -116,7 +145,7 @@ pub fn formatPerfCounters(
     const stats = activeStateStats();
     return try std.fmt.allocPrint(
         allocator,
-        "PERFCOUNTER alg={s} q={s} n_seqs={d} ksets={d} fillTrellis={d} chunk_hits={d}/{d} addInLogSpace={d} active_states_med={d} active_states_p95={d} active_states_max={d} active_states_positions={d}\n",
+        "PERFCOUNTER alg={s} q={s} n_seqs={d} ksets={d} fillTrellis={d} chunk_hits={d}/{d} addInLogSpace={d} addInLogSpace_log_exp={d} active_states_med={d} active_states_p95={d} active_states_max={d} active_states_positions={d}\n",
         .{
             algorithm,
             query_name,
@@ -124,8 +153,9 @@ pub fn formatPerfCounters(
             n_ksets,
             fillTrellis_calls,
             chunk_cache_hits,
-            chunk_cache_entries,
+            chunk_cache_lookups,
             addInLogSpace_calls,
+            addInLogSpace_log_exp_calls,
             stats.median,
             stats.p95,
             stats.max,

--- a/packages/zig-core/src/ham/perf_counters.zig
+++ b/packages/zig-core/src/ham/perf_counters.zig
@@ -1,0 +1,135 @@
+/// ham/perf_counters.zig — Phase-0 diagnostics counters for issue #366.
+///
+/// The whole module is gated on the `-Dperf-counters` build option (see
+/// `build.zig`). When the option is `false` (default), `enabled` is a
+/// comptime `false` and every `if (enabled) { ... }` block in the hot
+/// path compiles to nothing — bit-equality with the un-instrumented build
+/// is preserved.
+///
+/// Counters cover the metrics requested in #366 phase 0.1 / 0.2:
+///
+///   - addInLogSpace_calls       — `mathutils.zig:addInLogSpace`
+///   - fillTrellis_calls         — `dp_handler.zig:fillTrellis` entry
+///   - n_ksets                   — `dp_handler.zig:run` kset loop
+///   - chunk_cache_entries/hits  — `dp_handler.zig:fillTrellis` cache branch
+///   - active_state_hist[count]  — `trellis.zig` middleViterbiVals/middleForwardVals
+///
+/// State is process-global and reset at start of each `DPHandler.run()`.
+/// `formatPerfCounters` returns one structured PERFCOUNTER line per query;
+/// caller writes to stdout. Single-threaded by design (issue says
+/// `--n-procs 1`), so no atomics needed.
+
+const std = @import("std");
+const build_options = @import("build_options");
+
+pub const enabled: bool = build_options.perf_counters;
+
+/// Length of the active-state histogram. State indices in this codebase
+/// are bounded by `state.zig:STATE_MAX = 500`; one extra slot for 500 itself.
+const HIST_LEN: usize = 501;
+
+pub var addInLogSpace_calls: u64 = 0;
+pub var fillTrellis_calls: u64 = 0;
+pub var n_ksets: u64 = 0;
+pub var chunk_cache_entries: u64 = 0;
+pub var chunk_cache_hits: u64 = 0;
+pub var active_state_hist: [HIST_LEN]u64 = [_]u64{0} ** HIST_LEN;
+
+pub fn reset() void {
+    if (!enabled) return;
+    addInLogSpace_calls = 0;
+    fillTrellis_calls = 0;
+    n_ksets = 0;
+    chunk_cache_entries = 0;
+    chunk_cache_hits = 0;
+    // NB: explicit loop instead of `@memset(&active_state_hist, 0)` —
+    // Zig 0.15.2 hits an x86_64 codegen bug ("no encoding found for:
+    // none mov m64 m64 none none") on a Debug @memset over a fixed-size
+    // global u64 array. The loop sidesteps the bug and any optimizer
+    // will turn it back into a memset under ReleaseFast/ReleaseSafe.
+    var i: usize = 0;
+    while (i < HIST_LEN) : (i += 1) active_state_hist[i] = 0;
+}
+
+pub inline fn bumpAddInLogSpace() void {
+    if (enabled) addInLogSpace_calls += 1;
+}
+
+pub inline fn bumpFillTrellis() void {
+    if (enabled) fillTrellis_calls += 1;
+}
+
+pub inline fn bumpKSet() void {
+    if (enabled) n_ksets += 1;
+}
+
+pub inline fn bumpChunkCacheEntry() void {
+    if (enabled) chunk_cache_entries += 1;
+}
+
+pub inline fn bumpChunkCacheHit() void {
+    if (enabled) chunk_cache_hits += 1;
+}
+
+pub inline fn recordActiveStates(n: usize) void {
+    if (!enabled) return;
+    const idx = if (n >= HIST_LEN) HIST_LEN - 1 else n;
+    active_state_hist[idx] += 1;
+}
+
+/// Compute (median, p95, max, total_positions) over the active-state histogram.
+fn activeStateStats() struct { median: usize, p95: usize, max: usize, total: u64 } {
+    var total: u64 = 0;
+    for (active_state_hist) |c| total += c;
+    if (total == 0) return .{ .median = 0, .p95 = 0, .max = 0, .total = 0 };
+    const median_target = (total + 1) / 2;
+    const p95_target = (total * 95 + 99) / 100;
+    var cum: u64 = 0;
+    var median: usize = 0;
+    var p95: usize = 0;
+    var max_idx: usize = 0;
+    var i: usize = 0;
+    while (i < HIST_LEN) : (i += 1) {
+        if (active_state_hist[i] == 0) continue;
+        max_idx = i;
+        const next_cum = cum + active_state_hist[i];
+        if (cum < median_target and median_target <= next_cum) median = i;
+        if (cum < p95_target and p95_target <= next_cum) p95 = i;
+        cum = next_cum;
+    }
+    return .{ .median = median, .p95 = p95, .max = max_idx, .total = total };
+}
+
+/// Format the per-query counter summary as a heap-allocated `[]u8` (caller frees).
+/// Returns null when counters are disabled (caller skips the write).
+/// Format is intentionally trivial-to-grep:
+///   PERFCOUNTER alg=... q=... n_seqs=... ksets=... fillTrellis=... \
+///       chunk_hits=H/E addInLogSpace=... \
+///       active_states_med=... active_states_p95=... active_states_max=... active_states_positions=...
+pub fn formatPerfCounters(
+    allocator: std.mem.Allocator,
+    algorithm: []const u8,
+    query_name: []const u8,
+    n_seqs: usize,
+) !?[]u8 {
+    if (!enabled) return null;
+    const stats = activeStateStats();
+    return try std.fmt.allocPrint(
+        allocator,
+        "PERFCOUNTER alg={s} q={s} n_seqs={d} ksets={d} fillTrellis={d} chunk_hits={d}/{d} addInLogSpace={d} active_states_med={d} active_states_p95={d} active_states_max={d} active_states_positions={d}\n",
+        .{
+            algorithm,
+            query_name,
+            n_seqs,
+            n_ksets,
+            fillTrellis_calls,
+            chunk_cache_hits,
+            chunk_cache_entries,
+            addInLogSpace_calls,
+            stats.median,
+            stats.p95,
+            stats.max,
+            stats.total,
+        },
+    );
+}

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -13,6 +13,7 @@ const Sequences = @import("sequences.zig").Sequences;
 const Sequence = @import("sequences.zig").Sequence;
 const TracebackPath = @import("traceback_path.zig").TracebackPath;
 const mathutils = @import("mathutils.zig");
+const perf_counters = @import("perf_counters.zig");
 
 /// DP trellis for Forward/Viterbi algorithms.
 /// Corresponds to C++ `ham::Trellis`.
@@ -365,6 +366,7 @@ pub const Trellis = struct {
         next_states: *std.ArrayListUnmanaged(usize),
         position: usize,
     ) !void {
+        perf_counters.recordActiveStates(current_states.items.len);
         // See viterbi(): cache borrowed seqs pointer in a local for the inner loop.
         const seqs = self.seqs;
         for (current_states.items) |i_st_cur| {
@@ -399,6 +401,7 @@ pub const Trellis = struct {
         next_states: *std.ArrayListUnmanaged(usize),
         position: usize,
     ) !void {
+        perf_counters.recordActiveStates(current_states.items.len);
         // See viterbi(): cache borrowed seqs pointer in a local for the inner loop.
         const seqs = self.seqs;
         for (current_states.items) |i_st_cur| {


### PR DESCRIPTION
## Summary

Phase 0 of #366. Adds gated diagnostic counters to the Zig backend so every later phase-1+ item in #366 can be costed against measured numbers instead of speculation. **No production-path changes** — counters are guarded by `-Dperf-counters` (default false) and a `comptime const`, so the default build is byte-for-byte identical to `main`.

Reports `rung-2a` (`partis-test.py --no-simu --zig`) and `rung-2b` (`partis-test.py --paired --no-simu --zig`) measurements below.

Addresses Phase 0 of #366 only; the meta-issue stays open for Phase 1+.

## What was added

- **`build.zig`** — new `-Dperf-counters` option, propagated as a `build_options` module to all relevant Zig modules.
- **`src/ham/perf_counters.zig`** (new) — comptime-gated global counters, plus `formatPerfCounters` and an active-state histogram with median / p95 / max.
- **`src/ham/mathutils.zig`** — bump `addInLogSpace_calls` at function entry; bump `addInLogSpace_log_exp_calls` past both `NEG_INF` early-outs (each = 1 log + 1 exp of work).
- **`src/ham/trellis.zig`** — record `current_states.items.len` per `middleViterbiVals` / `middleForwardVals` invocation.
- **`src/ham/dp_handler.zig`** — bump `fillTrellis_calls` and `chunk_cache_lookups` / `chunk_cache_hits`; bump `n_ksets` per kset; reset counters at start of `run()`; concatenate the two output lines and emit one atomic `O_APPEND` writeAll per query.

When enabled, output is appended to the path in env var `PARTIS_ZIG_PERF_LOG`. Side-channel rather than stdout because partis discards bcrham stdout it does not recognise (`utils.py:5896+`).

The `addInLogSpace_calls` vs `addInLogSpace_log_exp_calls` split matters for downstream costing: the call counter is the rate of entries to the function; the work counter is the rate of actual `log` + `exp` invocations (each non-early-out call does exactly one of each). Item 3.2's predicted wall-share should be priced against the work counter, not the call counter.

## How to use

```bash
cd packages/zig-core && zig build -Doptimize=ReleaseFast -Dperf-counters=true
PARTIS_ZIG_PERF_LOG=/tmp/perf.log partis-test.py --paired --no-simu --zig
# /tmp/perf.log: one PERFCOUNTER + one PERFCOUNTER_CACHE per query
# (concatenated and emitted as one atomic O_APPEND write).
```

Default build (no flag) compiles the counter sites out, preserving bit-equal output.

## Findings

### Rung-2a unpaired (`partis-test.py --no-simu --zig`, 245 queries)

| metric | viterbi (231q) | forward (14q) |
|---|---|---|
| n_seqs / query | med 1, p95 3, max 11 | med 2, p95 10, max 11 |
| n_ksets / query | med 10, p95 54, max 272 | med 11, p95 22, max 22 |
| fillTrellis / query | med 23, p95 265, max 1450 | med 27, p95 67, max 67 |
| addInLogSpace **calls** / query | med 44, p95 520, max 2,448 | med 218,260, p95 570,786, max 570,786 |
| addInLogSpace **log+exp work** / query | med 10, p95 329, max 1,631 | **med 48,435, p95 175,679, max 175,679** |
| log+exp work fraction (work / calls) | 56.8% | **24.8%** |
| chunk-cache hit rate | **73.7%** (10,957 / 14,869) | **57.5%** (268 / 466) |
| active states / position | med-of-medians 53, med-of-p95s 263, max 300 | med-of-medians 53, med-of-p95s 258, max 300 |
| work concentration (top 5% / 25%) | 59.4% / 86.8% | 18.6% / 55.9% |

cumulative work across run: viterbi 14 K log+exp calls, forward **942 K log+exp calls**.

### Rung-2b paired (`partis-test.py --paired --no-simu --zig`, 1444 queries)

| metric | viterbi (1090q) | forward (354q) |
|---|---|---|
| n_seqs / query | med 1, p95 3, max 13 | med 2, p95 10, max 16 |
| n_ksets / query | med 5, p95 69, max 252 | **med 18, p95 186, max 261** |
| fillTrellis / query | med 21, p95 239, max 2,313 | med 88, p95 1,388, max 3,069 |
| addInLogSpace **calls** / query | med 30, p95 448, max 3,024 | med 380,575, p95 1,280,137, max 1,756,155 |
| addInLogSpace **log+exp work** / query | med 10, p95 224, max 2,266 | **med 113,073, p95 626,231, max 923,249** |
| log+exp work fraction (work / calls) | 57.1% | **35.0%** |
| chunk-cache hit rate | **78.3%** (74,613 / 95,275) | **86.1%** (72,482 / 84,224) |
| active states / position | med-of-medians 51, med-of-p95s 262, max 305 | med-of-medians 49, med-of-p95s 220, max 302 |
| work concentration (top 5% / 25%) | **59.2% / 85.3%** | 20.7% / 60.7% |

cumulative work across run: viterbi 79 K log+exp calls, forward **64.5 M log+exp calls**.

The viterbi medians on rung-2b are essentially the no-op-query population — top 5% of queries (55 of 1090) account for **59% of all log+exp work**, top 25% for **85%**. Quoting any per-query viterbi statistic without that caveat is misleading.

## What this does to the Phase-1+ cost menu

Phase-0 is a *measurement* deliverable, but several items are explicitly costed against the speculation it replaces. Each bullet below states what the measured numbers do to that costing — qualified for the small-workload caveat at the end.

- **Item 3.2 (vectorisable log/exp).** The hot site is `addInLogSpace`. On rung-2b paired forward — the heaviest workload measured — per-query log+exp work is median 1.13 × 10⁵, p95 6.3 × 10⁵, max 9.2 × 10⁵; cumulative 6.5 × 10⁷ across the whole run. **The work rate at this scale lives at the lower end of the issue's 10⁶–10⁷ speculation range.** Whether it stays there at #342's 30 k / 50 k workloads — where partition reaches deeper into hierarchical merging — is **not pinned by this PR**: rung-2b's 354 forward queries are a small sample (max ≈ 5× median), and the per-query distribution at larger scale is plausibly shifted toward larger queries by hierarchical merging. The work counter eliminates the call-vs-work overcount but does not extrapolate. Treat 3.2's predicted wall-share as "lower-end-bounded by these data, scale-up factor still open."

- **Item 3.3 (beam pruning).** Active states / position has median ~50 and p95 ~260 against `STATE_MAX = 500`. The fat tail (p95 ≫ median) means a conservative beam at `X = 30 nat` could shave the tail aggressively while leaving the median untouched. The issue's speculative 1.5–3× inner-loop ceiling is plausible given the long tail; landing it would chop the active-state distribution at the right end.

- **Item 2.1 (kset-grid arrays).** `n_ksets` median is 5–18, but the p95 / max in viterbi is 69 / 252 and in forward is 186 / 261. Cost is dominated by the tail (the `findPartialCacheMatch` scan is O(n_ksets²) per gene-region-kset). At p95 = 186 (forward), that's ~10 M iterator steps per query × 100 genes — a real cost on the worst-case end, smaller than the issue's 12 M / query speculation but the same order of magnitude.

- **Item 2.4 (kset threading).** Forward median `n_ksets = 18` is comparable to a typical core count, but viterbi median is 5. **At rung-2 medians, threading inside bcrham buys little**; only the long tail (p95–max range) has enough kset parallelism to feed a thread pool. Caveat: rung-2 partitioning is shallow; deeper hierarchical merging at #342-scale workloads is expected to skew `n_ksets` higher and could move the median. **Re-pin `n_ksets` distribution at rung-3+ before scheduling 2.4.**

- **Cache structural assumption (issue's "<30% suspect" gate).** Hit rate is **74–86%** across both workloads. Well above the threshold; the chunk cache is doing real work and #342's structural assumptions hold.

- **Item 3.0 (cacheForwardVals hoist).** Forward log+exp work per query is sufficient (~10⁵ median, 6 × 10⁵ p95) that hoisting `cacheForwardVals` out of the inner `i_st_prev` loop — collapsing call count by `~avg_from_states` — is mechanically attractive. With average from-state count likely 3–5 (HMM topology), this is the highest-confidence Phase-3 win on the data measured here.

### Things this PR does NOT pin

- **`bcrham fraction of total partis wall`.** The issue lists this as a phase-0 deliverable so percentage claims for Phase-3 items have a denominator. Extracting it cleanly requires per-process bcrham-only timing — `partis-test.py` reports per-action wall (which includes setup + bcrham + teardown). The two rung-2 workloads ran in 7.7 s (unpaired) and 51 s (paired) wall with 590–600% CPU — too small to give a stable bcrham-vs-partis split. This number stays open; for the larger benchmarks tracked in #342 (30 k paired, 50 k collision) the bcrham-dominant assumption was already validated empirically by the wall improvements landing in the bcrham layer. If Phase-1+ items want a precise denominator, a follow-up should add per-process timing instrumentation in partis itself rather than re-running rung 2 ad infinitum.
- **rung-3+ scaling.** Several claims above explicitly note "small-workload caveat." Re-pinning at rung-3 (5 k paired) or rung-5 (30 k paired) would either confirm rung-2 medians as representative or expose them as small-scale artefacts driven by the single-seq-cluster query mix. The infrastructure to do that is exactly what this PR ships; only the workload run is missing.

## Open question (still load-bearing)

The issue's bottom-of-doc question — *"Is the historical Zig-vs-C++ baseline still pinned anywhere we can re-validate against, or do we re-pin from current main each round?"* — is **unchanged by this PR**. Phase-0 work is `[zig-only]` and bit-equal-by-construction, so it does not need the answer. **Any `[cpp-mirror]` or `[semantic]` follow-up still must answer this question first.**

## Test plan

- [x] `zig build` (default: counters off, ReleaseFast)
- [x] `zig build test` (default + `-Dperf-counters=true`)
- [x] `partis-test.py --quick --zig` with default build → `ok`
- [x] `partis-test.py --quick --zig` with `-Dperf-counters=true` build → `ok`
- [x] `partis-test.py --no-simu --zig` (rung-2a) with `-Dperf-counters=true` → `ok` + 245 PERFCOUNTER lines collected
- [x] `partis-test.py --paired --no-simu --zig` (rung-2b) with `-Dperf-counters=true` → `ok` + 1,444 PERFCOUNTER lines collected
- [x] reviewer-flagged counter overcount addressed: split into `addInLogSpace_calls` (entries) and `addInLogSpace_log_exp_calls` (work past `NEG_INF` early-outs); both are emitted; numbers above are corrected.

Counter output and parity hold on every rung exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)