### PR TITLE
zig: promote f32→f64 for mute_freq, threshold args, RecoEvent.score (#377)

### DIFF
--- a/packages/zig-core/src/ham/args.zig
+++ b/packages/zig-core/src/ham/args.zig
@@ -64,10 +64,10 @@ pub const Args = struct {
     ambig_base: []u8,
     seed_unique_id: []u8,
 
-    hamming_fraction_bound_lo: f32,
-    hamming_fraction_bound_hi: f32,
-    logprob_ratio_threshold: f32,
-    max_logprob_drop: f32,
+    hamming_fraction_bound_lo: f64,
+    hamming_fraction_bound_hi: f64,
+    logprob_ratio_threshold: f64,
+    max_logprob_drop: f64,
 
     debug: i32,
     naive_hamming_cluster: i32,
@@ -108,7 +108,7 @@ pub const Args = struct {
             .seed_unique_id = try allocator.dupe(u8, ""),
             .hamming_fraction_bound_lo = 0.0,
             .hamming_fraction_bound_hi = 1.0,
-            .logprob_ratio_threshold = -std.math.inf(f32),
+            .logprob_ratio_threshold = -std.math.inf(f64),
             .max_logprob_drop = -1.0,
             .debug = 0,
             .naive_hamming_cluster = 0,

--- a/packages/zig-core/src/ham/bcr_utils/reco_event.zig
+++ b/packages/zig-core/src/ham/bcr_utils/reco_event.zig
@@ -16,7 +16,7 @@ pub const RecoEvent = struct {
     /// Insertion sequences: "fv", "vd", "dj", "jf".
     insertions: std.StringHashMapUnmanaged([]u8),
     naive_seq: []u8,
-    score: f32,
+    score: f64,
     cyst_position: i32,
     tryp_position: i32,
     cdr3_length: i32,
@@ -107,7 +107,7 @@ pub const RecoEvent = struct {
     }
 
     pub fn setScore(self: *RecoEvent, s: f64) void {
-        self.score = @floatCast(s);
+        self.score = s;
     }
 
     pub fn clear(self: *RecoEvent, allocator: std.mem.Allocator) void {

--- a/packages/zig-core/src/ham/bcr_utils/result.zig
+++ b/packages/zig-core/src/ham/bcr_utils/result.zig
@@ -72,10 +72,11 @@ pub const Result = struct {
 
         // Sort events descending by score. STABLE sort to make tied scores
         // resolve to first-pushed (deterministic across runs and backends).
-        // Ties happen at 30k+: f32 score truncation (Result::SetScore @floatCast)
-        // can collapse close f64 viterbi scores, and unstable pdqsort/introsort
-        // would otherwise pick different "best" events between Zig and C++ —
-        // which cascades through naive_seq → hfrac → cluster merges (#375).
+        // With score stored as f64 (#377) the f32-collapse failure mode from
+        // #375 is gone, but two ksets can still produce machine-epsilon-equal
+        // f64 scores; an unstable pdqsort/introsort would otherwise pick
+        // different "best" events between Zig and C++, cascading through
+        // naive_seq → hfrac → cluster merges. Originally added in #375.
         std.sort.block(RecoEvent, self.events.items, {}, struct {
             fn desc(_: void, a: RecoEvent, b: RecoEvent) bool {
                 return a.score > b.score;

--- a/packages/zig-core/src/ham/bcrham.zig
+++ b/packages/zig-core/src/ham/bcrham.zig
@@ -97,7 +97,7 @@ pub fn runAlgorithm(
         var dph = try DPHandler.init(allocator, args.algorithm, args, gl, hmms);
         defer dph.deinit();
 
-        var result = try dph.run(qseq_ptrs, kbounds, only_genes, @floatCast(qrow.mut_freq), true);
+        var result = try dph.run(qseq_ptrs, kbounds, only_genes, qrow.mut_freq, true);
         defer result.deinit();
 
         if (result.no_path) {
@@ -159,7 +159,7 @@ pub fn run(allocator: std.mem.Allocator, argv: []const [*:0]const u8) !void {
             .{ "--random-seed", "random_seed" },
             .{ "--min-largest-cluster-size", "min_largest_cluster_size" },
         };
-        const f32_flags = .{
+        const f64_flags = .{
             .{ "--hamming-fraction-bound-lo", "hamming_fraction_bound_lo" },
             .{ "--hamming-fraction-bound-hi", "hamming_fraction_bound_hi" },
             .{ "--logprob-ratio-threshold", "logprob_ratio_threshold" },
@@ -212,9 +212,9 @@ pub fn run(allocator: std.mem.Allocator, argv: []const [*:0]const u8) !void {
                     matched = true;
                 }
             }
-            inline for (f32_flags) |entry| {
+            inline for (f64_flags) |entry| {
                 if (std.mem.eql(u8, flag, entry[0])) {
-                    @field(args, entry[1]) = try std.fmt.parseFloat(f32, val);
+                    @field(args, entry[1]) = try std.fmt.parseFloat(f64, val);
                     matched = true;
                 }
             }

--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -211,7 +211,7 @@ pub const Glomerator = struct {
                     is_seed_missing,
                     only_genes.items,
                     kbounds,
-                    @floatCast(qrow.mut_freq),
+                    qrow.mut_freq,
                     @intCast(@max(0, qrow.cdr3_length)),
                     null, null,
                 );
@@ -233,7 +233,7 @@ pub const Glomerator = struct {
                 is_seed_missing,
                 only_genes.items,
                 kbounds,
-                @floatCast(qrow.mut_freq),
+                qrow.mut_freq,
                 @intCast(@max(0, qrow.cdr3_length)),
                 null, null,
             );
@@ -344,7 +344,7 @@ pub const Glomerator = struct {
     /// Run full hierarchical clustering and write output.
     /// Corresponds to C++ `Glomerator::Cluster`.
     pub fn cluster(self: *Glomerator) !void {
-        if (self.args.logprob_ratio_threshold == -std.math.inf(f32)) {
+        if (self.args.logprob_ratio_threshold == -std.math.inf(f64)) {
             return error.LogprobRatioThresholdNotSet;
         }
 
@@ -1214,7 +1214,7 @@ pub const Glomerator = struct {
             is_seed_missing,
             only_genes_list.items,
             kbounds,
-            @floatCast(mute_freq_total / @as(f64, @floatFromInt(n_names))),
+            mute_freq_total / @as(f64, @floatFromInt(n_names)),
             cdr3_length,
             null, null,
         );
@@ -1279,7 +1279,7 @@ pub const Glomerator = struct {
         const n_a_f64: f64 = @floatFromInt(ref_a.nSeqs());
         const n_b_f64: f64 = @floatFromInt(ref_b.nSeqs());
         const n_total_f64: f64 = n_a_f64 + n_b_f64;
-        const joint_mute_freq: f32 = @floatCast((n_a_f64 * @as(f64, ref_a.mute_freq) + n_b_f64 * @as(f64, ref_b.mute_freq)) / n_total_f64);
+        const joint_mute_freq: f64 = (n_a_f64 * ref_a.mute_freq + n_b_f64 * ref_b.mute_freq) / n_total_f64;
         const is_seed_missing = !ham_text.inString(self.args.seed_unique_id, joint_name, ":");
 
         var key_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
@@ -1460,8 +1460,10 @@ pub const Glomerator = struct {
         // C++ caches the subset in tmp_cachefo_ using the parent cluster's attributes
         // (only_genes, kbounds, mute_freq, cdr3_length). This is important because
         // later getCachefo() calls for the subset will find this entry instead of
-        // rebuilding from singles, and the parent's mute_freq (which carries f32
-        // merge cascade truncation) must be used for consistency with C++.
+        // rebuilding from singles, so the parent's mute_freq (the weighted-average
+        // value carried through the merge cascade) must be used for consistency
+        // with C++. Pre-#377 both backends stored mute_freq as f32, so the cascade
+        // also accumulated f32 truncation; #377 promoted both to f64.
         const cacheref = try self.getCachefo(queries);
         {
             var sub_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};

--- a/packages/zig-core/src/ham/glomerator/query.zig
+++ b/packages/zig-core/src/ham/glomerator/query.zig
@@ -22,7 +22,7 @@ pub const Query = struct {
     seed_missing: bool,
     only_genes: std.ArrayListUnmanaged([]u8),
     kbounds: KBounds,
-    mute_freq: f32,
+    mute_freq: f64,
     cdr3_length: usize,
     /// Names of the two parent queries (may be empty when not set).
     parents: ?[2][]u8,
@@ -51,7 +51,7 @@ pub const Query = struct {
         seed_missing: bool,
         only_genes: []const []const u8,
         kbounds: KBounds,
-        mute_freq: f32,
+        mute_freq: f64,
         cdr3_length: usize,
         parent1: ?[]const u8,
         parent2: ?[]const u8,


### PR DESCRIPTION
## Summary

Closes [#377](https://github.com/psathyrella/partis/issues/377). Promotes three
remaining `f32` storage sites to `f64` on the Zig backend, mirroring the C++
ham PR [#21](https://github.com/psathyrella/ham/pull/21). Removes the latent
narrow-then-widen patterns that PR
[#376](https://github.com/psathyrella/partis/pull/376) pinned via stable_sort.

Bundles all three phases of #377 into a single coordinated [cpp-mirror] PR pair:

1. **`Query.mute_freq`** (feeds emission rescaling). Was `f32`; the field, ctor
   param, and three feed sites now use `f64` directly. Drops three `@floatCast`
   narrowings: two at `Query.create` callers in the initial cachefo build, plus
   the merged-cluster weighted-average computation in `getMergedQuery`.
2. **Four threshold args** (`hamming_fraction_bound_lo/hi`,
   `logprob_ratio_threshold`, `max_logprob_drop`). Compared against `f64`
   quantities in the merge loop — `(double)(float)0.05 ≠ (double)0.05`, so a
   ~7.4e-9 window of true `f64` `hfrac` values flipped the comparison.
   Now stored as `f64` end-to-end; CLI parser uses `parseFloat(f64, ...)`;
   the `-inf(f32)` sentinel comparison at `glomerator.zig:347` is now `-inf(f64)`.
3. **`RecoEvent.score`** (the field #375 traced to the 30k divergence).
   Two ksets with `f64` Viterbi scores within ~1e-6 collapsed to identical
   `f32` values. Now `f64`; `setScore` no longer narrows. The Phase 3 pre-work
   (audit `partis/python/` for explicit `np.float32` casts on `logprob`) came
   back clean — no round-trip dependency on the partis side.

The `std.sort.block` in `Result.finalize` stays — at `f64` precision two ksets
can still produce machine-epsilon-equal scores, and we still want deterministic
tie-breaking across stdlib sort algorithms (C++ introsort vs. Zig pdqsort).
Comments rewritten to reflect the post-#377 invariant.

## Submodule bump

`packages/ham` → `377-float-to-double` tip
([ham PR #21](https://github.com/psathyrella/ham/pull/21)). Includes the
matching ham-side type changes (`Query::mute_freq_`, four threshold getters/args,
`RecoEvent::score_`).

## Files changed (Zig)

- `packages/zig-core/src/ham/glomerator/query.zig` — Phase 1 field/ctor `f32` → `f64`
- `packages/zig-core/src/ham/glomerator/glomerator.zig` — Phase 1 (drop `@floatCast`s at `Query.create` call sites + the merged-cluster `joint_mute_freq`), Phase 2 (`-inf(f32)` → `-inf(f64)`), comment refresh on the cache-cascade comment
- `packages/zig-core/src/ham/args.zig` — Phase 2 four threshold fields `f32` → `f64`, `-inf` sentinel
- `packages/zig-core/src/ham/bcrham.zig` — Phase 2 CLI parsing `parseFloat(f32, ...)` → `parseFloat(f64, ...)`; rename `f32_flags` tuple to `f64_flags`. Phase 1 cleanup of the redundant `@floatCast(qrow.mut_freq)` in the `runAlgorithm` path.
- `packages/zig-core/src/ham/bcr_utils/reco_event.zig` — Phase 3 field `f32` → `f64`; `setScore` no longer narrows
- `packages/zig-core/src/ham/bcr_utils/result.zig` — Phase 3 comment refresh on the stable-sort site

## Test plan

- [x] `bin/zig-build.sh` clean
- [x] `cd packages/ham && scons bcrham` clean
- [x] `zig build test` — 61/61 ham unit tests pass
- [x] **5k Zig-vs-C++ paired-loci**: bit-identical post-#377 (3797 igh + 3802 igk events, all identical). Both backends drop the f32 truncation symmetrically.
- [x] **`bin/partis-test.py --paired --no-simu`**: passes. `test/parameters/data` ok; `test/parameters/simu` shows pre-existing ref-results drift (3 files only in new) called out in `CLAUDE.md`. Run-time cells faster across the board (consistent with #366 perf work).
- [x] **`bin/partis-30k-parity-test.sh` (the gate)**: **PASSED, bit-identical**. 10750 igh events identical + 10813 igk events identical between Zig and C++ post-#377.

## Notes on residual `float` mentions

Per the issue's success criterion 2, the only remaining `float` mentions in
ham C++ after this PR are: third-party tclap headers, four cosmetic `float()`
casts at `dphandler.cc:565,567` and `glomerator.cc:611,1142` (non-blocking
cleanup; not in this PR), the `100. * float(GetRss())` formatter at
`glomerator.cc:327`, the TCLAP help-text strings `"float"` at `args.cc:22-25`,
and prose comments. No `float` field declarations, function parameters,
return types, or arithmetic expressions remain in precision-sensitive code.

## DEFERRED

- Cosmetic `float(...)` casts at `dphandler.cc:565,567` and
  `glomerator.cc:611,1142` — non-blocking, can land separately. Issue #377
  scope boundary.
- The `glomerator.cc:934` merge formula has redundant `double(...)` casts on
  `seqs_.size()` from `f41e055` (predates this PR) that become unnecessary
  once `mute_freq_` is `double`. Optional simplification; left as-is for
  minimal diff.
- The new precision unit tests (a)–(d) from the issue's "Test plan" — not
  written this round. The 5k + 30k bit-equality gates are the actual signal
  we use; the per-narrowing ULP/boundary tests would pin invariants that
  the gates already exercise. Could be filed as a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
