### PR TITLE
zig: fix fast_softplus LUT OOB read at d == 0 (#366)

### DIFF
--- a/packages/zig-core/src/ham/fast_math.c
+++ b/packages/zig-core/src/ham/fast_math.c
@@ -73,6 +73,14 @@ double fast_softplus(double d) {
     /* d ∈ [LUT_LO, 0] — index in [0, LUT_N] */
     double t = (d - LUT_LO) * LUT_SCALE;
     int i = (int) t;
+    /* Clamp `i` so `i+1` stays in bounds. At d == 0 (or d so close to 0
+     * that float rounding gives t == LUT_N), the unclamped i would equal
+     * LUT_N and the `softplus_lut[i+1]` read would be one past the array.
+     * The production result was correct only because `frac == 0` masked
+     * the OOB read; Debug-mode bounds checks fired. With the clamp,
+     * frac becomes 1.0 at the boundary and y0 + 1.0*(y1-y0) = y1 =
+     * softplus_lut[LUT_N], identical to the unclamped value. */
+    if (i >= LUT_N) i = LUT_N - 1;
     double frac = t - (double) i;
     double y0 = softplus_lut[i];
     double y1 = softplus_lut[i + 1];


### PR DESCRIPTION
## Summary

`fast_softplus(0.0)` reads `softplus_lut[LUT_N + 1]` — one past the end of the `LUT_N+1`-element table.

## Why production output was still correct

At `d == 0` exactly, `t = LUT_N` and `i = LUT_N`, so `frac = 0`. The interpolation formula `y0 + frac * (y1 - y0)` then returns `y0 = softplus_lut[LUT_N]` regardless of what `y1` reads, so the OOB read is multiplied out. Production binaries (ReleaseFast, no bounds checks) compute the correct value `log(2)`.

## Why the fix matters anyway

1. **Debug mode bounds checks fire.** The new `addInLogSpace: log(e^0 + e^0) = log(2)` unit test in `mathutils.zig` exercises this exact path and crashes with signal 6 (`thread panic: index 65537 out of bounds for type 'double[65537]'`). Discovered while reviewing PR #373.
2. **Float rounding extends the OOB range.** `t = (d - LUT_LO) * LUT_SCALE` can round to exactly `LUT_N` for `d` very close to but not equal to 0, so the OOB hits a tiny range around 0, not just the exact boundary.
3. **UB is brittle.** Any compiler optimization or float-mode change could expose the OOB read in production.

## The fix

Clamp `i` to `LUT_N - 1` so `i+1` is always in bounds. At the boundary, `frac` becomes 1.0 and `y0 + 1.0 * (y1 - y0) = y1 = softplus_lut[LUT_N]` — identical to the unclamped output.

## Validation

- ✓ `zig build test`: 61/61 unit tests pass (including the addInLogSpace test that previously crashed).
- ✓ 5k paired Zig partition: bit-identical to `/tmp/zig-5k-baseline` (3797 igh + 3802 igk events).
- ✓ Production output unchanged at the boundary by construction (linear interpolation degenerates to the same numerical answer).

## Test plan

- [x] `zig build test` passes
- [x] 5k paired Zig partition bit-identical to `/tmp/zig-5k-baseline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)