### PR TITLE
zig: hoist gene-keyed map pointers in runKSet (#366 Lever 1)

### DIFF
--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -51,25 +51,47 @@ const TrellisEntry = struct {
     trellis: Trellis,
 };
 
-/// Per-gene pointer bundle hoisted once at the top of `runKSet`'s
-/// per-gene loop iteration. Eliminates the redundant
-/// `self.scratch_cachefo.getPtr(gene)`, `self.paths.getPtr(gene)`,
-/// `self.scores.getPtr(gene)`, and `self.hmms.get(gene)` calls that
-/// would otherwise fire 3-6× per gene per kset on the hot path.
+/// Per-gene inner-map pointer bundle hoisted once at the top of
+/// `runKSet`'s per-gene loop iteration. Replaces 2-3 redundant
+/// `self.{scratch_cachefo,paths,scores}.getPtr(gene)` lookups in the
+/// gene-block body and inside `fillTrellis` with a single struct of
+/// pre-resolved pointers.
 ///
-/// Pointers are stable for the lifetime of one gene-block iteration:
-/// `initCache(gene)` populates the outer `scratch_cachefo` / `paths` /
-/// `scores` maps before the cache is built; no other caller adds new
-/// entries to those outer maps within a gene-block; and writes to the
-/// inner kset-keyed maps don't relocate the outer-map value slots.
-/// HMMHolder's gene→Model map is similarly stable post-load. See the
-/// Phase A lever-sizing memo on issue #366 for the wall attribution
-/// (HashMap-by-gene-name = ~33% of partition wall before this hoist).
+/// Honest cost framing: the lookups this hoist eliminates show as
+/// 0.00% of partition wall in the post-#380 perf-record (the
+/// `getIndex` symbols for value-types `AutoHashMapUnmanaged(KSet,
+/// TracebackPath)`, `AutoHashMapUnmanaged(KSet, f64)`, and
+/// `ArrayListUnmanaged(*TrellisEntry)` do not appear at the top of
+/// `/tmp/perf-1.1-results/partition-5k.perf.report`). The 24.63%
+/// `getIndex__anon_27622` bucket cited in the Phase A memo is
+/// HMMHolder's `[]const u8 → *Model` map only — a different value
+/// type, with one call per (gene, kset) on the cache-miss path that
+/// this hoist intentionally does NOT touch (hoisting it would add a
+/// `hmms.get` call on the cache-hit path where the original code
+/// uses `cached_path.hmm.?` instead). So this hoist is best framed
+/// as a code-clarity / dead-error-path-removal refactor; any wall
+/// improvement is in the noise.
+///
+/// Pointer-stability invariants (load-bearing):
+///   - `initCache(gene)` is the only site that grows
+///     `scratch_cachefo` / `paths` / `scores`. It runs immediately
+///     above the cache build at the top of each gene-block iteration.
+///   - Within one gene-block iteration, the outer string-keyed maps
+///     don't grow. Inner-map writes (`gp.put(scratch, kset, ...)`,
+///     `cache_list.append(allocator, entry)`, etc.) modify the inner
+///     map's internal pointers but don't relocate the outer-map
+///     value slot.
+///   - `.?` unwraps below would panic in `Debug`/`ReleaseSafe` if
+///     the invariant ever broke; `ReleaseFast` would silently UAF.
+///     The `partis-test.py --paired --safe` rung covers the
+///     `ReleaseSafe` build mode (originally added so the UAF risk
+///     of caching pointers across put-calls would surface loudly in
+///     CI). If you change the locking around `initCache` or add a
+///     new outer-map writer, also re-confirm via that rung.
 const PerGeneCache = struct {
     cachefo: *std.ArrayListUnmanaged(*TrellisEntry),
     paths: *std.AutoHashMapUnmanaged(KSet, TracebackPath),
     scores: *std.AutoHashMapUnmanaged(KSet, f64),
-    model: *Model,
 };
 
 /// Corresponds to C++ `ham::DPHandler`.
@@ -636,6 +658,7 @@ pub const DPHandler = struct {
         kset_alloc: std.mem.Allocator,
         kset: KSet,
         query_seqs: *const Sequences,
+        gene: []const u8,
         gc: *const PerGeneCache,
     ) ![]const u8 {
         const allocator = self.scratchAllocator();
@@ -678,6 +701,13 @@ pub const DPHandler = struct {
         var tmptrell: ?Trellis = null;
         defer if (tmptrell) |*t| t.deinit();
 
+        // Lazy model load. We do NOT hoist this into PerGeneCache: the
+        // original code only paid `hmms.get(gene)` on the cache-miss path
+        // (the cache-hit path in runKSet uses `cached_path.hmm.?` instead).
+        // Phase 0 reports cache-hit at 78–86% of ksets, so hoisting model
+        // would *add* a per-kset `hmms.get` call to that majority path.
+        const model = try self.hmms.get(gene);
+
         var origin: []const u8 = "scratch";
         const trell_ptr: *Trellis = if (cached_trellis == null) blk: {
             // No cache: heap-allocate a TrellisEntry to give the stored trellis
@@ -689,7 +719,7 @@ pub const DPHandler = struct {
             errdefer allocator.destroy(entry);
             entry.query_seqs = try query_seqs.clone(allocator);
             errdefer entry.query_seqs.deinit(allocator);
-            entry.trellis = try Trellis.initWithSeqs(allocator, gc.model, &entry.query_seqs, null);
+            entry.trellis = try Trellis.initWithSeqs(allocator, model, &entry.query_seqs, null);
             errdefer entry.trellis.deinit();
 
             // gc.cachefo is guaranteed non-null by the caller (initCache
@@ -707,7 +737,7 @@ pub const DPHandler = struct {
             // The path items below are explicitly routed through `allocator`
             // (per-query scratch), not `kset_alloc`, since they're stored in
             // `self.paths` and outlive the kset. (Item 4, #342.)
-            tmptrell = try Trellis.initWithSeqs(kset_alloc, gc.model, query_seqs, cached_trellis);
+            tmptrell = try Trellis.initWithSeqs(kset_alloc, model, query_seqs, cached_trellis);
             origin = "chunk";
             break :blk &tmptrell.?;
         };
@@ -717,7 +747,7 @@ pub const DPHandler = struct {
             try trell_ptr.viterbi();
             const sc = trell_ptr.ending_viterbi_log_prob;
             // Store traceback path
-            var path = TracebackPath.initWithModel(gc.model);
+            var path = TracebackPath.initWithModel(model);
             errdefer path.deinit(allocator);
             if (sc != mathutils.NEG_INF) {
                 // Explicitly pass `allocator` (per-query scratch) so the path's
@@ -731,7 +761,7 @@ pub const DPHandler = struct {
             break :blk trell_ptr.ending_forward_log_prob;
         };
 
-        const gene_choice_score = log(gc.model.overall_prob);
+        const gene_choice_score = log(model.overall_prob);
         const final_score = mathutils.addWithMinusInfinities(uncorrected_score, gene_choice_score);
 
         try gc.scores.put(allocator, kset, final_score);
@@ -987,17 +1017,16 @@ pub const DPHandler = struct {
             for (sorted_genes) |gene| {
                 try self.initCache(gene);
 
-                // Hoist all gene-keyed lookups once per gene-block. After
-                // initCache, the outer string-keyed maps don't grow within
-                // this iteration so the inner pointers stay stable. Phase A
-                // measured ~33% of partition wall in HashMap[gene_name]
-                // lookups; this hoist is the primary lever for #366. See
-                // PerGeneCache doc-block.
+                // Hoist the three gene-keyed inner-map pointers once per
+                // gene-block. After initCache(gene), the outer string-keyed
+                // maps don't grow within this iteration so the inner-slot
+                // pointers stay stable. We deliberately do NOT hoist
+                // `self.hmms.get(gene)` — see PerGeneCache doc-block for the
+                // cache-hit-path regression rationale.
                 const gc = PerGeneCache{
                     .cachefo = self.scratch_cachefo.getPtr(gene).?,
                     .paths = self.paths.getPtr(gene).?,
                     .scores = self.scores.getPtr(gene).?,
-                    .model = try self.hmms.get(gene),
                 };
 
                 var origin: []const u8 = "";
@@ -1018,7 +1047,7 @@ pub const DPHandler = struct {
                     try gc.scores.put(scratch, kset, cached_score);
                     origin = "cached";
                 } else {
-                    origin = try self.fillTrellis(allocator, kset, &query_seqs, &gc);
+                    origin = try self.fillTrellis(allocator, kset, &query_seqs, gene, &gc);
                 }
 
                 const gene_score = gc.scores.get(kset) orelse mathutils.NEG_INF;

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -51,6 +51,27 @@ const TrellisEntry = struct {
     trellis: Trellis,
 };
 
+/// Per-gene pointer bundle hoisted once at the top of `runKSet`'s
+/// per-gene loop iteration. Eliminates the redundant
+/// `self.scratch_cachefo.getPtr(gene)`, `self.paths.getPtr(gene)`,
+/// `self.scores.getPtr(gene)`, and `self.hmms.get(gene)` calls that
+/// would otherwise fire 3-6× per gene per kset on the hot path.
+///
+/// Pointers are stable for the lifetime of one gene-block iteration:
+/// `initCache(gene)` populates the outer `scratch_cachefo` / `paths` /
+/// `scores` maps before the cache is built; no other caller adds new
+/// entries to those outer maps within a gene-block; and writes to the
+/// inner kset-keyed maps don't relocate the outer-map value slots.
+/// HMMHolder's gene→Model map is similarly stable post-load. See the
+/// Phase A lever-sizing memo on issue #366 for the wall attribution
+/// (HashMap-by-gene-name = ~33% of partition wall before this hoist).
+const PerGeneCache = struct {
+    cachefo: *std.ArrayListUnmanaged(*TrellisEntry),
+    paths: *std.AutoHashMapUnmanaged(KSet, TracebackPath),
+    scores: *std.AutoHashMapUnmanaged(KSet, f64),
+    model: *Model,
+};
+
 /// Corresponds to C++ `ham::DPHandler`.
 pub const DPHandler = struct {
     algorithm: []const u8,
@@ -560,9 +581,10 @@ pub const DPHandler = struct {
 
     /// Look for a cached kset whose region sequences are a prefix of the
     /// query's per-region undigitized strings (built via `getSubSeqs`).
-    /// Returns null-kset if none found.
-    fn findPartialCacheMatch(self: *DPHandler, region: Region, gene: []const u8, kset: KSet) KSet {
-        const gene_scores = self.scores.get(gene) orelse return KSet{ .v = 0, .d = 0 };
+    /// Returns null-kset if none found. `gene_scores` is the per-gene
+    /// inner map hoisted by the caller (see `PerGeneCache`); replaces
+    /// the prior `self.scores.get(gene)` lookup at this site.
+    fn findPartialCacheMatch(_: *DPHandler, region: Region, gene_scores: *const std.AutoHashMapUnmanaged(KSet, f64), kset: KSet) KSet {
         if (gene_scores.get(kset) != null) return kset;
 
         switch (region) {
@@ -614,7 +636,7 @@ pub const DPHandler = struct {
         kset_alloc: std.mem.Allocator,
         kset: KSet,
         query_seqs: *const Sequences,
-        gene: []const u8,
+        gc: *const PerGeneCache,
     ) ![]const u8 {
         const allocator = self.scratchAllocator();
         perf_counters.bumpFillTrellis();
@@ -624,29 +646,25 @@ pub const DPHandler = struct {
         var cached_trellis: ?*const Trellis = null;
         if (!self.args.no_chunk_cache) {
             perf_counters.bumpChunkCacheLookup();
-            if (self.scratch_cachefo.getPtr(gene)) |cache_list| {
-                for (cache_list.items) |te| {
-                    const cached_seqs = te.query_seqs.seqs.items;
-                    const current_seqs = query_seqs.seqs.items;
-                    if (cached_seqs.len != current_seqs.len) continue;
-                    var all_match = true;
-                    for (cached_seqs, current_seqs) |*cached, *current| {
-                        // cached must START WITH current (prefix match)
-                        if (!std.mem.startsWith(u8, cached.undigitized, current.undigitized)) {
-                            all_match = false;
-                            break;
-                        }
-                    }
-                    if (all_match) {
-                        cached_trellis = &te.trellis;
-                        perf_counters.bumpChunkCacheHit();
+            for (gc.cachefo.items) |te| {
+                const cached_seqs = te.query_seqs.seqs.items;
+                const current_seqs = query_seqs.seqs.items;
+                if (cached_seqs.len != current_seqs.len) continue;
+                var all_match = true;
+                for (cached_seqs, current_seqs) |*cached, *current| {
+                    // cached must START WITH current (prefix match)
+                    if (!std.mem.startsWith(u8, cached.undigitized, current.undigitized)) {
+                        all_match = false;
                         break;
                     }
                 }
+                if (all_match) {
+                    cached_trellis = &te.trellis;
+                    perf_counters.bumpChunkCacheHit();
+                    break;
+                }
             }
         }
-
-        const model = try self.hmms.get(gene);
 
         // Match C++ DPHandler::FillTrellis logic exactly:
         //   - When no cached trellis: create scratch, store it, run algorithm ON THE SCRATCH directly.
@@ -671,23 +689,13 @@ pub const DPHandler = struct {
             errdefer allocator.destroy(entry);
             entry.query_seqs = try query_seqs.clone(allocator);
             errdefer entry.query_seqs.deinit(allocator);
-            entry.trellis = try Trellis.initWithSeqs(allocator, model, &entry.query_seqs, null);
+            entry.trellis = try Trellis.initWithSeqs(allocator, gc.model, &entry.query_seqs, null);
             errdefer entry.trellis.deinit();
 
-            if (self.scratch_cachefo.getPtr(gene)) |cache_list| {
-                try cache_list.append(allocator, entry);
-                break :blk &entry.trellis;
-            } else {
-                // gene not in scratch_cachefo (shouldn't happen after initCache).
-                // Assert so safe builds (Debug, ReleaseSafe — including the
-                // rung-1 UAF-coverage run) panic loudly; ReleaseFast keeps
-                // the cleanup + error-return path as a defensive fallback.
-                std.debug.assert(false);
-                entry.trellis.deinit();
-                entry.query_seqs.deinit(allocator);
-                allocator.destroy(entry);
-                return error.GeneNotInScratchCache;
-            }
+            // gc.cachefo is guaranteed non-null by the caller (initCache
+            // ran before the gc was built — see PerGeneCache doc-block).
+            try gc.cachefo.append(allocator, entry);
+            break :blk &entry.trellis;
         } else blk: {
             // Have cache: temp trellis borrows from the caller's query_seqs
             // (no clone — lifetime is just this call). Backed by the per-kset
@@ -699,7 +707,7 @@ pub const DPHandler = struct {
             // The path items below are explicitly routed through `allocator`
             // (per-query scratch), not `kset_alloc`, since they're stored in
             // `self.paths` and outlive the kset. (Item 4, #342.)
-            tmptrell = try Trellis.initWithSeqs(kset_alloc, model, query_seqs, cached_trellis);
+            tmptrell = try Trellis.initWithSeqs(kset_alloc, gc.model, query_seqs, cached_trellis);
             origin = "chunk";
             break :blk &tmptrell.?;
         };
@@ -709,30 +717,24 @@ pub const DPHandler = struct {
             try trell_ptr.viterbi();
             const sc = trell_ptr.ending_viterbi_log_prob;
             // Store traceback path
-            var path = TracebackPath.initWithModel(model);
+            var path = TracebackPath.initWithModel(gc.model);
             errdefer path.deinit(allocator);
             if (sc != mathutils.NEG_INF) {
                 // Explicitly pass `allocator` (per-query scratch) so the path's
                 // items don't capture the temp trellis's per-kset arena.
                 try trell_ptr.traceback(allocator, &path);
             }
-            if (self.paths.getPtr(gene)) |gene_paths| {
-                try gene_paths.put(allocator, kset, path);
-            } else {
-                path.deinit(allocator);
-            }
+            try gc.paths.put(allocator, kset, path);
             break :blk sc;
         } else blk: {
             try trell_ptr.forward();
             break :blk trell_ptr.ending_forward_log_prob;
         };
 
-        const gene_choice_score = log(model.overall_prob);
+        const gene_choice_score = log(gc.model.overall_prob);
         const final_score = mathutils.addWithMinusInfinities(uncorrected_score, gene_choice_score);
 
-        if (self.scores.getPtr(gene)) |gene_scores| {
-            try gene_scores.put(allocator, kset, final_score);
-        }
+        try gc.scores.put(allocator, kset, final_score);
 
         return origin;
     }
@@ -985,32 +987,41 @@ pub const DPHandler = struct {
             for (sorted_genes) |gene| {
                 try self.initCache(gene);
 
+                // Hoist all gene-keyed lookups once per gene-block. After
+                // initCache, the outer string-keyed maps don't grow within
+                // this iteration so the inner pointers stay stable. Phase A
+                // measured ~33% of partition wall in HashMap[gene_name]
+                // lookups; this hoist is the primary lever for #366. See
+                // PerGeneCache doc-block.
+                const gc = PerGeneCache{
+                    .cachefo = self.scratch_cachefo.getPtr(gene).?,
+                    .paths = self.paths.getPtr(gene).?,
+                    .scores = self.scores.getPtr(gene).?,
+                    .model = try self.hmms.get(gene),
+                };
+
                 var origin: []const u8 = "";
-                const partial_match = self.findPartialCacheMatch(region, gene, kset);
+                const partial_match = self.findPartialCacheMatch(region, gc.scores, kset);
                 if (!partial_match.isNull()) {
                     // Copy path and score from cached kset. Both go into
                     // `self.paths` / `self.scores`, which outlive the kset
                     // — route through `scratch`, not `allocator`.
-                    if (self.paths.getPtr(gene)) |gp| {
-                        if (gp.get(partial_match)) |cached_path| {
-                            var path_copy = TracebackPath.init();
-                            errdefer path_copy.deinit(scratch);
-                            try path_copy.path.appendSlice(scratch, cached_path.path.items);
-                            path_copy.setScore(cached_path.score);
-                            path_copy.setModel(cached_path.hmm.?);
-                            try gp.put(scratch, kset, path_copy);
-                        }
+                    if (gc.paths.get(partial_match)) |cached_path| {
+                        var path_copy = TracebackPath.init();
+                        errdefer path_copy.deinit(scratch);
+                        try path_copy.path.appendSlice(scratch, cached_path.path.items);
+                        path_copy.setScore(cached_path.score);
+                        path_copy.setModel(cached_path.hmm.?);
+                        try gc.paths.put(scratch, kset, path_copy);
                     }
-                    if (self.scores.getPtr(gene)) |gs| {
-                        const cached_score = gs.get(partial_match) orelse mathutils.NEG_INF;
-                        try gs.put(scratch, kset, cached_score);
-                    }
+                    const cached_score = gc.scores.get(partial_match) orelse mathutils.NEG_INF;
+                    try gc.scores.put(scratch, kset, cached_score);
                     origin = "cached";
                 } else {
-                    origin = try self.fillTrellis(allocator, kset, &query_seqs, gene);
+                    origin = try self.fillTrellis(allocator, kset, &query_seqs, &gc);
                 }
 
-                const gene_score = if (self.scores.getPtr(gene)) |gs| gs.get(kset) orelse mathutils.NEG_INF else mathutils.NEG_INF;
+                const gene_score = gc.scores.get(kset) orelse mathutils.NEG_INF;
 
                 // Debug: per-gene viterbi output
                 if (self.args.debug == 2 and std.mem.eql(u8, self.algorithm, "viterbi")) {


### PR DESCRIPTION
## Summary

Hoist `self.scratch_cachefo.getPtr(gene)` / `self.paths.getPtr(gene)` / `self.scores.getPtr(gene)` into a small `PerGeneCache` struct built once per gene-block iteration in `runKSet`, then thread that struct through `fillTrellis` and `findPartialCacheMatch`. Replaces 2-3 redundant string-keyed lookups per (gene, kset) with a single struct of pre-resolved pointers.

**This is a code-clarity/dead-error-path refactor, not a perf win.** Honest cost framing below.

## Honest cost framing (revised after skeptic review)

The first version of this PR hoisted `self.hmms.get(gene)` into `PerGeneCache` and claimed 16-22% wall improvement on the basis of Phase A's "33% HashMap bucket" finding. **That framing was wrong**, and a follow-up commit (`0105a4f1c`) reverts the model hoist:

1. The 24.63% `getIndex__anon_27622` bucket cited in [the Phase A memo](https://github.com/psathyrella/partis/issues/366#issuecomment-4412818846) is the `[]const u8 → *Model` symbol — **HMMHolder.hmms only**. The `scratch_cachefo`/`paths`/`scores` maps appear at **0.00%** in the perf-record (their value-types yield separate `__anon_N` instantiations, none of which surface at the top of the report). The hoist of those three maps therefore addresses essentially zero measurable cost.

2. The original code only called `hmms.get(gene)` on the cache-miss path (the cache-hit branch in `runKSet` reuses `cached_path.hmm.?` from the prior fillTrellis call). Phase 0 reports cache-hit at 78-86% of ksets. **Hoisting `model` into PerGeneCache added a `hmms.get` call on that majority path** — a strict regression. The fix commit reverts to lazy-load inside `fillTrellis`.

## Verification

| Check | Result |
|---|---|
| `partis-test.py --quick` (ReleaseFast + ReleaseSafe) | pass |
| 1k paired partition under ReleaseSafe | completes without panic (validates `.?` unwraps under bounds checking) |
| `partis-test.py --paired` | pass on bcrham steps; pre-existing simulate failure (missing R) and pre-existing single-chain logprob drift, both verified to also exist on the un-modified branch |
| 30k Zig-vs-baseline | all 29994 successful events bit-equal; 4/5 invalid placeholder UIDs reorder, but a baseline rerun produces a *third* ordering — pre-existing nondeterminism from `n_procs=10` timing affecting the partis Python failed-queries set union. The 30k parity gate has been measuring a property that doesn't hold for the baseline either. |

## Wall measurement (pooled across May 8 + May 9, n=6 baseline + n=9 lever1 variants)

```
baseline (May 8 + May 9, n=6):           bcrham mean 168.4s median 167.5s
lever1 with model hoist (May 8 + May 9): bcrham mean 166.9s median 165.0s   (+0.9% / +1.5%)
lever1 without model hoist (May 9, n=3): bcrham mean 171.0s median 168.5s   (-1.5% / -0.6%)
```

All three groups overlap within ±2% on a within-group sd of ~7-8s. The wall delta is sign-noise; the original "1.5% improvement" headline was the favorable end of the noise band.

## Why merge anyway?

- **Code clarity**: eliminates 2-3 redundant string lookups in source per gene-block iteration; makes pointer lifetime explicit through the `PerGeneCache` struct.
- **Dead error path removed**: the `assert(false)` + `error.GeneNotInScratchCache` branch in fillTrellis was unreachable since #342 item 5 made `initCache` populate all three maps with the same key. Drops it.
- **Sets up future work**: a Glomerator-side investigation may want a similar pointer-bundle pattern for its own gene/UID-keyed caches.

## Why not merge

- Wall delta is zero. Adds a small struct + threading through one extra function for a refactor with no measured benefit.

## Followups

- [Correction comment](https://github.com/psathyrella/partis/issues/366#issuecomment-...) posted on #366 retracting the wrong "Lever 5 — Glomerator" sizing in [the Lever 1 followup memo](https://github.com/psathyrella/partis/issues/366#issuecomment-4414013335) — Glomerator's symbols (`getCachefo` 4.5%, `merge` 3.4%, etc.) are already attributed in the perf report and don't fold into the 24.63% getIndex bucket. Whatever HashMap caching exists in Glomerator is keyed by UID strings and seq strings, not gene names.
- Parity gate needs to sort failed-events by UID before byte-diffing, since the current invariant doesn't hold even for baseline-vs-baseline reruns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)