### PR TITLE
partis: add bcrham wall-fraction timer

### DIFF
--- a/bin/partis
+++ b/bin/partis
@@ -1849,4 +1849,10 @@ random.seed(args.random_seed)
 numpy.random.seed(args.random_seed)
 start = time.time()
 args.func(args)
-print('      total time: %.1f' % (time.time()-start))
+total_time = time.time() - start
+print('      total time: %.1f' % total_time)
+from partis import partitiondriver
+bcrham_t, bcrham_n = partitiondriver.get_bcrham_summary()
+if bcrham_n > 0:
+    pct = 100.0 * bcrham_t / total_time if total_time > 0 else 0.0
+    print('      bcrham time: %.1f (%.1f%% of total, %d calls)' % (bcrham_t, pct, bcrham_n))

--- a/partis/partitiondriver.py
+++ b/partis/partitiondriver.py
@@ -37,6 +37,17 @@ from .hist import Hist
 from . import seqfileopener
 
 # ----------------------------------------------------------------------------------------
+# Process-global accumulator for bcrham subprocess wall time, used to print a
+# "bcrham time: X (Y% of total)" summary alongside the final "total time:" line
+# in bin/partis. Phase 0 of issue #366 deferred pinning the bcrham fraction
+# pending partis-level timing instrumentation; this is that instrumentation.
+_cumul_bcrham_time = 0.0
+_cumul_bcrham_calls = 0
+
+def get_bcrham_summary():
+    return _cumul_bcrham_time, _cumul_bcrham_calls
+
+# ----------------------------------------------------------------------------------------
 class PartitionDriver(object):
     """ Class to parse input files, start bcrham jobs, and parse/interpret bcrham output for annotation and partitioning """
     def __init__(self, args, glfo, input_info, simglfo, reco_info):
@@ -1390,7 +1401,11 @@ class PartitionDriver(object):
                    'outfname' : get_outfname(iproc),
                    'dbgfo' : self.bcrham_proc_info[iproc]}
                   for iproc in range(n_procs)]
+        run_start = time.time()
         utils.run_cmds(cmdfos, batch_system=self.args.batch_system, batch_options=self.args.batch_options, batch_config_fname=self.args.batch_config_fname, debug='print' if self.args.debug else None)
+        global _cumul_bcrham_time, _cumul_bcrham_calls
+        _cumul_bcrham_time += time.time() - run_start
+        _cumul_bcrham_calls += 1
         self.print_partition_dbgfo()
 
         self.check_wait_times(time.time()-start)


### PR DESCRIPTION
## Summary

Adds a `bcrham time: X.X (YY.Y% of total, N calls)` line alongside the existing `total time:` line at end of every `partis` invocation, giving cumulative bcrham subprocess wall and its fraction of partis wall.

## Why

Phase 0 of #366 explicitly [deferred](https://github.com/psathyrella/partis/issues/366) pinning the bcrham fraction pending partis-level timing instrumentation: *"7.7 s / 51 s wall is too small to extract a stable bcrham-vs-partis split. Belongs in a partis-level timing instrumentation follow-up."* This is that instrumentation.

The fraction is the load-bearing denominator for sizing any Zig-only or bcrham-internal optimization against partis wall. Without it, "predicted +X% bcrham" cannot be projected onto observed partis wall at any scale.

Concrete motivating use: re-costing #369 (item 1.1 sparse memset) and #370 (item 2.1 dense kset grids) at the bcrham layer revealed a 6–8% bcrham-wall regression at 5k paired partition, opposite the predicted 1–3% improvement from #369. The signal is invisible at the partis-wall layer (~6% partis-wall delta lives within within-group noise) but clear at the bcrham layer (where within-group range is 3–6% but between-group delta is 7–8%, with the dominant subprocess running 93% bcrham).

## Implementation

- Process-global accumulator in `partis/partitiondriver.py`: `_cumul_bcrham_time` and `_cumul_bcrham_calls`, incremented around the `utils.run_cmds(...)` call in `PartitionDriver.execute()`. Exposed via `get_bcrham_summary()`.
- New print in `bin/partis` after the existing total-time print, suppressed when no bcrham subprocesses ran (e.g. paired-loci parent process whose work is orchestration).
- For paired-loci runs, each single-chain subprocess prints its own total/bcrham line on its own stdout; cross-process aggregation in the parent is intentionally out of scope (~~5 lines for `len`-able sum~~, but adds shell-scraping fragility for marginal benefit).

## Output sample

500-seq paired partition with C++ bcrham (default backend):

```
      total time: 12.2
      bcrham time: 11.8 (96.3% of total, 9 calls)
      ...
      total time: 35.3   <- parent, no bcrham line (correctly suppressed)
```

Same workload, `--zig` backend:

```
      total time: 0.3
      bcrham time: 0.1 (39.8% of total, 1 calls)
```

## Test plan

- [x] Byte-identical output vs baseline on 500-seq paired partition (`zig-compare.py`)
- [x] Tested with both C++ bcrham (default) and Zig backend (`--zig`)
- [x] Parent-process suppression (no bcrham line when `bcrham_n == 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)