### PR TITLE
zig: sparse @memset in swapColumnsActive (#366 item 1.1 re-attempt)

### DIFF
--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -182,6 +182,14 @@ pub const Trellis = struct {
         defer current_states.deinit(allocator);
         var next_states = std.ArrayListUnmanaged(usize){};
         defer next_states.deinit(allocator);
+        // Third list for the sparse-memset three-way rotation in
+        // swapColumnsActive (#366 item 1.1). Holds the candidate-set used
+        // as input to the previous middleViterbiVals call; rotates into
+        // the role of "dirty-list for two swaps from now" so the sparse
+        // clear has the right indices in hand at every iteration without
+        // any per-active-state bookkeeping in the hot inner loop.
+        var prev_current_states = std.ArrayListUnmanaged(usize){};
+        defer prev_current_states.deinit(allocator);
 
         // Position 0: transitions from init state
         const init_st = self.hmm.initial orelse return error.NoInitState;
@@ -192,6 +200,16 @@ pub const Trellis = struct {
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
+            // Track which slots the init code wrote, so the three-way list
+            // rotation in swapColumnsActive can derive iter-2's dirty-list
+            // (= these init writes) without a separate `init_written_states`
+            // list. Treats init as a virtual "iteration 0": its
+            // current_states output is the indices it wrote, and rotates
+            // into prev_current_states at swap #1 → ready for sparse-clear
+            // at swap #2 when the buffer swap exposes these slots in
+            // scoring_current. This is the small refinement of the plan's
+            // "option (b)" (init memset alone leaves swap #2's clear empty).
+            try current_states.append(allocator, i_st);
             self.cacheViterbiVals(0, dpval, i_st);
             // Mark outbound transitions for next position (deduplicated)
             for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
@@ -205,10 +223,10 @@ pub const Trellis = struct {
         // Positions 1..seq_len-1
         var position: usize = 1;
         while (position < seq_len) : (position += 1) {
-            try self.swapColumnsActive(allocator, &current_states, &next_states);
+            self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
             try self.middleViterbiVals(allocator, current_states, &next_states, position);
         }
-        try self.swapColumnsActive(allocator, &current_states, &next_states);
+        self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
 
         // Compute ending probability
         self.ending_viterbi_pointer = -1;
@@ -250,6 +268,10 @@ pub const Trellis = struct {
         defer current_states.deinit(allocator);
         var next_states = std.ArrayListUnmanaged(usize){};
         defer next_states.deinit(allocator);
+        // Third list for the sparse-memset three-way rotation in
+        // swapColumnsActive (#366 item 1.1); see viterbi() for the rationale.
+        var prev_current_states = std.ArrayListUnmanaged(usize){};
+        defer prev_current_states.deinit(allocator);
 
         // Position 0: transitions from init state
         const init_st = self.hmm.initial orelse return error.NoInitState;
@@ -260,6 +282,10 @@ pub const Trellis = struct {
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
+            // Track which slots the init code wrote so the three-way list
+            // rotation can derive iter-2's dirty-list. See viterbi() for
+            // the longer rationale; same logic applies here verbatim.
+            try current_states.append(allocator, i_st);
             // Mark outbound transitions for next position (deduplicated)
             for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
                 if (!self.next_seen.isSet(j)) {
@@ -273,10 +299,10 @@ pub const Trellis = struct {
         // Positions 1..seq_len-1
         var position: usize = 1;
         while (position < seq_len) : (position += 1) {
-            try self.swapColumnsActive(allocator, &current_states, &next_states);
+            self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
             try self.middleForwardVals(allocator, current_states, &next_states, position);
         }
-        try self.swapColumnsActive(allocator, &current_states, &next_states);
+        self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
 
         // Compute ending probability
         self.ending_forward_log_prob = mathutils.NEG_INF;
@@ -326,28 +352,60 @@ pub const Trellis = struct {
 
     fn swapColumnsActive(
         self: *Trellis,
-        allocator: std.mem.Allocator,
         current_states: *std.ArrayListUnmanaged(usize),
         next_states: *std.ArrayListUnmanaged(usize),
-    ) !void {
-        // Swap scoring_current ↔ scoring_previous
+        prev_current_states: *std.ArrayListUnmanaged(usize),
+    ) void {
+        // Swap scoring_current ↔ scoring_previous.
         const tmp = self.scoring_previous;
         self.scoring_previous = self.scoring_current;
         self.scoring_current = tmp;
-        @memset(self.scoring_current, mathutils.NEG_INF);
+
+        // Sparse-clear scoring_current at the indices written two iterations
+        // ago (= the contents of prev_current_states at entry). After the
+        // buffer swap, scoring_current is the buffer that held those writes,
+        // so only those slots could hold non-NEG_INF; clearing them restores
+        // the same post-condition the previous full @memset gave (entire
+        // buffer NEG_INF before middle{Viterbi,Forward}Vals at iteration N
+        // writes through its current_states subset).
+        //
+        // This is the #366 item 1.1 sparse-memset path. Hot-path discipline
+        // (the rule that #369 violated): no `try`, no allocation, no fallible
+        // op in this loop — it must compile to a tight indexed store. The
+        // dirty-list arrives in `prev_current_states` as a zero-cost side
+        // effect of the three-way list rotation below; no per-active-state
+        // bookkeeping inside middle{Viterbi,Forward}Vals.
+        for (prev_current_states.items) |j| self.scoring_current[j] = mathutils.NEG_INF;
 
         // Clear next_seen for all indices that were in next_states
         // (they will become current_states; next_seen tracks what's queued for the NEW next)
         for (next_states.items) |j| self.next_seen.unset(j);
 
-        // current_states ← next_states; next_states ← empty
-        // Swap the backing allocations to avoid reallocation
-        const old_current_items = current_states.items;
-        const old_current_cap = current_states.capacity;
+        // Three-way list rotation: prev_current ← current, current ← next,
+        // next ← (old prev_current, then cleared). After this rotation:
+        //   - current_states.items = the candidate-set for the NEXT
+        //     middle{Viterbi,Forward}Vals call (i.e., what was in
+        //     next_states at entry, populated by the previous iteration);
+        //   - prev_current_states.items = the candidate-set that was just
+        //     used as input to the previous middle{...}Vals call. Those
+        //     indices name the slots in scoring_previous (post-rotation),
+        //     and will become the dirty-list for the sparse-clear two
+        //     swaps from now (when those slots have rotated back into
+        //     scoring_current via the next two buffer swaps).
+        //   - next_states is empty (clearRetainingCapacity), ready for
+        //     the next middle{...}Vals to populate the iteration-after-next
+        //     candidate set.
+        //
+        // ArrayListUnmanaged is two POD fields (items: []usize, capacity:
+        // usize); this is allocation-free struct-field assignment, no `try`.
+        const tmp_items = prev_current_states.items;
+        const tmp_capacity = prev_current_states.capacity;
+        prev_current_states.items = current_states.items;
+        prev_current_states.capacity = current_states.capacity;
         current_states.items = next_states.items;
         current_states.capacity = next_states.capacity;
-        next_states.items = old_current_items;
-        next_states.capacity = old_current_cap;
+        next_states.items = tmp_items;
+        next_states.capacity = tmp_capacity;
         next_states.clearRetainingCapacity();
         // Sort current_states in ascending order to match C++ bitset iteration
         // (0..n_states). This is critical: cacheForwardVals accumulates
@@ -356,7 +414,6 @@ pub const Trellis = struct {
         // produce different results. The cached forward_log_probs values are
         // then read by chunk-cached trellises via endingForwardLogProbAt().
         std.mem.sort(usize, current_states.items, {}, std.sort.asc(usize));
-        _ = allocator; // backing storage reuse avoids new allocations
     }
 
     fn middleViterbiVals(


### PR DESCRIPTION
## Summary

Replace full `@memset(scoring_current, NEG_INF)` in `swapColumnsActive` with a sparse loop over the indices written two iterations ago. The dirty-list arrives as a zero-cost side effect of a three-way rotation of (`prev_current`, `current`, `next`) at each call — **no per-active-state bookkeeping inside `middle{Viterbi,Forward}Vals`**. This is the "derive the dirty list from the existing list mechanism" prescription from the revert of #369 (`af317d8de`), which had paid +6.9% bcrham wall via in-loop `ArrayList.append` + error-union propagation.

`swapColumnsActive` is now non-fallible (`void`, no `try`, no allocation, no fallible op). The rotation is six pointer/usize struct-field assignments. Init code in `viterbi()` / `forward()` also populates `current_states` with W₀ (the slots it wrote) so the rotation invariant holds at swap #2 — a small refinement of the plan's option (b), which only handled swap #1.

Companion to #366 → see the issue comment from 2026-05-08 ("Re-attempt #366 item 1.1: sparse memset of `scoring_current` in `swapColumnsActive`") for the full design rationale.

## Verification

| Check | Result |
|---|---|
| `partis-test.py --quick` | pass |
| `partis-test.py --paired --no-simu` | pass (3 pre-existing diffs noted in CLAUDE.md, no new ones) |
| 5k Zig-vs-C++ paired bit-equality | identical (3797 igh + 3802 igk events match `/tmp/parity-5k-377-cpp/`) |
| **30k Zig-vs-C++ paired parity gate** | **identical** (10750 igh + 10813 igk events match `/tmp/parity-30k-377-{cpp,zig}/`) |
| Perf-counter sanity (active-states, chunk-cache) | aggregate.txt bit-identical to pre-change baseline (the patch alters how slots get cleared, not what is computed) |
| Median-of-3 5k Zig bcrham wall | **wall unchanged within noise** — Δ ≥ −0.5% acceptance criterion met (see below) |

## Wall measurement (caveat: small n, high variance)

Median-of-3 5k Zig-only bcrham wall (sum of per-locus `bcrham time:` from #371's instrumentation; baseline is the same topic branch with this PR's patch stashed):

```
baseline runs: 178.5, 160.8, 170.9   median 170.9s, mean 170.07s
patched  runs: 169.3, 166.2, 179.7   median 169.3s, mean 171.73s
```

The right reading is **"wall unchanged within noise"**, not a positive claim. Permutation test on the 6 numbers gives p ≈ 0.5 (the observed median delta is the *most likely* outcome under the null hypothesis); by means the delta is the opposite sign (−0.98%). Per-run variance is ~5% CV, which gives σ ≈ 8s and an effective resolution floor of ~4% on this metric at n=3.

Why the wall floor is high: per `/tmp/perf-1.1-results/aggregate.txt`, **80.5% of viterbi and 86.4% of forward `fillTrellis` calls hit the chunk-cache short-circuit** at `trellis.zig:149-154` and never reach `swapColumnsActive`. So whatever true effect this micro-opt has on the modified code path is diluted ~5× in end-to-end wall. The plan's "+0–2%" expectation lives below the n=3 noise floor on this workload.

What is rock-solid here:
- The **acceptance bar (Δ ≥ −0.5%)** is satisfied: the patch has no measurable wall regression. That was the merge gate, and it's met.
- The **bit-identical `aggregate.txt`** and **bit-identical 30k parity** confirm the patch alters *how* slots are cleared, not *what* is computed.
- The previous attempt (#369) was detected at +6.9%, well outside the noise floor — so the harness can resolve a real regression of that size, just not a sub-1% improvement at n=3.

If a positive wall claim is wanted later, the right tool is `perf stat -d` instruction count on a focused sub-workload (the same tool that diagnosed #369's +5.6% instructions), not 3-run end-to-end wall.

## Test plan

- [x] `partis-test.py --quick`
- [x] `partis-test.py --paired --no-simu`
- [x] 5k Zig-vs-C++ parity (vs `/tmp/parity-5k-377-cpp/`)
- [x] 30k Zig-vs-C++ parity gate (vs `/tmp/parity-30k-377-{cpp,zig}/`)
- [x] Median-of-3 5k Zig wall: no regression (Δ ≥ −0.5% met; positive directional claim *not* supported at n=3)
- [x] Perf-counter distributions unchanged (`bin/zig-perf-counters-run.sh`, diffed `aggregate.txt`)

## Reviewer notes

- **Test coverage gap (advisory)**: the existing `trellis.zig` tests either skip silently when `/fh/fast` is unavailable or bypass `swapColumnsActive` entirely (the flat-traceback layout test hand-builds a `Trellis` and never calls it). A synthetic 2-state HMM over seq_len ≥ 3 that asserts `scoring_current` is fully `NEG_INF` after each swap would close the gap and protect the rotation invariant from future drift. Not a blocker — the 30k parity gate exercises the path under load — but worth filing as a follow-up.
- `zig fmt --check src/ham/trellis.zig` reports a pre-existing whitespace issue at the file head that is **also** present on `origin/366-zig-perf-next` and is unrelated to this PR. Not fixed here to keep the diff scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)