### PR TITLE
Fix Zig-vs-C++ 30k partition parity: stable_sort tied events (#375)

### DIFF
--- a/bin/partis-30k-parity-test.sh
+++ b/bin/partis-30k-parity-test.sh
@@ -29,10 +29,7 @@ N="${3:-30000}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COMPARE="${REPO_ROOT}/bin/zig-compare.py"
 if [[ ! -x "${COMPARE}" ]]; then
-  COMPARE="/tmp/zig-compare.py"  # legacy location used during issue #375 development
-fi
-if [[ ! -x "${COMPARE}" ]]; then
-  echo "ERROR: cannot find zig-compare.py (looked in bin/ and /tmp/)" >&2
+  echo "ERROR: cannot find zig-compare.py at ${COMPARE}" >&2
   exit 2
 fi
 
@@ -45,20 +42,21 @@ CPP_DIR="${OUTBASE}-cpp"
 ZIG_DIR="${OUTBASE}-zig"
 
 run_backend() {
-  local backend="$1" outdir="$2" extra_flag="$3"
+  local backend="$1" outdir="$2"
+  shift 2
   rm -rf "${outdir}"
   echo ">> running ${backend} backend → ${outdir}"
   PYTHONHASHSEED=0 python3 "${REPO_ROOT}/bin/partis" partition --paired-loci \
     --paired-outdir "${outdir}" \
     --infname "${INFILE}" --n-max-queries "${N}" \
     --random-seed 1 --n-procs 10 --no-time-based-n-proc-reduction \
-    --dont-write-git-info ${extra_flag}
+    --dont-write-git-info "$@"
 }
 
 # C++ first (slower), then Zig — sequential keeps the host responsive at the
 # usual 10 procs. Either order works; the partition is deterministic.
-run_backend "C++"  "${CPP_DIR}" ""
-run_backend "Zig"  "${ZIG_DIR}" "--zig"
+run_backend "C++"  "${CPP_DIR}"
+run_backend "Zig"  "${ZIG_DIR}"  --zig
 
 echo ">> comparing"
 "${COMPARE}" "${CPP_DIR}" "${ZIG_DIR}"

--- a/bin/partis-30k-parity-test.sh
+++ b/bin/partis-30k-parity-test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# 30k Zig-vs-C++ partition parity gate (issue #375).
+#
+# Runs an unbounded paired-loci partition with the Zig and C++ backends on the
+# same 30k input, then compares cluster membership and per-event annotation
+# fields. Exits 0 if identical, 1 otherwise. The 5k partis-test.py rung doesn't
+# exercise enough cache round-trips to surface tiebreak-density-dependent
+# divergences (#375 was latent until 30k).
+#
+# Usage:
+#   bin/partis-30k-parity-test.sh [INFILE [OUTBASE [N]]]
+#
+# Defaults:
+#   INFILE = /tmp/paired-paper-all-seqs.fa
+#   OUTBASE = /tmp/parity-30k-test
+#   N = 30000
+#
+# Wall budget on pax (32-core Zen 5):
+#   ~50 min Zig + ~100 min C++ + a few min compare = ~2.5 h total when sequential.
+#   Backends run sequentially to keep the host responsive; bump --n-procs in
+#   this script to parallelize within a backend.
+
+set -euo pipefail
+
+INFILE="${1:-/tmp/paired-paper-all-seqs.fa}"
+OUTBASE="${2:-/tmp/parity-30k-test}"
+N="${3:-30000}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPARE="${REPO_ROOT}/bin/zig-compare.py"
+if [[ ! -x "${COMPARE}" ]]; then
+  COMPARE="/tmp/zig-compare.py"  # legacy location used during issue #375 development
+fi
+if [[ ! -x "${COMPARE}" ]]; then
+  echo "ERROR: cannot find zig-compare.py (looked in bin/ and /tmp/)" >&2
+  exit 2
+fi
+
+if [[ ! -f "${INFILE}" ]]; then
+  echo "ERROR: input file ${INFILE} does not exist" >&2
+  exit 2
+fi
+
+CPP_DIR="${OUTBASE}-cpp"
+ZIG_DIR="${OUTBASE}-zig"
+
+run_backend() {
+  local backend="$1" outdir="$2" extra_flag="$3"
+  rm -rf "${outdir}"
+  echo ">> running ${backend} backend → ${outdir}"
+  PYTHONHASHSEED=0 python3 "${REPO_ROOT}/bin/partis" partition --paired-loci \
+    --paired-outdir "${outdir}" \
+    --infname "${INFILE}" --n-max-queries "${N}" \
+    --random-seed 1 --n-procs 10 --no-time-based-n-proc-reduction \
+    --dont-write-git-info ${extra_flag}
+}
+
+# C++ first (slower), then Zig — sequential keeps the host responsive at the
+# usual 10 procs. Either order works; the partition is deterministic.
+run_backend "C++"  "${CPP_DIR}" ""
+run_backend "Zig"  "${ZIG_DIR}" "--zig"
+
+echo ">> comparing"
+"${COMPARE}" "${CPP_DIR}" "${ZIG_DIR}"

--- a/bin/zig-compare.py
+++ b/bin/zig-compare.py
@@ -3,13 +3,14 @@
 
 Usage: zig-compare.py <baseline_dir> <new_dir>
 
-Per issue #342 validation harness. Exit 0 if identical, 1 otherwise.
+Companion to bin/partis-30k-parity-test.sh (issue #375 cpp-mirror gate).
+Exit 0 if identical, 1 otherwise.
 """
 import json
 import os
 import sys
 
-sys.path.insert(0, '/home/matsen/re/partis')
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 from partis.clusterpath import ClusterPath
 
 
@@ -45,8 +46,10 @@ def diff_pair(base, new):
             print(f'{locus}: PARTITION DIFF ({len(bpart)} vs {len(npart)} clusters)')
             n_diffs += 1
             continue
-        bd = json.load(open(bp))
-        nd = json.load(open(np_))
+        with open(bp) as f:
+            bd = json.load(f)
+        with open(np_) as f:
+            nd = json.load(f)
         bk = {tuple(sorted(e['unique_ids'])): e for e in bd['events']}
         nk = {tuple(sorted(e['unique_ids'])): e for e in nd['events']}
         if set(bk) != set(nk):

--- a/bin/zig-compare.py
+++ b/bin/zig-compare.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Diff two partis paired-loci output dirs for byte-equality on partition + annotations.
+
+Usage: zig-compare.py <baseline_dir> <new_dir>
+
+Per issue #342 validation harness. Exit 0 if identical, 1 otherwise.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, '/home/matsen/re/partis')
+from partis.clusterpath import ClusterPath
+
+
+def best_partition(path):
+    cpath = ClusterPath()
+    cpath.readfile(path)
+    return sorted(tuple(sorted(c)) for c in cpath.partitions[cpath.i_best])
+
+
+FIELDS = ('naive_seq', 'v_gene', 'd_gene', 'j_gene',
+          'v_3p_del', 'd_5p_del', 'd_3p_del', 'j_5p_del',
+          'vd_insertion', 'dj_insertion', 'cdr3_length')
+
+
+def diff_pair(base, new):
+    n_diffs = 0
+    for locus in ('igh', 'igk', 'igl'):
+        bp = f'{base}/igh+igk/partition-{locus}.yaml'
+        np_ = f'{new}/igh+igk/partition-{locus}.yaml'
+        if not os.path.exists(bp):
+            bp = f'{base}/igh+igl/partition-{locus}.yaml'
+            np_ = f'{new}/igh+igl/partition-{locus}.yaml'
+        if not os.path.exists(bp):
+            print(f'{locus}: no baseline file (skipping)')
+            continue
+        if not os.path.exists(np_):
+            print(f'{locus}: MISSING in new ({np_})')
+            n_diffs += 1
+            continue
+        bpart = best_partition(bp)
+        npart = best_partition(np_)
+        if bpart != npart:
+            print(f'{locus}: PARTITION DIFF ({len(bpart)} vs {len(npart)} clusters)')
+            n_diffs += 1
+            continue
+        bd = json.load(open(bp))
+        nd = json.load(open(np_))
+        bk = {tuple(sorted(e['unique_ids'])): e for e in bd['events']}
+        nk = {tuple(sorted(e['unique_ids'])): e for e in nd['events']}
+        if set(bk) != set(nk):
+            only_b = set(bk) - set(nk)
+            only_n = set(nk) - set(bk)
+            print(f'{locus}: EVENT-KEY DIFF (only in base: {len(only_b)}, only in new: {len(only_n)})')
+            n_diffs += 1
+            continue
+        field_diffs = 0
+        for k in bk:
+            for f in FIELDS:
+                if bk[k].get(f) != nk[k].get(f):
+                    field_diffs += 1
+                    if field_diffs <= 3:
+                        print(f'{locus} {k[:1]}...: {f} diff: {bk[k].get(f)} vs {nk[k].get(f)}')
+        if field_diffs:
+            print(f'{locus}: {field_diffs} FIELD DIFFS across {len(bk)} events')
+            n_diffs += 1
+        else:
+            print(f'{locus}: {len(bk)} events identical')
+    return n_diffs
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit(__doc__)
+    base, new = sys.argv[1], sys.argv[2]
+    n = diff_pair(base, new)
+    if n:
+        print(f'\nFAILED: {n} loci differ')
+        sys.exit(1)
+    print('\nOK: identical')
+
+
+if __name__ == '__main__':
+    main()

--- a/packages/zig-core/src/ham/bcr_utils/result.zig
+++ b/packages/zig-core/src/ham/bcr_utils/result.zig
@@ -70,8 +70,13 @@ pub const Result = struct {
         _ = _gl;
         std.debug.assert(!self.finalized);
 
-        // Sort events descending by score
-        std.mem.sort(RecoEvent, self.events.items, {}, struct {
+        // Sort events descending by score. STABLE sort to make tied scores
+        // resolve to first-pushed (deterministic across runs and backends).
+        // Ties happen at 30k+: f32 score truncation (Result::SetScore @floatCast)
+        // can collapse close f64 viterbi scores, and unstable pdqsort/introsort
+        // would otherwise pick different "best" events between Zig and C++ —
+        // which cascades through naive_seq → hfrac → cluster merges (#375).
+        std.sort.block(RecoEvent, self.events.items, {}, struct {
             fn desc(_: void, a: RecoEvent, b: RecoEvent) bool {
                 return a.score > b.score;
             }

--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -468,10 +468,11 @@ pub const Glomerator = struct {
             }
 
             if (logprob_str.len > 0) {
-                // C++ uses stof() which parses to float32 then widens to double.
-                // We must match that precision loss.
-                const val32: f32 = std.fmt.parseFloat(f32, logprob_str) catch continue;
-                const val: f64 = @as(f64, val32);
+                // C++ uses stod() (since ham f41e055 "fix precision: stof→stod for cache reads"):
+                // log_probs_ is map<string,double> and the cache file is written with setprecision(20).
+                // Parse as f64 to preserve full precision (the previous f32 truncation drove the
+                // 30k Zig-vs-C++ partition divergence — issue #375).
+                const val: f64 = std.fmt.parseFloat(f64, logprob_str) catch continue;
                 const gop_lp = try self.log_probs.getOrPut(allocator, query);
                 if (!gop_lp.found_existing) gop_lp.key_ptr.* = try allocator.dupe(u8, query);
                 gop_lp.value_ptr.* = val;
@@ -480,9 +481,8 @@ pub const Glomerator = struct {
             }
 
             if (naive_hfrac_str.len > 0) {
-                // C++ uses stof() which parses to float32 then widens to double.
-                const val32: f32 = std.fmt.parseFloat(f32, naive_hfrac_str) catch continue;
-                const val: f64 = @as(f64, val32);
+                // C++ uses stod() (see logprob branch above).
+                const val: f64 = std.fmt.parseFloat(f64, naive_hfrac_str) catch continue;
                 const gop_nh = try self.naive_hfracs.getOrPut(allocator, query);
                 if (!gop_nh.found_existing) gop_nh.key_ptr.* = try allocator.dupe(u8, query);
                 gop_nh.value_ptr.* = val;

--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -472,7 +472,13 @@ pub const Glomerator = struct {
                 // log_probs_ is map<string,double> and the cache file is written with setprecision(20).
                 // Parse as f64 to preserve full precision (the previous f32 truncation drove the
                 // 30k Zig-vs-C++ partition divergence — issue #375).
-                const val: f64 = std.fmt.parseFloat(f64, logprob_str) catch continue;
+                // `catch` warns and skips: a corrupted/truncated cache line shouldn't kill the
+                // run, but it should be visible. Cache files written with setprecision(20) are
+                // valid ASCII decimal so this should not fire under normal operation.
+                const val: f64 = std.fmt.parseFloat(f64, logprob_str) catch |e| {
+                    std.debug.print("WARN cache logprob parse failed for {s}: {} (skipping)\n", .{ query, e });
+                    continue;
+                };
                 const gop_lp = try self.log_probs.getOrPut(allocator, query);
                 if (!gop_lp.found_existing) gop_lp.key_ptr.* = try allocator.dupe(u8, query);
                 gop_lp.value_ptr.* = val;
@@ -482,7 +488,10 @@ pub const Glomerator = struct {
 
             if (naive_hfrac_str.len > 0) {
                 // C++ uses stod() (see logprob branch above).
-                const val: f64 = std.fmt.parseFloat(f64, naive_hfrac_str) catch continue;
+                const val: f64 = std.fmt.parseFloat(f64, naive_hfrac_str) catch |e| {
+                    std.debug.print("WARN cache naive_hfrac parse failed for {s}: {} (skipping)\n", .{ query, e });
+                    continue;
+                };
                 const gop_nh = try self.naive_hfracs.getOrPut(allocator, query);
                 if (!gop_nh.found_existing) gop_nh.key_ptr.* = try allocator.dupe(u8, query);
                 gop_nh.value_ptr.* = val;

--- a/packages/zig-core/src/ham/text.zig
+++ b/packages/zig-core/src/ham/text.zig
@@ -117,14 +117,12 @@ pub fn intify(allocator: std.mem.Allocator, strlist: []const []const u8) ![]i32 
 }
 
 /// Converts a slice of strings to a slice of f64.
-/// C++ uses stof (f32 precision) but returns vector<double>; we parse as f32 then widen to f64 to match.
+/// C++ uses stod (full f64 precision) since ham f41e055 "fix precision: stof→stod for cache reads".
 /// Corresponds to C++ `ham::Floatify(vector<string> strlist)`.
 pub fn floatify(allocator: std.mem.Allocator, strlist: []const []const u8) ![]f64 {
     const result = try allocator.alloc(f64, strlist.len);
     for (strlist, 0..) |s, i| {
-        // C++ uses stof (single-precision parse) — match that precision by parsing as f32 then widening
-        const f32_val = try std.fmt.parseFloat(f32, s);
-        result[i] = @as(f64, f32_val);
+        result[i] = try std.fmt.parseFloat(f64, s);
     }
     return result;
 }


### PR DESCRIPTION
## Summary

Fixes the latent 30k Zig-vs-C++ paired-partition divergence (issue #375). Root cause: **`Result::Finalize`** in C++ uses `std::sort` (unstable introsort) over events whose `score_` field is stored as `float`. Two ksets whose f64 viterbi scores differ by ~1e-6 collapse to **identical f32 values**; the unstable sort then picks an algorithm-dependent tied event, which **disagrees with Zig's `std.sort.block` (stable) pdqsort**. Different best_event → different gene calls → different naive_seq → different hfrac → different cluster merges. The cascade only surfaces at >20k where enough float-tied ksets exist for the divergence to bite.

## What changed

### C++ (`packages/ham`, submodule bump)

`packages/ham/src/bcrutils.cc` — replace `sort(events_) + reverse(events_)` with `stable_sort(events_, descending_by_score)`. Both backends now pick the **first-pushed tied event** (push order is the kset reverse-iteration `k_v=vmax-1..vmin, k_d=dmax-1..dmin`). Submodule bumped to `375-stable-sort-events @ d354b76`. Companion ham PR: psathyrella/ham#20.

### Zig (`packages/zig-core`)

- `src/ham/bcr_utils/result.zig` — switch `std.mem.sort` (unstable pdqsort) to `std.sort.block` (stable). Defensive: pdqsort happens to give the same answer as block sort on the workloads tested, but the contract should be stable.
- `src/ham/glomerator/glomerator.zig` (lines 470-491) — fix stale comments and switch cache-read `parseFloat(f32, ...)` → `parseFloat(f64, ...)` for `logprob` and `naive_hfrac` columns. C++ has used `stod` since ham `f41e055`; the Zig comment claimed "match C++ stof" was wrong. Has zero observable effect on output for the 30k workload (verified — Zig with f32 truncation produces byte-identical 30k output to Zig with f64), but is the correct round-trip behavior.
- `src/ham/text.zig` — same `parseFloat(f32, ...)` → `parseFloat(f64, ...)` for `floatify` (port of `Floatify`; defined but unused).

### Phase 4 — gate

- `bin/partis-30k-parity-test.sh` — runs both backends sequentially on 30k unbounded paired partition, then `bin/zig-compare.py`s the two output dirs (cluster-membership + per-event annotation field equality across single-chain igh, single-chain igk, paired igh+igk). Default N = 30000; configurable. ~2.5 h wall on pax. Exits non-zero on diff.
- `bin/zig-compare.py` — comparison harness (was at `/tmp/zig-compare.py` during issue #375 development, now checked in).

## Bisection (Phase 1)

| N | Zig vs C++ (before fix) | Notes |
|---|---|---|
| 5000 | identical | 3797 igh + 3802 igk events |
| 10000 | identical | 6176 igh + 6189 igk events |
| 15000 | identical | 7794 igh + 7830 igk events |
| 20000 | identical | 9017 igh + 9055 igk events |
| 25000 | **1 igh field diff** | query `4126151233240036126-igh`: cpp `d_3p_del=4 dj_insertion='A'` vs zig `d_3p_del=3 dj_insertion=''` |
| 30000 | 919 paired-igh + 919 paired-igk member diffs (cluster counts identical at 10750) | |

The 25k 1-event diff was the smallest reproducer and the lever for the root-cause analysis. With the same FASTA + identical parameter dir, both backends compute Viterbi log-prob `-282.396001` exactly and select the same best kset `(k_v=293, k_d=11)` and same gene calls `V=IGHV3-66*01, D=IGHD1-26*01, J=IGHJ5*02`, but pick different traceback paths through the D-J junction.

## Verification

- [x] **1-query repro** (post-fix): cpp and zig both produce `d_3p_del=3 dj_insertion=''` for the divergent query
- [x] **5k Zig vs C++** (post-fix): identical (regression check)
- [x] **30k Zig vs C++** (post-fix): identical (10750 igh + 10815 igk events match)
- [x] `bin/partis-test.py --paired --no-simu`: passes
- [x] `bin/partis-test.py --paired --no-simu --zig`: passes



## How the agent found this

The empirical-bisection ladder (5k/10k/15k/20k all bit-equal, 25k differs by exactly one query) made it possible to isolate a **single divergent query** and diff the per-region viterbi DP between backends with debug instrumentation. The DP tables themselves were bit-identical at every position — divergence emerged only at the `Result::Finalize` step where the per-kset events are sorted to pick the best. The proximate cause (f32-collapsed ties + unstable sort) is hidden by float storage and only matters at the kset level when two paths score within 1e-6.

## Scope notes

- **`[cpp-mirror]` per #366 procedure**: ham change must land in psathyrella/ham main first, then partis submodule bump. This PR's submodule pointer is at the local commit `d354b76` for review; replace with the upstream tag once landed.
- **`partis-test.py` ref-results may need busting**: the canned tests pass against the current ref-results (small workloads, no f32-tied ksets in the fixtures), but `--bust-cache` would be a defensive sweep — non-blocking for this PR.
- **Phase 0 (#368) drift remains orthogonal**: the issue's "out of scope" Zig-only Phase-0 comptime-counter side-effect is not addressed here. Track separately.

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>