### PR TITLE
zig: fast_softplus LUT, partis wall -23.7% / -15.3% Zig/C++ (#366 item 3.2)

### DIFF
--- a/packages/zig-core/build.zig
+++ b/packages/zig-core/build.zig
@@ -35,6 +35,11 @@ pub fn build(b: *std.Build) void {
     // to actual glibc (dynamic 'U' symbols) rather than Zig's compiler-rt
     // (local 't' symbols that may differ from glibc on some CPUs).
     exe.addCSourceFile(.{ .file = b.path("src/ham/glibc_math.c"), .flags = &.{ "-O2", "-fno-builtin" } });
+    // fast_math.c — fast_softplus LUT (issue #366 item 3.2). Mirrors
+    // packages/ham/src/fast_math.c on the C++ side; both must stay in sync.
+    // -ffp-contract=off keeps the linear-interp arithmetic bit-deterministic
+    // across compilers (cheap insurance for cross-backend bit equality).
+    exe.addCSourceFile(.{ .file = b.path("src/ham/fast_math.c"), .flags = &.{ "-O3", "-ffp-contract=off", "-fno-builtin" } });
     b.installArtifact(exe);
 
     // ── compare: equivalence harness binary ──────────────────────────────
@@ -120,6 +125,7 @@ pub fn build(b: *std.Build) void {
     ham_test_mod.linkSystemLibrary("c", .{});
     const unit_tests = b.addTest(.{ .root_module = ham_test_mod });
     unit_tests.addCSourceFile(.{ .file = b.path("src/ham/glibc_math.c"), .flags = &.{ "-O2", "-fno-builtin" } });
+    unit_tests.addCSourceFile(.{ .file = b.path("src/ham/fast_math.c"), .flags = &.{ "-O3", "-ffp-contract=off", "-fno-builtin" } });
     const run_unit_tests = b.addRunArtifact(unit_tests);
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_unit_tests.step);

--- a/packages/zig-core/src/ham/fast_math.c
+++ b/packages/zig-core/src/ham/fast_math.c
@@ -1,0 +1,80 @@
+/* fast_math.c — fast log-sum-exp via tabulated softplus.
+ *
+ * Drop-in replacement for the `log(1 + exp(d))` work in AddInLogSpace
+ * (mathutils.h:98). Replaces 1 log + 1 exp glibc call (~5–17 ns combined,
+ * arch-dependent) with a single 65 K-entry linear-interpolation lookup
+ * (~3.5–10 ns per call).
+ *
+ * Pre-flight measurements at issue #366 item 3.2:
+ *   - Zen 5 (glibc 2.39): glibc 9.6 ns → LUT64K 7.3 ns per addInLogSpace
+ *   - Broadwell:          glibc 16.7 ns → LUT64K 10.0 ns
+ *   - LUT64K accuracy: max abs error 6.5e-9 over [-30, 0] (5 orders under
+ *     the partis-test 1e-5 gate).
+ *
+ * Why a 65 K linear-interp table:
+ *   The Cephes scalar polynomial alternative (~7-15 ns) loses to modern
+ *   glibc's FMA-optimized scalar log/exp on every CPU we tested. LUT
+ *   wins because it replaces ~10 ALU ops + branches with a single load
+ *   + 1 multiply + 1 fma. Smaller LUTs (256, 4 K, 16 K) fail the worst-
+ *   case error budget; LUT64K passes by 4×. Cubic interp at 1 K entries
+ *   would also pass speed-wise but not accuracy-wise.
+ *
+ * The linear-interp arithmetic dominates over the table size in cycle
+ * count (LUT256 ≈ LUT64K on every benchmarked CPU), so going larger is
+ * effectively free as long as the hot region stays cache-resident — and
+ * it does, because real DP traffic concentrates near d = 0.
+ *
+ * Built with -O3 -ffp-contract=off so that the linear-interp arithmetic
+ * is bit-deterministic across g++/clang/zig from the same C source.
+ * (Without that flag, cross-compiler drift would be 1–2 ULP — far under
+ * the partis-test gate, but bit-equality between backends is cheap to
+ * keep so we keep it.)
+ *
+ * Mirrored on the Zig side at packages/zig-core/src/ham/fast_math.c.
+ * Both sides MUST stay in sync; the table is data so cross-backend
+ * parity is trivial as long as the same source compiles to both.
+ */
+#include <math.h>
+
+/* Range of d for which the table covers softplus(d) = log(1 + exp(d))
+ * directly. Outside this range, we use the closed-form fall-throughs:
+ *   d < LUT_LO:  exp(d) is well under double precision, softplus ≈ 0.
+ *   d > 0:       use the symmetry softplus(d) = d + softplus(-d).
+ *
+ * Within addInLogSpace's standard form (see mathutils.h AddInLogSpace),
+ * the argument is always (smaller - larger) ≤ 0. The d > 0 branch is
+ * defensive — should not be exercised in practice, but keeps the
+ * function safe to call independently.
+ */
+#define LUT_N  65536
+#define LUT_LO -30.0
+#define LUT_HI 0.0
+
+static double softplus_lut[LUT_N + 1];
+
+/* (LUT_N / |LUT_LO|) precomputed for the index calculation. Using a
+ * macro keeps it a compile-time constant, which the compiler can fold
+ * into the multiply at the call site. */
+#define LUT_SCALE ((double) LUT_N / -(LUT_LO))
+
+__attribute__((constructor))
+static void init_softplus_lut(void) {
+    /* log1p(exp(d)) is the numerically stable form of log(1 + exp(d))
+     * for the table-build phase. Build is one-shot at process start. */
+    for (int i = 0; i <= LUT_N; ++i) {
+        double d = LUT_LO + (LUT_HI - LUT_LO) * (double) i / (double) LUT_N;
+        softplus_lut[i] = log1p(exp(d));
+    }
+}
+
+double fast_softplus(double d) {
+    if (d < LUT_LO) return 0.0;
+    if (d > 0.0)    return d + fast_softplus(-d);   /* symmetry */
+    /* d ∈ [LUT_LO, 0] — index in [0, LUT_N] */
+    double t = (d - LUT_LO) * LUT_SCALE;
+    int i = (int) t;
+    double frac = t - (double) i;
+    double y0 = softplus_lut[i];
+    double y1 = softplus_lut[i + 1];
+    return y0 + frac * (y1 - y0);
+}

--- a/packages/zig-core/src/ham/mathutils.zig
+++ b/packages/zig-core/src/ham/mathutils.zig
@@ -24,6 +24,15 @@ extern fn glibc_exp(x: f64) f64;
 pub const log = glibc_log;
 pub const exp = glibc_exp;
 
+// fast_softplus(d) = log(1 + exp(d)), via 64K-entry linear-interp LUT.
+// Implemented in fast_math.c; mirrored on the C++ side at
+// packages/ham/src/fast_math.c. Replaces 1 log + 1 exp glibc call inside
+// addInLogSpace with a single load + 1 mul + 1 fma — ~22-40% speedup
+// per addInLogSpace call across Zen 3-5 and Intel Broadwell. Accuracy
+// 6.5e-9 max abs over [-30, 0] (5 orders under partis-test 1e-5 gate).
+// See fast_math.c for the design notes (issue #366 item 3.2).
+extern fn fast_softplus(d: f64) f64;
+
 /// Negative infinity constant for log-probability computations.
 /// Replaces the verbose `-std.math.inf(f64)` throughout the codebase.
 pub const NEG_INF: f64 = -math.inf(f64);
@@ -68,14 +77,15 @@ pub fn addInLogSpace(first: f64, second: f64) f64 {
     perf_counters.bumpAddInLogSpace();
     if (first == NEG_INF) return second;
     if (second == NEG_INF) return first;
-    // Past both early-outs: this call does exactly 1 log + 1 exp. Bump
-    // the work counter separately so item-3.2 cost predictions can be
-    // priced against actual transcendental work, not call rate.
+    // Past both early-outs: one call to fast_softplus (LUT lookup, no glibc
+    // log/exp). The counter name kept its original log+exp suffix because
+    // the call site is still the place where item-3.2's transcendental work
+    // used to live — re-naming would invalidate prior #368 measurements.
     perf_counters.bumpAddInLogSpaceLogExp();
     if (first > second) {
-        return first + log(1.0 + exp(second - first));
+        return first + fast_softplus(second - first);
     } else {
-        return second + log(1.0 + exp(first - second));
+        return second + fast_softplus(first - second);
     }
 }
 


### PR DESCRIPTION
## Summary

Mirrors [ham#19](https://github.com/psathyrella/ham/pull/19) on the Zig side and bumps the \`packages/ham\` submodule pointer to pick it up. Both backends switch \`addInLogSpace\` from \`log(1 + exp(d))\` to a shared 64 K-entry linear-interpolation LUT of softplus.

For [psathyrella/partis#366](https://github.com/psathyrella/partis/issues/366) item 3.2.

## Wall measurement (5k paired, median-of-3, AMD Zen 5)

|  | Zig | C++ |
|---|---|---|
| wall before | 291.4 s | 397.0 s |
| wall after | 222.5 s | 336.4 s |
| **partis wall savings** | **23.7%** | **15.3%** |
| **bcrham wall savings** | **33.8%** | **20.1%** |

C++ matches the original 15-20% partis wall projection from PERF-NEXT.md item 3.2. Zig substantially exceeds it because the dlopen wrappers \`glibc_log\` / \`glibc_exp\` (~3% of bcrham cycles per the [handoff perf-record](https://github.com/psathyrella/partis/issues/366#issuecomment-4391395768)) also disappear with \`fast_softplus\`.

## Why LUT, not Cephes polynomial

A pre-flight cross-arch microbench (Zen 3 / Zen 4 / Zen 5 / Intel Broadwell, all glibc 2.39) showed:

- **Cephes scalar polynomial loses to glibc 2.39 on every architecture** by 14-50%. Modern glibc 2.29+ ships FMA-optimized scalar log/exp; scalar Horner can't beat them on FMA-capable CPUs.
- **LUT linear-interp wins on every architecture** by 22-41% per addInLogSpace call. Linear-interp ALU pipeline (1 mul + 1 fma) dominates over the table lookup, so larger tables are essentially free up to L2 size.
- LUT64K (the chosen size) has 6.5e-9 max abs softplus error over [-30, 0] — five orders of magnitude under the partis-test 1e-5 gate.

This [supersedes the polynomial design](https://github.com/psathyrella/partis/issues/366#issuecomment-4392812563) selected in the prior handoff comment. Full data tables and the microbench source are in [psathyrella/partis#366](https://github.com/psathyrella/partis/issues/366).

## Output bit-equality

LUT64K's accuracy is also below the precision at which partis output values get serialized to YAML, so **no ref-results regeneration is needed**. Verified at three scales:

- partis-test (full, non-paired): 0 / 14 logprobs differ, 0 / 40 naive seqs differ
- 100-query paired partition: bit-identical naive_seq / V/D/J calls / deletions / insertions
- 5k paired partition (3797 + 3802 events): bit-identical between {old C++ baseline, new C++, new Zig}

## What changed

- \`packages/ham\` submodule pointer bumped to ham#19 branch tip (\`fcb3755\`). To be re-pinned to the merge commit after ham#19 lands.
- \`packages/zig-core/src/ham/fast_math.c\` — verbatim copy of \`packages/ham/src/fast_math.c\` (shared C source kept in sync across the two binaries).
- \`packages/zig-core/src/ham/mathutils.zig\` — \`addInLogSpace\` calls \`fast_softplus(b - a)\` instead of \`log(1 + exp(b - a))\`. The \`bumpAddInLogSpaceLogExp\` perf counter keeps its name (not its semantics) so #368 measurements remain comparable.
- \`packages/zig-core/build.zig\` — \`addCSourceFile\` for \`fast_math.c\` in both the main exe and the unit-test runner. Built with \`-O3 -ffp-contract=off -fno-builtin\` for cross-compiler bit-determinism.

## Sequencing

1. Land [ham#19](https://github.com/psathyrella/ham/pull/19) first.
2. Update this PR's \`packages/ham\` submodule pointer to the ham merge commit.
3. Land this PR on \`366-zig-perf-next\`.
4. Re-pin \`/tmp/zig-{500,5k,30k,50kcoll}-baseline\` per the [#366 re-pin procedure](https://github.com/psathyrella/partis/issues/366#issuecomment-4391141047).

## Test plan

- [x] Zig builds (\`bin/zig-build.sh\`)
- [x] C++ builds (\`scons bcrham\` in submodule)
- [x] Symbol \`fast_softplus\` linked into both binaries (\`nm\` confirmed)
- [x] partis-test (full): no partis-output drift
- [x] partis-test --paired: passes (env-side R failure on simulate is pre-existing)
- [x] Cross-backend parity: 5k paired byte-equal
- [x] Wall measurement: median-of-3, both backends
- [ ] After merge: re-pin /tmp/zig-{500,5k,30k,50kcoll}-baseline
- [ ] After merge: 30k paired byte-equality + wall vs new pinned baseline (pre-merge gate)
- [ ] After merge: 50k-collision byte-equality + wall (topic→main acceptance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)