### PR TITLE
zig: sparse memset of scoring_current (#366 item 1.1)

### DIFF
--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -65,6 +65,18 @@ pub const Trellis = struct {
     scoring_current: []f64,
     scoring_previous: []f64,
 
+    /// Indices into scoring_current that may hold non-NEG_INF values
+    /// (a SUPERSET of truly-dirty slots — see `swapColumnsActive`). Mirrors
+    /// the swap of scoring_current ↔ scoring_previous so the sparse clear
+    /// in `swapColumnsActive` only touches slots that were active two
+    /// iterations ago, instead of the full n_states column. Item 1.1 of
+    /// #366: at rung-2 medians (~50 active states / 500 n_states) this
+    /// drops the per-position memset from O(n_states) to O(active).
+    scoring_current_dirty: std.ArrayListUnmanaged(usize),
+    /// Indices into scoring_previous that may hold non-NEG_INF values.
+    /// See `scoring_current_dirty`.
+    scoring_previous_dirty: std.ArrayListUnmanaged(usize),
+
     /// Scratch bitset for deduplicating next_states additions.
     next_seen: state_mod.StateBitset,
 
@@ -118,6 +130,8 @@ pub const Trellis = struct {
             .viterbi_indices = .{},
             .scoring_current = scoring_current,
             .scoring_previous = scoring_previous,
+            .scoring_current_dirty = .{},
+            .scoring_previous_dirty = .{},
             .next_seen = state_mod.StateBitset.initEmpty(),
             .allocator = allocator,
         };
@@ -132,6 +146,8 @@ pub const Trellis = struct {
         self.viterbi_indices.deinit(allocator);
         allocator.free(self.scoring_current);
         allocator.free(self.scoring_previous);
+        self.scoring_current_dirty.deinit(allocator);
+        self.scoring_previous_dirty.deinit(allocator);
     }
 
     /// Run the Viterbi algorithm.
@@ -174,9 +190,13 @@ pub const Trellis = struct {
         @memset(self.traceback_table, -1);
         self.traceback_n_states = n_states;
 
-        // Reset scoring columns
+        // Reset scoring columns. Dirty lists pair with the buffers and start
+        // empty: the full memset establishes the all-NEG_INF invariant that
+        // the sparse clear in `swapColumnsActive` relies on.
         @memset(self.scoring_current, mathutils.NEG_INF);
         @memset(self.scoring_previous, mathutils.NEG_INF);
+        self.scoring_current_dirty.clearRetainingCapacity();
+        self.scoring_previous_dirty.clearRetainingCapacity();
 
         var current_states = std.ArrayListUnmanaged(usize){};
         defer current_states.deinit(allocator);
@@ -192,6 +212,7 @@ pub const Trellis = struct {
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
+            try self.scoring_current_dirty.append(allocator, i_st);
             self.cacheViterbiVals(0, dpval, i_st);
             // Mark outbound transitions for next position (deduplicated)
             for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
@@ -242,9 +263,11 @@ pub const Trellis = struct {
         try self.forward_log_probs.resize(allocator, seq_len);
         @memset(self.forward_log_probs.items, mathutils.NEG_INF);
 
-        // Reset scoring columns
+        // Reset scoring columns. See `viterbi()` for the dirty-list invariant.
         @memset(self.scoring_current, mathutils.NEG_INF);
         @memset(self.scoring_previous, mathutils.NEG_INF);
+        self.scoring_current_dirty.clearRetainingCapacity();
+        self.scoring_previous_dirty.clearRetainingCapacity();
 
         var current_states = std.ArrayListUnmanaged(usize){};
         defer current_states.deinit(allocator);
@@ -260,6 +283,7 @@ pub const Trellis = struct {
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
+            try self.scoring_current_dirty.append(allocator, i_st);
             // Mark outbound transitions for next position (deduplicated)
             for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
                 if (!self.next_seen.isSet(j)) {
@@ -330,11 +354,23 @@ pub const Trellis = struct {
         current_states: *std.ArrayListUnmanaged(usize),
         next_states: *std.ArrayListUnmanaged(usize),
     ) !void {
-        // Swap scoring_current ↔ scoring_previous
-        const tmp = self.scoring_previous;
-        self.scoring_previous = self.scoring_current;
-        self.scoring_current = tmp;
-        @memset(self.scoring_current, mathutils.NEG_INF);
+        // Swap scoring_current ↔ scoring_previous, and the parallel dirty
+        // lists. After the swap, `scoring_current` is the buffer that was
+        // last written *two* iterations ago (or position-0 init); only the
+        // slots in `scoring_current_dirty` (the freshly-swapped-in list) can
+        // be non-NEG_INF, so a sparse clear over those slots restores the
+        // all-NEG_INF invariant. Item 1.1 of #366.
+        std.mem.swap([]f64, &self.scoring_current, &self.scoring_previous);
+        std.mem.swap(
+            std.ArrayListUnmanaged(usize),
+            &self.scoring_current_dirty,
+            &self.scoring_previous_dirty,
+        );
+
+        for (self.scoring_current_dirty.items) |idx| {
+            self.scoring_current[idx] = mathutils.NEG_INF;
+        }
+        self.scoring_current_dirty.clearRetainingCapacity();
 
         // Clear next_seen for all indices that were in next_states
         // (they will become current_states; next_seen tracks what's queued for the NEW next)
@@ -373,6 +409,12 @@ pub const Trellis = struct {
             const st_cur = self.hmm.stateByIndex(i_st_cur);
             const emission_val = st_cur.emissionLogprobSeqs(seqs, position);
             if (std.math.isNegativeInf(emission_val)) continue;
+            // Track for the sparse clear in `swapColumnsActive`. This is a
+            // SUPERSET of slots we actually write: if every i_st_prev has
+            // NEG_INF prev_val, no write happens but i_st_cur is still in the
+            // dirty list. Clearing an already-NEG_INF slot is a no-op, so the
+            // superset is bit-equal.
+            try self.scoring_current_dirty.append(allocator, i_st_cur);
             for (st_cur.from_state_indices.items) |i_st_prev| {
                 const prev_val = self.scoring_previous[i_st_prev];
                 if (std.math.isNegativeInf(prev_val)) continue;
@@ -408,6 +450,8 @@ pub const Trellis = struct {
             const st_cur = self.hmm.stateByIndex(i_st_cur);
             const emission_val = st_cur.emissionLogprobSeqs(seqs, position);
             if (std.math.isNegativeInf(emission_val)) continue;
+            // See `middleViterbiVals` for the dirty-list invariant.
+            try self.scoring_current_dirty.append(allocator, i_st_cur);
             for (st_cur.from_state_indices.items) |i_st_prev| {
                 const prev_val = self.scoring_previous[i_st_prev];
                 if (std.math.isNegativeInf(prev_val)) continue;


### PR DESCRIPTION
## Summary

Item 1.1 of #366 (Phase 1, [zig-only]). Targets the topic branch `366-zig-perf-next` (sub-PR cadence; mirrors the #342 / `342-zig-perf-cleanup` model).

Replace the full `@memset(scoring_current, NEG_INF)` in `Trellis.swapColumnsActive` (over `n_states = 500` slots) with a sparse clear over only the slots that were active two iterations ago. Track those slots via two new dirty index lists (`scoring_current_dirty` / `scoring_previous_dirty`) that swap alongside the scoring buffers.

The dirty list is a **superset** of truly-non-NEG_INF slots — appended once per `i_st_cur` after the emission-NEG_INF skip in `middleViterbiVals` / `middleForwardVals`, and once per finite-`dpval` entry in the position-0 init loops. If every `i_st_prev` ends up with `prev_val = NEG_INF`, the slot stays NEG_INF and clearing it later is a no-op. So the result is bit-equal to the prior full memset.

## Why this first

- Smallest possible Phase-1 item.
- Validates the topic-branch sub-PR cadence on something where the wall delta is directly justified by Phase 0's pinned active-state distribution: median ~50/500, p95 ~260/500. Save = full-column minus active-set, concentrated on median-case columns.
- Composes cleanly with later Phase-1+ items (no structural changes elsewhere).

## Audit

The sparse clear relies on the all-NEG_INF invariant for slots **not** in the active list. Confirmed:

1. **Position-0 init.** `viterbi()` and `forward()` both `@memset(scoring_current/previous, NEG_INF)` before the loop starts (`trellis.zig:178-179` / `246-247`). Establishes the invariant.
2. **Chunk-cache temp trellis path.** `dp_handler.zig:702` calls `Trellis.initWithSeqs`, which full-memsets both buffers; then `forward()` / `viterbi()` redo the full memset. Same invariant.
3. **Cached-trellis short-circuit.** `viterbi()` / `forward()` early-return at `trellis.zig:149-154` / `236-239` before any DP. `swapColumnsActive` never runs in this path.
4. **All writes to `scoring_current`** are at indices in `init_st.to_state_indices` (position 0) or `current_states.items` (positions 1+). Verified by grep across the package.

Both `viterbi()` and `forward()` reset the dirty lists with `clearRetainingCapacity()` after the buffer @memsets, so the lists carry no stale state between algorithm runs on a re-used trellis.

## Expected wall

Issue estimates 1–2 % on Forward at ~10 % active-state ratio. Phase 0 pinned median ~10 % (50/500), p95 ~52 % (260/500) — saving is concentrated on the median-case columns, not the tail. Realistic ceiling 1–3 % wall on rung-3+ Forward-heavy workloads. **Methodology** (per issue, deferred to post-1.1 batch): median wall of 3 rung-3 runs, counters off, against `origin/366-zig-perf-next`.

## Test plan

- [x] `zig build test` (default) — passes
- [x] `zig build test -Dperf-counters=true` — passes
- [x] `partis-test.py --quick --zig` — `ok`
- [x] `partis-test.py --no-simu --zig` — logprob diff 0/14, naive_seqs diff 0/37 (bit-equal)
- [x] `partis-test.py --paired --no-simu --zig` — `ok` on production diff
- [ ] (deferred to post-1.1 batch) median-of-3 rung-3 wall comparison

Pre-existing baseline drifts noted in `CLAUDE.md` (file-count diffs in `test/parameters/simu`) reproduced both with and without this change.

Refs #366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)