### PR TITLE
zig: pre-resolve *Model in initCache (#366 Lever 5, doc-only — close without merge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ packages/RPANDA/lib/
 /packages/zig-core/.zig-cache/
 /packages/zig-core/zig-cache/
 /packages/zig-core/.zig-install/
+/.claude/

--- a/bin/partis
+++ b/bin/partis
@@ -1849,4 +1849,10 @@ random.seed(args.random_seed)
 numpy.random.seed(args.random_seed)
 start = time.time()
 args.func(args)
-print('      total time: %.1f' % (time.time()-start))
+total_time = time.time() - start
+print('      total time: %.1f' % total_time)
+from partis import partitiondriver
+bcrham_t, bcrham_n = partitiondriver.get_bcrham_summary()
+if bcrham_n > 0:
+    pct = 100.0 * bcrham_t / total_time if total_time > 0 else 0.0
+    print('      bcrham time: %.1f (%.1f%% of total, %d calls)' % (bcrham_t, pct, bcrham_n))

--- a/bin/partis-30k-parity-test.sh
+++ b/bin/partis-30k-parity-test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# 30k Zig-vs-C++ partition parity gate (issue #375).
+#
+# Runs an unbounded paired-loci partition with the Zig and C++ backends on the
+# same 30k input, then compares cluster membership and per-event annotation
+# fields. Exits 0 if identical, 1 otherwise. The 5k partis-test.py rung doesn't
+# exercise enough cache round-trips to surface tiebreak-density-dependent
+# divergences (#375 was latent until 30k).
+#
+# Usage:
+#   bin/partis-30k-parity-test.sh [INFILE [OUTBASE [N]]]
+#
+# Defaults:
+#   INFILE = /tmp/paired-paper-all-seqs.fa
+#   OUTBASE = /tmp/parity-30k-test
+#   N = 30000
+#
+# Wall budget on pax (32-core Zen 5):
+#   ~50 min Zig + ~100 min C++ + a few min compare = ~2.5 h total when sequential.
+#   Backends run sequentially to keep the host responsive; bump --n-procs in
+#   this script to parallelize within a backend.
+
+set -euo pipefail
+
+INFILE="${1:-/tmp/paired-paper-all-seqs.fa}"
+OUTBASE="${2:-/tmp/parity-30k-test}"
+N="${3:-30000}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPARE="${REPO_ROOT}/bin/zig-compare.py"
+if [[ ! -x "${COMPARE}" ]]; then
+  echo "ERROR: cannot find zig-compare.py at ${COMPARE}" >&2
+  exit 2
+fi
+
+if [[ ! -f "${INFILE}" ]]; then
+  echo "ERROR: input file ${INFILE} does not exist" >&2
+  exit 2
+fi
+
+CPP_DIR="${OUTBASE}-cpp"
+ZIG_DIR="${OUTBASE}-zig"
+
+run_backend() {
+  local backend="$1" outdir="$2"
+  shift 2
+  rm -rf "${outdir}"
+  echo ">> running ${backend} backend → ${outdir}"
+  PYTHONHASHSEED=0 python3 "${REPO_ROOT}/bin/partis" partition --paired-loci \
+    --paired-outdir "${outdir}" \
+    --infname "${INFILE}" --n-max-queries "${N}" \
+    --random-seed 1 --n-procs 10 --no-time-based-n-proc-reduction \
+    --dont-write-git-info "$@"
+}
+
+# C++ first (slower), then Zig — sequential keeps the host responsive at the
+# usual 10 procs. Either order works; the partition is deterministic.
+run_backend "C++"  "${CPP_DIR}"
+run_backend "Zig"  "${ZIG_DIR}"  --zig
+
+echo ">> comparing"
+"${COMPARE}" "${CPP_DIR}" "${ZIG_DIR}"

--- a/bin/zig-compare.py
+++ b/bin/zig-compare.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Diff two partis paired-loci output dirs for byte-equality on partition + annotations.
+
+Usage: zig-compare.py <baseline_dir> <new_dir>
+
+Companion to bin/partis-30k-parity-test.sh (issue #375 cpp-mirror gate).
+Exit 0 if identical, 1 otherwise.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+from partis.clusterpath import ClusterPath
+
+
+def best_partition(path):
+    cpath = ClusterPath()
+    cpath.readfile(path)
+    return sorted(tuple(sorted(c)) for c in cpath.partitions[cpath.i_best])
+
+
+FIELDS = ('naive_seq', 'v_gene', 'd_gene', 'j_gene',
+          'v_3p_del', 'd_5p_del', 'd_3p_del', 'j_5p_del',
+          'vd_insertion', 'dj_insertion', 'cdr3_length')
+
+
+def diff_pair(base, new):
+    n_diffs = 0
+    for locus in ('igh', 'igk', 'igl'):
+        bp = f'{base}/igh+igk/partition-{locus}.yaml'
+        np_ = f'{new}/igh+igk/partition-{locus}.yaml'
+        if not os.path.exists(bp):
+            bp = f'{base}/igh+igl/partition-{locus}.yaml'
+            np_ = f'{new}/igh+igl/partition-{locus}.yaml'
+        if not os.path.exists(bp):
+            print(f'{locus}: no baseline file (skipping)')
+            continue
+        if not os.path.exists(np_):
+            print(f'{locus}: MISSING in new ({np_})')
+            n_diffs += 1
+            continue
+        bpart = best_partition(bp)
+        npart = best_partition(np_)
+        if bpart != npart:
+            print(f'{locus}: PARTITION DIFF ({len(bpart)} vs {len(npart)} clusters)')
+            n_diffs += 1
+            continue
+        with open(bp) as f:
+            bd = json.load(f)
+        with open(np_) as f:
+            nd = json.load(f)
+        bk = {tuple(sorted(e['unique_ids'])): e for e in bd['events']}
+        nk = {tuple(sorted(e['unique_ids'])): e for e in nd['events']}
+        if set(bk) != set(nk):
+            only_b = set(bk) - set(nk)
+            only_n = set(nk) - set(bk)
+            print(f'{locus}: EVENT-KEY DIFF (only in base: {len(only_b)}, only in new: {len(only_n)})')
+            n_diffs += 1
+            continue
+        field_diffs = 0
+        for k in bk:
+            for f in FIELDS:
+                if bk[k].get(f) != nk[k].get(f):
+                    field_diffs += 1
+                    if field_diffs <= 3:
+                        print(f'{locus} {k[:1]}...: {f} diff: {bk[k].get(f)} vs {nk[k].get(f)}')
+        if field_diffs:
+            print(f'{locus}: {field_diffs} FIELD DIFFS across {len(bk)} events')
+            n_diffs += 1
+        else:
+            print(f'{locus}: {len(bk)} events identical')
+    return n_diffs
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit(__doc__)
+    base, new = sys.argv[1], sys.argv[2]
+    n = diff_pair(base, new)
+    if n:
+        print(f'\nFAILED: {n} loci differ')
+        sys.exit(1)
+    print('\nOK: identical')
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/zig-perf-counters-aggregate.py
+++ b/bin/zig-perf-counters-aggregate.py
@@ -8,8 +8,13 @@ all queries.
 
 The log file is produced by partis-zig-core when built with
 -Dperf-counters=true and run with PARTIS_ZIG_PERF_LOG=<path> in the env. See
-packages/zig-core/src/ham/perf_counters.zig for the metric definitions and
-PERF-NEXT.md Phase 0.1 / 0.2 for the priors this is meant to test against.
+packages/zig-core/src/ham/perf_counters.zig for the metric definitions.
+
+These counters pin denominators (active-state distribution, n_ksets,
+fillTrellis call counts, addInLogSpace call counts, chunk-cache hit rate)
+for the perf-work cost claims tracked in issue #366
+(https://github.com/psathyrella/partis/issues/366). Originally landed in
+PR #368.
 
 Usage: zig-perf-counters-aggregate.py <log-file>
 """

--- a/bin/zig-perf-counters-aggregate.py
+++ b/bin/zig-perf-counters-aggregate.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Aggregate PERFCOUNTER + PERFCOUNTER_CACHE lines from a perf log file.
+
+Per-query summary: median/p95/max of ksets, fillTrellis calls, addInLogSpace
+calls, addInLogSpace+log_exp work calls, active-state distribution stats, and
+chunk-cache hit rate. Plus a chunk-cache prefix-list-length histogram across
+all queries.
+
+The log file is produced by partis-zig-core when built with
+-Dperf-counters=true and run with PARTIS_ZIG_PERF_LOG=<path> in the env. See
+packages/zig-core/src/ham/perf_counters.zig for the metric definitions and
+PERF-NEXT.md Phase 0.1 / 0.2 for the priors this is meant to test against.
+
+Usage: zig-perf-counters-aggregate.py <log-file>
+"""
+import re
+import sys
+from collections import defaultdict
+
+
+def parse_kv(line):
+    return {m.group(1): m.group(2) for m in re.finditer(r"(\w+)=(\S+)", line)}
+
+
+def stats(xs):
+    if not xs:
+        return None
+    xs = sorted(xs)
+    n = len(xs)
+    return {
+        "n": n,
+        "min": xs[0],
+        "median": xs[n // 2],
+        "p95": xs[int(n * 0.95)] if n > 1 else xs[0],
+        "max": xs[-1],
+        "mean": sum(xs) / n,
+        "total": sum(xs),
+    }
+
+
+def main(path):
+    by_alg = defaultdict(lambda: {
+        "ksets": [], "fillTrellis": [], "addInLogSpace": [],
+        "addInLogSpace_log_exp": [], "chunk_hits": [], "chunk_lookups": [],
+        "active_med": [], "active_p95": [], "active_max": [], "active_positions": [],
+        "n_seqs": [],
+    })
+    cache_buckets = defaultdict(lambda: defaultdict(int))
+    n_lines = 0
+    n_cache_lines = 0
+
+    for line in open(path):
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("PERFCOUNTER_CACHE"):
+            n_cache_lines += 1
+            kv = parse_kv(line[len("PERFCOUNTER_CACHE "):])
+            alg = kv.get("alg", "?")
+            for k, v in kv.items():
+                if k in ("alg", "q"):
+                    continue
+                cache_buckets[alg][k] += int(v)
+            continue
+        if not line.startswith("PERFCOUNTER"):
+            continue
+        n_lines += 1
+        kv = parse_kv(line[len("PERFCOUNTER "):])
+        alg = kv.get("alg", "?")
+        d = by_alg[alg]
+        d["n_seqs"].append(int(kv["n_seqs"]))
+        d["ksets"].append(int(kv["ksets"]))
+        d["fillTrellis"].append(int(kv["fillTrellis"]))
+        d["addInLogSpace"].append(int(kv["addInLogSpace"]))
+        d["addInLogSpace_log_exp"].append(int(kv["addInLogSpace_log_exp"]))
+        h, l = kv["chunk_hits"].split("/")
+        d["chunk_hits"].append(int(h))
+        d["chunk_lookups"].append(int(l))
+        d["active_med"].append(int(kv["active_states_med"]))
+        d["active_p95"].append(int(kv["active_states_p95"]))
+        d["active_max"].append(int(kv["active_states_max"]))
+        d["active_positions"].append(int(kv["active_states_positions"]))
+
+    print(f"# parsed {n_lines} PERFCOUNTER + {n_cache_lines} PERFCOUNTER_CACHE lines from {path}")
+    for alg, d in by_alg.items():
+        nq = len(d["ksets"])
+        print(f"\n## algorithm={alg}, n_queries={nq}")
+
+        def row(name, xs, fmt="{:>12,d}"):
+            s = stats(xs)
+            if s is None:
+                return
+            print(f"  {name:<32}  median={fmt.format(s['median'])}  p95={fmt.format(s['p95'])}  max={fmt.format(s['max'])}  mean={s['mean']:>12,.1f}  total={s['total']:>14,d}")
+
+        row("n_seqs (per query)", d["n_seqs"])
+        row("ksets (per query)", d["ksets"])
+        row("fillTrellis calls (per query)", d["fillTrellis"])
+        row("addInLogSpace calls (per query)", d["addInLogSpace"])
+        row("addInLogSpace+log_exp (per query)", d["addInLogSpace_log_exp"])
+
+        # active states are already per-query medians/p95/maxes; aggregate across queries
+        row("active_states median-of-medians", d["active_med"])
+        row("active_states median-of-p95s", d["active_p95"])
+        row("active_states median-of-maxes", d["active_max"])
+        row("active_positions (per query)", d["active_positions"])
+
+        # chunk-cache rate
+        total_hits = sum(d["chunk_hits"])
+        total_lookups = sum(d["chunk_lookups"])
+        if total_lookups:
+            print(f"  {'chunk_cache_rate':<32}  hits/lookups = {total_hits:,} / {total_lookups:,} = {100*total_hits/total_lookups:.1f}%")
+
+    if cache_buckets:
+        print("\n## chunk-cache prefix-list-length histogram (across all queries)")
+        for alg, buckets in cache_buckets.items():
+            print(f"  alg={alg}")
+            order = ["0", "1", "2", "3", "4", "5", "6_9", "10_19", "20_49", "50_99", "100_199", "200p"]
+            total = sum(buckets.values())
+            for k in order:
+                v = buckets.get(k, 0)
+                pct = 100 * v / total if total else 0
+                print(f"    {k:>8}: {v:>10,d}  ({pct:>5.1f}%)")
+            print(f"    {'total':>8}: {total:>10,d}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/bin/zig-perf-counters-run.sh
+++ b/bin/zig-perf-counters-run.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Build partis-zig-core with -Dperf-counters=true and run a partition workload
+# with PARTIS_ZIG_PERF_LOG set, so each query emits one PERFCOUNTER line plus
+# one PERFCOUNTER_CACHE line (chunk-cache prefix-list-length histogram) into
+# the log. See packages/zig-core/src/ham/perf_counters.zig for the metric set
+# and packages/zig-core/PERF-NEXT.md Phase 0.1/0.2 for what these are for.
+#
+# Pair with bin/zig-perf-counters-aggregate.py to compute median/p95/max
+# distributions and chunk-cache hit rate from the resulting log.
+#
+# Usage:
+#   bin/zig-perf-counters-run.sh [INFILE [OUTBASE [N [N_PROCS]]]]
+#
+# Defaults:
+#   INFILE  = /tmp/paired-paper-all-seqs.fa
+#   OUTBASE = /tmp/perf-counters-test
+#   N       = 1000
+#   N_PROCS = 1   (PERF-NEXT.md 0.1 specifies n-procs 1 for clean wall-time
+#                 numbers; for distribution stats only, n_procs > 1 is fine)
+#
+# After the run, the perf log path is:
+#   $OUTBASE/zig-perf.log
+# and the aggregated summary path is:
+#   $OUTBASE/aggregate.txt
+#
+# The script restores the un-instrumented ReleaseFast build at the end so the
+# working tree's binary is back to bit-equality-baseline state.
+
+set -euo pipefail
+
+INFILE="${1:-/tmp/paired-paper-all-seqs.fa}"
+OUTBASE="${2:-/tmp/perf-counters-test}"
+N="${3:-1000}"
+N_PROCS="${4:-1}"
+
+PARTIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ZIG_CORE_DIR="$PARTIS_DIR/packages/zig-core"
+PERF_LOG="$OUTBASE/zig-perf.log"
+AGG_OUT="$OUTBASE/aggregate.txt"
+
+mkdir -p "$OUTBASE"
+rm -f "$PERF_LOG" "$AGG_OUT"
+
+# ── 1. Build with perf counters enabled ─────────────────────────────────────
+echo "==> building partis-zig-core with -Dperf-counters=true"
+(cd "$ZIG_CORE_DIR" && zig build -Doptimize=ReleaseFast -Dperf-counters=true)
+
+# ── 2. Run partition with the perf log set ──────────────────────────────────
+RUN_OUTBASE="$OUTBASE/run-output"
+rm -rf "$RUN_OUTBASE"
+mkdir -p "$RUN_OUTBASE"
+
+echo "==> running partition: N=$N, n_procs=$N_PROCS, infile=$INFILE"
+echo "==> perf log: $PERF_LOG"
+
+# shellcheck disable=SC1091
+source "$PARTIS_DIR/.venv/bin/activate"
+
+PARTIS_ZIG_PERF_LOG="$PERF_LOG" PYTHONHASHSEED=0 python3 "$PARTIS_DIR/bin/partis" \
+    partition --paired-loci \
+    --paired-outdir "$RUN_OUTBASE" \
+    --infname "$INFILE" \
+    --n-max-queries "$N" \
+    --random-seed 1 \
+    --n-procs "$N_PROCS" \
+    --no-time-based-n-proc-reduction \
+    --dont-write-git-info \
+    --zig
+
+# ── 3. Aggregate ────────────────────────────────────────────────────────────
+echo "==> aggregating $PERF_LOG → $AGG_OUT"
+python3 "$PARTIS_DIR/bin/zig-perf-counters-aggregate.py" "$PERF_LOG" | tee "$AGG_OUT"
+
+# ── 4. Restore un-instrumented build ────────────────────────────────────────
+echo "==> restoring un-instrumented partis-zig-core (ReleaseFast, no perf counters)"
+(cd "$ZIG_CORE_DIR" && zig build -Doptimize=ReleaseFast)
+
+echo "==> done. raw log: $PERF_LOG    summary: $AGG_OUT"

--- a/bin/zig-perf-counters-run.sh
+++ b/bin/zig-perf-counters-run.sh
@@ -2,8 +2,14 @@
 # Build partis-zig-core with -Dperf-counters=true and run a partition workload
 # with PARTIS_ZIG_PERF_LOG set, so each query emits one PERFCOUNTER line plus
 # one PERFCOUNTER_CACHE line (chunk-cache prefix-list-length histogram) into
-# the log. See packages/zig-core/src/ham/perf_counters.zig for the metric set
-# and packages/zig-core/PERF-NEXT.md Phase 0.1/0.2 for what these are for.
+# the log. See packages/zig-core/src/ham/perf_counters.zig for the metric set.
+#
+# These counters pin denominators for the perf-work cost claims tracked in
+# issue #366 (https://github.com/psathyrella/partis/issues/366) — the
+# distributions every later perf-item's wall claim depends on:
+# per-query active-state median/p95/max, n_ksets, fillTrellis call counts,
+# addInLogSpace call counts, and chunk-cache hit rate. Originally landed in
+# PR #368.
 #
 # Pair with bin/zig-perf-counters-aggregate.py to compute median/p95/max
 # distributions and chunk-cache hit rate from the resulting log.
@@ -15,8 +21,10 @@
 #   INFILE  = /tmp/paired-paper-all-seqs.fa
 #   OUTBASE = /tmp/perf-counters-test
 #   N       = 1000
-#   N_PROCS = 1   (PERF-NEXT.md 0.1 specifies n-procs 1 for clean wall-time
-#                 numbers; for distribution stats only, n_procs > 1 is fine)
+#   N_PROCS = 1   (single-proc keeps wall-time numbers clean for cost-claim
+#                 sizing — multi-proc smears the symbol map across child PIDs
+#                 and adds scheduling jitter. For distribution stats only,
+#                 n_procs > 1 is fine.)
 #
 # After the run, the perf log path is:
 #   $OUTBASE/zig-perf.log

--- a/packages/zig-core/build.zig
+++ b/packages/zig-core/build.zig
@@ -4,6 +4,19 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    // -Dperf-counters: gate the issue-#366 phase-0 diagnostics counters in
+    // src/ham/perf_counters.zig. When false (default), every counter site
+    // is `if (enabled) { ... }` with `enabled = false`, so the inner-loop
+    // calls compile to nothing and bit-equal output is preserved.
+    const perf_counters = b.option(
+        bool,
+        "perf-counters",
+        "Enable Phase-0 perf counters (issue #366). Default false; counters compile out when off.",
+    ) orelse false;
+    const perf_opts = b.addOptions();
+    perf_opts.addOption(bool, "perf_counters", perf_counters);
+    const build_options_module = perf_opts.createModule();
+
     // ── partis-zig-core executable: bcrham-compatible CLI ────────────────
     // `zig build` produces this by default. No external library deps.
     const exe = b.addExecutable(.{
@@ -14,6 +27,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    exe.root_module.addImport("build_options", build_options_module);
     // Link libc so release builds can use std.heap.c_allocator (malloc/free),
     // which avoids GPA's per-allocation tracking overhead.
     exe.root_module.linkSystemLibrary("c", .{});
@@ -32,6 +46,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    compare.root_module.addImport("build_options", build_options_module);
     b.installArtifact(compare);
 
     // ── lib: C ABI shared library (requires ig-sw sources from partis) ───
@@ -45,6 +60,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    cabi_mod.addImport("build_options", build_options_module);
     if (igsw_src.len > 0) {
         cabi_mod.addIncludePath(.{ .cwd_relative = igsw_src });
     }
@@ -96,6 +112,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    ham_test_mod.addImport("build_options", build_options_module);
     // Link libc + glibc_math shim so tests that exercise mathutils.log/exp
     // resolve `glibc_log` / `glibc_exp`. Without these, unit tests linking
     // anything that uses the math hot path fail with "undefined symbol:

--- a/packages/zig-core/build.zig
+++ b/packages/zig-core/build.zig
@@ -35,6 +35,11 @@ pub fn build(b: *std.Build) void {
     // to actual glibc (dynamic 'U' symbols) rather than Zig's compiler-rt
     // (local 't' symbols that may differ from glibc on some CPUs).
     exe.addCSourceFile(.{ .file = b.path("src/ham/glibc_math.c"), .flags = &.{ "-O2", "-fno-builtin" } });
+    // fast_math.c — fast_softplus LUT (issue #366 item 3.2). Mirrors
+    // packages/ham/src/fast_math.c on the C++ side; both must stay in sync.
+    // -ffp-contract=off keeps the linear-interp arithmetic bit-deterministic
+    // across compilers (cheap insurance for cross-backend bit equality).
+    exe.addCSourceFile(.{ .file = b.path("src/ham/fast_math.c"), .flags = &.{ "-O3", "-ffp-contract=off", "-fno-builtin" } });
     b.installArtifact(exe);
 
     // ── compare: equivalence harness binary ──────────────────────────────
@@ -120,6 +125,7 @@ pub fn build(b: *std.Build) void {
     ham_test_mod.linkSystemLibrary("c", .{});
     const unit_tests = b.addTest(.{ .root_module = ham_test_mod });
     unit_tests.addCSourceFile(.{ .file = b.path("src/ham/glibc_math.c"), .flags = &.{ "-O2", "-fno-builtin" } });
+    unit_tests.addCSourceFile(.{ .file = b.path("src/ham/fast_math.c"), .flags = &.{ "-O3", "-ffp-contract=off", "-fno-builtin" } });
     const run_unit_tests = b.addRunArtifact(unit_tests);
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_unit_tests.step);

--- a/packages/zig-core/src/ham/args.zig
+++ b/packages/zig-core/src/ham/args.zig
@@ -64,10 +64,10 @@ pub const Args = struct {
     ambig_base: []u8,
     seed_unique_id: []u8,
 
-    hamming_fraction_bound_lo: f32,
-    hamming_fraction_bound_hi: f32,
-    logprob_ratio_threshold: f32,
-    max_logprob_drop: f32,
+    hamming_fraction_bound_lo: f64,
+    hamming_fraction_bound_hi: f64,
+    logprob_ratio_threshold: f64,
+    max_logprob_drop: f64,
 
     debug: i32,
     naive_hamming_cluster: i32,
@@ -108,7 +108,7 @@ pub const Args = struct {
             .seed_unique_id = try allocator.dupe(u8, ""),
             .hamming_fraction_bound_lo = 0.0,
             .hamming_fraction_bound_hi = 1.0,
-            .logprob_ratio_threshold = -std.math.inf(f32),
+            .logprob_ratio_threshold = -std.math.inf(f64),
             .max_logprob_drop = -1.0,
             .debug = 0,
             .naive_hamming_cluster = 0,

--- a/packages/zig-core/src/ham/bcr_utils/reco_event.zig
+++ b/packages/zig-core/src/ham/bcr_utils/reco_event.zig
@@ -16,7 +16,7 @@ pub const RecoEvent = struct {
     /// Insertion sequences: "fv", "vd", "dj", "jf".
     insertions: std.StringHashMapUnmanaged([]u8),
     naive_seq: []u8,
-    score: f32,
+    score: f64,
     cyst_position: i32,
     tryp_position: i32,
     cdr3_length: i32,
@@ -107,7 +107,7 @@ pub const RecoEvent = struct {
     }
 
     pub fn setScore(self: *RecoEvent, s: f64) void {
-        self.score = @floatCast(s);
+        self.score = s;
     }
 
     pub fn clear(self: *RecoEvent, allocator: std.mem.Allocator) void {

--- a/packages/zig-core/src/ham/bcr_utils/result.zig
+++ b/packages/zig-core/src/ham/bcr_utils/result.zig
@@ -70,8 +70,13 @@ pub const Result = struct {
         _ = _gl;
         std.debug.assert(!self.finalized);
 
-        // Sort events descending by score
-        std.mem.sort(RecoEvent, self.events.items, {}, struct {
+        // Sort events descending by score. STABLE sort to make tied scores
+        // resolve to first-pushed (deterministic across runs and backends).
+        // Ties happen at 30k+: f32 score truncation (Result::SetScore @floatCast)
+        // can collapse close f64 viterbi scores, and unstable pdqsort/introsort
+        // would otherwise pick different "best" events between Zig and C++ —
+        // which cascades through naive_seq → hfrac → cluster merges (#375).
+        std.sort.block(RecoEvent, self.events.items, {}, struct {
             fn desc(_: void, a: RecoEvent, b: RecoEvent) bool {
                 return a.score > b.score;
             }

--- a/packages/zig-core/src/ham/bcr_utils/result.zig
+++ b/packages/zig-core/src/ham/bcr_utils/result.zig
@@ -72,10 +72,11 @@ pub const Result = struct {
 
         // Sort events descending by score. STABLE sort to make tied scores
         // resolve to first-pushed (deterministic across runs and backends).
-        // Ties happen at 30k+: f32 score truncation (Result::SetScore @floatCast)
-        // can collapse close f64 viterbi scores, and unstable pdqsort/introsort
-        // would otherwise pick different "best" events between Zig and C++ —
-        // which cascades through naive_seq → hfrac → cluster merges (#375).
+        // With score stored as f64 (#377) the f32-collapse failure mode from
+        // #375 is gone, but two ksets can still produce machine-epsilon-equal
+        // f64 scores; an unstable pdqsort/introsort would otherwise pick
+        // different "best" events between Zig and C++, cascading through
+        // naive_seq → hfrac → cluster merges. Originally added in #375.
         std.sort.block(RecoEvent, self.events.items, {}, struct {
             fn desc(_: void, a: RecoEvent, b: RecoEvent) bool {
                 return a.score > b.score;

--- a/packages/zig-core/src/ham/bcrham.zig
+++ b/packages/zig-core/src/ham/bcrham.zig
@@ -97,7 +97,7 @@ pub fn runAlgorithm(
         var dph = try DPHandler.init(allocator, args.algorithm, args, gl, hmms);
         defer dph.deinit();
 
-        var result = try dph.run(qseq_ptrs, kbounds, only_genes, @floatCast(qrow.mut_freq), true);
+        var result = try dph.run(qseq_ptrs, kbounds, only_genes, qrow.mut_freq, true);
         defer result.deinit();
 
         if (result.no_path) {
@@ -159,7 +159,7 @@ pub fn run(allocator: std.mem.Allocator, argv: []const [*:0]const u8) !void {
             .{ "--random-seed", "random_seed" },
             .{ "--min-largest-cluster-size", "min_largest_cluster_size" },
         };
-        const f32_flags = .{
+        const f64_flags = .{
             .{ "--hamming-fraction-bound-lo", "hamming_fraction_bound_lo" },
             .{ "--hamming-fraction-bound-hi", "hamming_fraction_bound_hi" },
             .{ "--logprob-ratio-threshold", "logprob_ratio_threshold" },
@@ -212,9 +212,9 @@ pub fn run(allocator: std.mem.Allocator, argv: []const [*:0]const u8) !void {
                     matched = true;
                 }
             }
-            inline for (f32_flags) |entry| {
+            inline for (f64_flags) |entry| {
                 if (std.mem.eql(u8, flag, entry[0])) {
-                    @field(args, entry[1]) = try std.fmt.parseFloat(f32, val);
+                    @field(args, entry[1]) = try std.fmt.parseFloat(f64, val);
                     matched = true;
                 }
             }

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -34,117 +34,6 @@ const GeneKSetKey = struct {
     kset: KSet,
 };
 
-/// Per-gene dense score grid over the kset rectangle. Replaces the
-/// `AutoHashMapUnmanaged(KSet, f64)` inner-map of `DPHandler.scores`
-/// (item 2.1 of #366). The C++ `map<KSet, double>` it descends from gave
-/// `findPartialCacheMatch` an `O(n_filled_ksets)` scan per call, called
-/// `n_genes × 3 × n_ksets` times per query — `O(n_genes × n_ksets²)`
-/// per query of map iteration. The dense grid replaces that with O(1)
-/// direct lookup and an `O(d_dim)` (V-region) or `O(v_dim)` (J-region)
-/// bounded scan, plus drops the per-cell HashMap pointer-chasing.
-///
-/// Layout: row-major `[v_dim * d_dim]` indexed as
-/// `idx = (k_v - kgrid_vmin) * d_dim + (k_d - kgrid_dmin)`. The query's
-/// `kbounds` pin both the offsets and the dims, so the grid covers
-/// every kset that `run()` will ever write.
-///
-/// "Unfilled" is tracked by a parallel `DynamicBitSetUnmanaged` rather
-/// than a NaN sentinel in `cells`. The bitset is 1 bit per cell (memset 0
-/// = 1/64 the bandwidth of a NaN memset over the f64 backing array), so
-/// the per-gene init cost stays small even when most cells go unread —
-/// which is the common case in partition workloads, where many
-/// (gene, kset) pairs are never visited.
-const ScoreGrid = struct {
-    cells: []f64,
-    filled: std.DynamicBitSetUnmanaged,
-    v_dim: usize,
-    d_dim: usize,
-
-    fn init(allocator: std.mem.Allocator, v_dim: usize, d_dim: usize) !ScoreGrid {
-        const total = v_dim * d_dim;
-        const cells = try allocator.alloc(f64, total);
-        errdefer allocator.free(cells);
-        // Cells are intentionally NOT initialised — `filled` gates every read,
-        // so an unfilled cell is never observed.
-        const filled = try std.DynamicBitSetUnmanaged.initEmpty(allocator, total);
-        return .{ .cells = cells, .filled = filled, .v_dim = v_dim, .d_dim = d_dim };
-    }
-
-    fn deinit(self: *ScoreGrid, allocator: std.mem.Allocator) void {
-        self.filled.deinit(allocator);
-        allocator.free(self.cells);
-    }
-
-    inline fn idx(self: *const ScoreGrid, v_off: usize, d_off: usize) usize {
-        return v_off * self.d_dim + d_off;
-    }
-
-    inline fn isFilled(self: *const ScoreGrid, v_off: usize, d_off: usize) bool {
-        return self.filled.isSet(self.idx(v_off, d_off));
-    }
-
-    inline fn get(self: *const ScoreGrid, v_off: usize, d_off: usize) ?f64 {
-        const i = self.idx(v_off, d_off);
-        return if (self.filled.isSet(i)) self.cells[i] else null;
-    }
-
-    inline fn put(self: *ScoreGrid, v_off: usize, d_off: usize, score: f64) void {
-        const i = self.idx(v_off, d_off);
-        self.cells[i] = score;
-        self.filled.set(i);
-    }
-};
-
-/// Per-gene dense traceback-path grid. Mirrors `ScoreGrid` for the
-/// `DPHandler.paths` map; only allocated under the viterbi algorithm
-/// (forward leaves the gene's entry absent from the outer map).
-///
-/// "Unfilled" is tracked by a parallel `DynamicBitSetUnmanaged` so the
-/// `cells` slice can be left uninitialised — skipping a per-cell
-/// `TracebackPath.init()` over `v_dim × d_dim` cells. The same logic as
-/// `ScoreGrid`: under partition-style workloads, most cells go unread,
-/// and the prior eager init was the dominant cost.
-const PathGrid = struct {
-    cells: []TracebackPath,
-    filled: std.DynamicBitSetUnmanaged,
-    v_dim: usize,
-    d_dim: usize,
-
-    fn init(allocator: std.mem.Allocator, v_dim: usize, d_dim: usize) !PathGrid {
-        const total = v_dim * d_dim;
-        const cells = try allocator.alloc(TracebackPath, total);
-        errdefer allocator.free(cells);
-        // See `ScoreGrid.init` — `filled` gates every read, cells stay garbage
-        // until written.
-        const filled = try std.DynamicBitSetUnmanaged.initEmpty(allocator, total);
-        return .{ .cells = cells, .filled = filled, .v_dim = v_dim, .d_dim = d_dim };
-    }
-
-    fn deinit(self: *PathGrid, allocator: std.mem.Allocator) void {
-        // Walk only filled cells: unfilled cells hold uninitialised memory
-        // and `TracebackPath.deinit` would read its `path` ArrayList field.
-        var it = self.filled.iterator(.{});
-        while (it.next()) |i| self.cells[i].deinit(allocator);
-        self.filled.deinit(allocator);
-        allocator.free(self.cells);
-    }
-
-    inline fn idx(self: *const PathGrid, v_off: usize, d_off: usize) usize {
-        return v_off * self.d_dim + d_off;
-    }
-
-    inline fn getPtr(self: *PathGrid, v_off: usize, d_off: usize) ?*TracebackPath {
-        const i = self.idx(v_off, d_off);
-        return if (self.filled.isSet(i)) &self.cells[i] else null;
-    }
-
-    inline fn put(self: *PathGrid, v_off: usize, d_off: usize, path: TracebackPath) void {
-        const i = self.idx(v_off, d_off);
-        self.cells[i] = path;
-        self.filled.set(i);
-    }
-};
-
 /// Cached trellis entry. Owns the Sequences the trellis was built over.
 ///
 /// The entry itself is **heap-allocated** and the cache list holds pointers
@@ -197,29 +86,14 @@ pub const DPHandler = struct {
     /// call (item 5 of #342). `scores` owns the duped key bytes; `clear()`
     /// frees keys only when iterating `scores` to avoid a triple-free.
     scratch_cachefo: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(*TrellisEntry)),
-    /// paths_: gene → dense kset-grid of TracebackPath (only populated under
-    /// viterbi; absent in forward). Keys are borrowed (see `scratch_cachefo`
-    /// doc-block); the canonical owner is `scores`. Item 2.1 of #366: dense
-    /// grid replaces the prior `AutoHashMapUnmanaged(KSet, TracebackPath)`.
-    paths: std.StringHashMapUnmanaged(PathGrid),
-    /// scores_: gene → dense kset-grid of f64. Owns the gene-name keys shared
-    /// with `scratch_cachefo` and `paths` (item 5 of #342). Item 2.1 of #366:
-    /// dense grid replaces the prior `AutoHashMapUnmanaged(KSet, f64)`; see
-    /// `ScoreGrid` for layout and the NaN-sentinel "unfilled" semantics.
-    scores: std.StringHashMapUnmanaged(ScoreGrid),
+    /// paths_: gene → (KSet → TracebackPath). Keys are borrowed (see
+    /// `scratch_cachefo` doc-block); the canonical owner is `scores`.
+    paths: std.StringHashMapUnmanaged(std.AutoHashMapUnmanaged(KSet, TracebackPath)),
+    /// scores_: gene → (KSet → f64). Owns the gene-name keys shared with
+    /// `scratch_cachefo` and `paths` (item 5 of #342).
+    scores: std.StringHashMapUnmanaged(std.AutoHashMapUnmanaged(KSet, f64)),
     /// per_gene_support_: gene → best full-annotation log-prob
     per_gene_support: std.StringHashMapUnmanaged(f64),
-
-    /// Kgrid offsets and dimensions. Set at the top of every `run()` from
-    /// `kbounds` and used by every `ScoreGrid` / `PathGrid` allocation in
-    /// the call. Stale between `run()` calls; only the live query reads them.
-    /// Stored on the handler rather than per-grid because every grid in a
-    /// query shares the same dims, and the conversion from `KSet` to
-    /// `(v_off, d_off)` happens at every read/write site.
-    kgrid_vmin: usize,
-    kgrid_dmin: usize,
-    kgrid_v_dim: usize,
-    kgrid_d_dim: usize,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -239,21 +113,7 @@ pub const DPHandler = struct {
             .paths = .{},
             .scores = .{},
             .per_gene_support = .{},
-            .kgrid_vmin = 0,
-            .kgrid_dmin = 0,
-            .kgrid_v_dim = 0,
-            .kgrid_d_dim = 0,
         };
-    }
-
-    /// Convert a KSet to its dense-grid (v_off, d_off). Asserts the kset is
-    /// inside the current query's grid bounds — every write site routes
-    /// ksets from the `runKSet` loop, which iterates over `[vmin, vmax) ×
-    /// [dmin, dmax)`, so an out-of-bounds kset here is a programmer bug.
-    inline fn kgridOff(self: *const DPHandler, kset: KSet) struct { v: usize, d: usize } {
-        std.debug.assert(kset.v >= self.kgrid_vmin and kset.v < self.kgrid_vmin + self.kgrid_v_dim);
-        std.debug.assert(kset.d >= self.kgrid_dmin and kset.d < self.kgrid_dmin + self.kgrid_d_dim);
-        return .{ .v = kset.v - self.kgrid_vmin, .d = kset.d - self.kgrid_dmin };
     }
 
     /// Per-query scratch allocator. **Always re-derive at the use site** —
@@ -300,21 +160,18 @@ pub const DPHandler = struct {
         self.scratch_cachefo.deinit(allocator);
         self.scratch_cachefo = .{};
 
-        // Free paths. Keys are shared with `scores` (see above). Item 2.1
-        // of #366: each value is now a dense `PathGrid` rather than a
-        // `AutoHashMap`; `PathGrid.deinit` walks the dense cells, deiniting
-        // every filled traceback path.
+        // Free paths. Keys are shared with `scores` (see above).
         var pit = self.paths.iterator();
         while (pit.next()) |entry| {
+            var inner_it = entry.value_ptr.iterator();
+            while (inner_it.next()) |kv| kv.value_ptr.deinit(allocator);
             entry.value_ptr.deinit(allocator);
         }
         self.paths.deinit(allocator);
         self.paths = .{};
 
         // Free scores. This is the canonical owner of the gene-name keys
-        // shared with `scratch_cachefo` and `paths`. Item 2.1 of #366: each
-        // value is now a dense `ScoreGrid` (single backing slice) rather
-        // than an `AutoHashMap`.
+        // shared with `scratch_cachefo` and `paths`.
         var sit = self.scores.iterator();
         while (sit.next()) |entry| {
             allocator.free(entry.key_ptr.*);
@@ -446,15 +303,6 @@ pub const DPHandler = struct {
         if (kbounds.vmin == 0 or kbounds.dmin == 0 or
             kbounds.vmax <= kbounds.vmin or kbounds.dmax <= kbounds.dmin)
             return error.TrivialKBounds;
-
-        // Item 2.1 of #366: pin the dense kset-grid bounds for this query.
-        // Every `ScoreGrid` / `PathGrid` allocated under `initCache` below
-        // sizes itself against these dims, and every `kgridOff` conversion
-        // resolves against these offsets.
-        self.kgrid_vmin = kbounds.vmin;
-        self.kgrid_dmin = kbounds.dmin;
-        self.kgrid_v_dim = kbounds.vmax - kbounds.vmin;
-        self.kgrid_d_dim = kbounds.dmax - kbounds.dmin;
 
         var best_scores: std.AutoHashMapUnmanaged(KSet, f64) = .{};
         defer best_scores.deinit(allocator);
@@ -701,85 +549,47 @@ pub const DPHandler = struct {
 
         const allocator = self.scratchAllocator();
         try self.scratch_cachefo.ensureUnusedCapacity(allocator, 1);
+        try self.paths.ensureUnusedCapacity(allocator, 1);
         try self.scores.ensureUnusedCapacity(allocator, 1);
 
-        // Allocate the grids before any map insertion so a mid-init OOM
-        // can't leave `scratch_cachefo` populated while `scores` is still
-        // empty — `clear()` is the canonical key owner and would miss a
-        // dangling `scratch_cachefo` entry if the order were inverted.
-        // After this block, every `putAssumeCapacity` is infallible.
-        var grid = try ScoreGrid.init(allocator, self.kgrid_v_dim, self.kgrid_d_dim);
-        errdefer grid.deinit(allocator);
-
-        // `paths` is only populated under viterbi; in forward mode the gene's
-        // entry is left absent, so `self.paths.getPtr(gene)` returns null at
-        // every read site (`fillTrellis` path-store, `findPartialCacheMatch`
-        // cache-copy block, `getPathNames`). This matches the old behaviour
-        // where the inner `AutoHashMap` was put-but-never-populated under
-        // forward — same observable, less allocation.
-        const want_paths = std.mem.eql(u8, self.algorithm, "viterbi");
-        var path_grid: PathGrid = undefined;
-        if (want_paths) {
-            try self.paths.ensureUnusedCapacity(allocator, 1);
-            path_grid = try PathGrid.init(allocator, self.kgrid_v_dim, self.kgrid_d_dim);
-        }
-        errdefer if (want_paths) path_grid.deinit(allocator);
-
         const key = try allocator.dupe(u8, gene);
-
-        // Infallible from here: every map has its capacity reserved and the
-        // grids are constructed. No partial-state window.
         self.scratch_cachefo.putAssumeCapacity(key, .{});
-        self.scores.putAssumeCapacity(key, grid);
-        if (want_paths) self.paths.putAssumeCapacity(key, path_grid);
+        self.paths.putAssumeCapacity(key, .{});
+        self.scores.putAssumeCapacity(key, .{});
     }
 
     /// Look for a cached kset whose region sequences are a prefix of the
     /// query's per-region undigitized strings (built via `getSubSeqs`).
     /// Returns null-kset if none found.
     fn findPartialCacheMatch(self: *DPHandler, region: Region, gene: []const u8, kset: KSet) KSet {
-        const gene_scores = self.scores.getPtr(gene) orelse return KSet{ .v = 0, .d = 0 };
+        const gene_scores = self.scores.get(gene) orelse return KSet{ .v = 0, .d = 0 };
+        if (gene_scores.get(kset) != null) return kset;
 
-        // Direct hit on the requested kset — same fast-path as the prior
-        // map-based version.
-        const off = self.kgridOff(kset);
-        if (gene_scores.get(off.v, off.d) != null) return kset;
-
-        // Item 2.1 of #366. The C++ source iterated `map<KSet,double>` in
-        // ascending `(v, d)` order; the Zig `AutoHashMap` was unordered, so
-        // the prior scan hand-tracked the minimum. Both produced the same
-        // logical match; the dense scan below produces it in O(d_dim) for
-        // V-region and O(v_dim) for J-region instead of O(n_filled_ksets).
         switch (region) {
             .v => {
-                // V-region: smallest filled d at fixed v. Iterate d_off in
-                // ascending order; first non-null is the smallest-d match.
-                var d_off: usize = 0;
-                while (d_off < gene_scores.d_dim) : (d_off += 1) {
-                    if (gene_scores.get(off.v, d_off) != null) {
-                        return KSet{ .v = kset.v, .d = self.kgrid_dmin + d_off };
+                // C++ map<KSet,double> iterates in ascending (v,d) order, so
+                // it returns the smallest-d match. We must replicate that.
+                var best: ?KSet = null;
+                var it = gene_scores.iterator();
+                while (it.next()) |kv| {
+                    if (kv.key_ptr.v == kset.v) {
+                        if (best == null or kv.key_ptr.d < best.?.d)
+                            best = kv.key_ptr.*;
                     }
                 }
+                if (best) |b| return b;
             },
             .j => {
-                // J-region: among entries with v + d == target, smallest
-                // (v, d) lexicographically. On the diagonal each v has at
-                // most one d, so this is just the smallest filled v on the
-                // diagonal — iterate v_off ascending; for each, if the
-                // matching d is in-bounds and filled, return it.
-                const target = kset.v + kset.d;
-                var v_off: usize = 0;
-                while (v_off < gene_scores.v_dim) : (v_off += 1) {
-                    const v = self.kgrid_vmin + v_off;
-                    if (target < v) break; // ascending v means d would go negative from here on
-                    const d = target - v;
-                    if (d < self.kgrid_dmin) continue;
-                    const d_off_j = d - self.kgrid_dmin;
-                    if (d_off_j >= gene_scores.d_dim) continue;
-                    if (gene_scores.get(v_off, d_off_j) != null) {
-                        return KSet{ .v = v, .d = d };
+                var best: ?KSet = null;
+                var it = gene_scores.iterator();
+                while (it.next()) |kv| {
+                    if (kv.key_ptr.v + kv.key_ptr.d == kset.v + kset.d) {
+                        if (best == null or kv.key_ptr.v < best.?.v or
+                            (kv.key_ptr.v == best.?.v and kv.key_ptr.d < best.?.d))
+                            best = kv.key_ptr.*;
                     }
                 }
+                if (best) |b| return b;
             },
             .d => {},
         }
@@ -907,8 +717,7 @@ pub const DPHandler = struct {
                 try trell_ptr.traceback(allocator, &path);
             }
             if (self.paths.getPtr(gene)) |gene_paths| {
-                const off = self.kgridOff(kset);
-                gene_paths.put(off.v, off.d, path);
+                try gene_paths.put(allocator, kset, path);
             } else {
                 path.deinit(allocator);
             }
@@ -922,8 +731,7 @@ pub const DPHandler = struct {
         const final_score = mathutils.addWithMinusInfinities(uncorrected_score, gene_choice_score);
 
         if (self.scores.getPtr(gene)) |gene_scores| {
-            const off = self.kgridOff(kset);
-            gene_scores.put(off.v, off.d, final_score);
+            try gene_scores.put(allocator, kset, final_score);
         }
 
         return origin;
@@ -1183,29 +991,26 @@ pub const DPHandler = struct {
                     // Copy path and score from cached kset. Both go into
                     // `self.paths` / `self.scores`, which outlive the kset
                     // — route through `scratch`, not `allocator`.
-                    const dst_off = self.kgridOff(kset);
-                    const src_off = self.kgridOff(partial_match);
                     if (self.paths.getPtr(gene)) |gp| {
-                        if (gp.getPtr(src_off.v, src_off.d)) |cached_path| {
+                        if (gp.get(partial_match)) |cached_path| {
                             var path_copy = TracebackPath.init();
                             errdefer path_copy.deinit(scratch);
                             try path_copy.path.appendSlice(scratch, cached_path.path.items);
                             path_copy.setScore(cached_path.score);
                             path_copy.setModel(cached_path.hmm.?);
-                            gp.put(dst_off.v, dst_off.d, path_copy);
+                            try gp.put(scratch, kset, path_copy);
                         }
                     }
                     if (self.scores.getPtr(gene)) |gs| {
-                        const cached_score = gs.get(src_off.v, src_off.d) orelse mathutils.NEG_INF;
-                        gs.put(dst_off.v, dst_off.d, cached_score);
+                        const cached_score = gs.get(partial_match) orelse mathutils.NEG_INF;
+                        try gs.put(scratch, kset, cached_score);
                     }
                     origin = "cached";
                 } else {
                     origin = try self.fillTrellis(allocator, kset, &query_seqs, gene);
                 }
 
-                const off = self.kgridOff(kset);
-                const gene_score = if (self.scores.getPtr(gene)) |gs| gs.get(off.v, off.d) orelse mathutils.NEG_INF else mathutils.NEG_INF;
+                const gene_score = if (self.scores.getPtr(gene)) |gs| gs.get(kset) orelse mathutils.NEG_INF else mathutils.NEG_INF;
 
                 // Debug: per-gene viterbi output
                 if (self.args.debug == 2 and std.mem.eql(u8, self.algorithm, "viterbi")) {
@@ -1385,8 +1190,7 @@ pub const DPHandler = struct {
         allocator: std.mem.Allocator,
     ) !std.ArrayListUnmanaged([]u8) {
         const gene_paths = self.paths.getPtr(gene) orelse return .{};
-        const off = self.kgridOff(kset);
-        const path = gene_paths.getPtr(off.v, off.d) orelse return .{};
+        const path = gene_paths.getPtr(kset) orelse return .{};
         return path.nameVector(allocator);
     }
 

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -51,26 +51,39 @@ const TrellisEntry = struct {
     trellis: Trellis,
 };
 
+/// Per-gene scratch cache value: bundles the chunk-cache list of
+/// `*TrellisEntry`s with the pre-resolved `*Model` for the gene
+/// (#366 lever 5).
+///
+/// Resolving the model once at `initCache` time and stashing it
+/// here eliminates per-`fillTrellis` calls into
+/// `HMMHolder.hmms.get(gene)` — that map is `[]const u8 → *Model`
+/// (StringHashMap), and post-#380 perf-record attributes 24.63% of
+/// partition wall to `getIndex__anon_27622`, the `getIndex`
+/// instantiation for that value type. The hoist is intentionally
+/// at per-(gene, query) granularity: the cache-hit path in
+/// `runKSet` already avoids `hmms.get` (it uses
+/// `cached_path.hmm.?`), so we don't want to add a lookup there.
+/// `initCache(gene)` early-returns on subsequent calls within the
+/// same query, so resolving the model in `initCache` is paid once
+/// per (gene, query), not once per (gene, kset).
+///
+/// `*Model` lifetime: HMMHolder owns models for the full process
+/// lifetime — it never evicts and never reloads, so the resolved
+/// pointer is stable across run() calls. We do NOT free the
+/// `*Model` from this struct; HMMHolder.deinit handles that.
+const ScratchCacheEntry = struct {
+    list: std.ArrayListUnmanaged(*TrellisEntry),
+    model: *Model,
+};
+
 /// Per-gene inner-map pointer bundle hoisted once at the top of
 /// `runKSet`'s per-gene loop iteration. Replaces 2-3 redundant
 /// `self.{scratch_cachefo,paths,scores}.getPtr(gene)` lookups in the
 /// gene-block body and inside `fillTrellis` with a single struct of
-/// pre-resolved pointers.
-///
-/// Honest cost framing: the lookups this hoist eliminates show as
-/// 0.00% of partition wall in the post-#380 perf-record (the
-/// `getIndex` symbols for value-types `AutoHashMapUnmanaged(KSet,
-/// TracebackPath)`, `AutoHashMapUnmanaged(KSet, f64)`, and
-/// `ArrayListUnmanaged(*TrellisEntry)` do not appear at the top of
-/// `/tmp/perf-1.1-results/partition-5k.perf.report`). The 24.63%
-/// `getIndex__anon_27622` bucket cited in the Phase A memo is
-/// HMMHolder's `[]const u8 → *Model` map only — a different value
-/// type, with one call per (gene, kset) on the cache-miss path that
-/// this hoist intentionally does NOT touch (hoisting it would add a
-/// `hmms.get` call on the cache-hit path where the original code
-/// uses `cached_path.hmm.?` instead). So this hoist is best framed
-/// as a code-clarity / dead-error-path-removal refactor; any wall
-/// improvement is in the noise.
+/// pre-resolved pointers. Also exposes the per-gene `*Model` via
+/// `cache_entry.model` (#366 lever 5) so `fillTrellis` need not
+/// re-call `self.hmms.get(gene)`.
 ///
 /// Pointer-stability invariants (load-bearing):
 ///   - `initCache(gene)` is the only site that grows
@@ -78,8 +91,8 @@ const TrellisEntry = struct {
 ///     above the cache build at the top of each gene-block iteration.
 ///   - Within one gene-block iteration, the outer string-keyed maps
 ///     don't grow. Inner-map writes (`gp.put(scratch, kset, ...)`,
-///     `cache_list.append(allocator, entry)`, etc.) modify the inner
-///     map's internal pointers but don't relocate the outer-map
+///     `cache_entry.list.append(allocator, entry)`, etc.) modify the
+///     inner map's internal pointers but don't relocate the outer-map
 ///     value slot.
 ///   - `.?` unwraps below would panic in `Debug`/`ReleaseSafe` if
 ///     the invariant ever broke; `ReleaseFast` would silently UAF.
@@ -89,7 +102,7 @@ const TrellisEntry = struct {
 ///     CI). If you change the locking around `initCache` or add a
 ///     new outer-map writer, also re-confirm via that rung.
 const PerGeneCache = struct {
-    cachefo: *std.ArrayListUnmanaged(*TrellisEntry),
+    cache_entry: *ScratchCacheEntry,
     paths: *std.AutoHashMapUnmanaged(KSet, TracebackPath),
     scores: *std.AutoHashMapUnmanaged(KSet, f64),
 };
@@ -117,9 +130,11 @@ pub const DPHandler = struct {
     /// and reuses the backing pages for the next call. Item 4, #342.
     query_arena: std.heap.ArenaAllocator,
 
-    /// scratch_cachefo_: gene → list of *TrellisEntry. Entries are
-    /// individually heap-allocated for stable address (the trellis at each
-    /// entry borrows `&entry.query_seqs` and that pointer must stay valid
+    /// scratch_cachefo_: gene → ScratchCacheEntry (chunk-cache list +
+    /// pre-resolved `*Model` for the gene; see `ScratchCacheEntry` and
+    /// #366 lever 5). Entries within `.list` are individually
+    /// heap-allocated for stable address (the trellis at each entry
+    /// borrows `&entry.query_seqs` and that pointer must stay valid
     /// across appends to the same gene's list). Address stability is
     /// preserved under the per-query arena because arenas only grow —
     /// past allocations are never relocated.
@@ -128,7 +143,7 @@ pub const DPHandler = struct {
     /// `paths` and `scores`, which are populated by the same `initCache`
     /// call (item 5 of #342). `scores` owns the duped key bytes; `clear()`
     /// frees keys only when iterating `scores` to avoid a triple-free.
-    scratch_cachefo: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(*TrellisEntry)),
+    scratch_cachefo: std.StringHashMapUnmanaged(ScratchCacheEntry),
     /// paths_: gene → (KSet → TracebackPath). Keys are borrowed (see
     /// `scratch_cachefo` doc-block); the canonical owner is `scores`.
     paths: std.StringHashMapUnmanaged(std.AutoHashMapUnmanaged(KSet, TracebackPath)),
@@ -190,15 +205,17 @@ pub const DPHandler = struct {
         // trellis first (it doesn't own seqs but may use seq_len etc.), then
         // the Sequences, then destroy the entry struct itself.
         // Keys are shared with `paths` and `scores` (item 5 of #342); freed
-        // once below when iterating `scores`.
+        // once below when iterating `scores`. The `.model` pointer is owned
+        // by HMMHolder (one Model per gene, freed in HMMHolder.deinit) — do
+        // NOT deinit/destroy it here.
         var cit = self.scratch_cachefo.iterator();
         while (cit.next()) |entry| {
-            for (entry.value_ptr.items) |te| {
+            for (entry.value_ptr.list.items) |te| {
                 te.trellis.deinit();
                 te.query_seqs.deinit(allocator);
                 allocator.destroy(te);
             }
-            entry.value_ptr.deinit(allocator);
+            entry.value_ptr.list.deinit(allocator);
         }
         self.scratch_cachefo.deinit(allocator);
         self.scratch_cachefo = .{};
@@ -498,7 +515,7 @@ pub const DPHandler = struct {
         var buckets = [_]u64{0} ** 12;
         var it = self.scratch_cachefo.iterator();
         while (it.next()) |entry| {
-            const n = entry.value_ptr.items.len;
+            const n = entry.value_ptr.list.items.len;
             const idx: usize =
                 if (n == 0) 0 else if (n == 1) 1 else if (n == 2) 2 else if (n == 3) 3 else if (n == 4) 4 else if (n == 5) 5 else if (n < 10) 6 else if (n < 20) 7 else if (n < 50) 8 else if (n < 100) 9 else if (n < 200) 10 else 11;
             buckets[idx] += 1;
@@ -595,8 +612,16 @@ pub const DPHandler = struct {
         try self.paths.ensureUnusedCapacity(allocator, 1);
         try self.scores.ensureUnusedCapacity(allocator, 1);
 
+        // Pre-resolve the gene's `*Model` once per (gene, query) (#366
+        // lever 5). HMMHolder.hmms is a StringHashMap; the lookup is the
+        // 24.63% `getIndex__anon_27622` bucket in the post-#380
+        // perf-record. Fetching here, on the gene's first kset, replaces
+        // the per-`fillTrellis` lookup that would otherwise repeat on
+        // every cache-miss kset for the same gene.
+        const m = try self.hmms.get(gene);
+
         const key = try allocator.dupe(u8, gene);
-        self.scratch_cachefo.putAssumeCapacity(key, .{});
+        self.scratch_cachefo.putAssumeCapacity(key, .{ .list = .{}, .model = m });
         self.paths.putAssumeCapacity(key, .{});
         self.scores.putAssumeCapacity(key, .{});
     }
@@ -658,7 +683,6 @@ pub const DPHandler = struct {
         kset_alloc: std.mem.Allocator,
         kset: KSet,
         query_seqs: *const Sequences,
-        gene: []const u8,
         gc: *const PerGeneCache,
     ) ![]const u8 {
         const allocator = self.scratchAllocator();
@@ -669,7 +693,7 @@ pub const DPHandler = struct {
         var cached_trellis: ?*const Trellis = null;
         if (!self.args.no_chunk_cache) {
             perf_counters.bumpChunkCacheLookup();
-            for (gc.cachefo.items) |te| {
+            for (gc.cache_entry.list.items) |te| {
                 const cached_seqs = te.query_seqs.seqs.items;
                 const current_seqs = query_seqs.seqs.items;
                 if (cached_seqs.len != current_seqs.len) continue;
@@ -701,12 +725,11 @@ pub const DPHandler = struct {
         var tmptrell: ?Trellis = null;
         defer if (tmptrell) |*t| t.deinit();
 
-        // Lazy model load. We do NOT hoist this into PerGeneCache: the
-        // original code only paid `hmms.get(gene)` on the cache-miss path
-        // (the cache-hit path in runKSet uses `cached_path.hmm.?` instead).
-        // Phase 0 reports cache-hit at 78–86% of ksets, so hoisting model
-        // would *add* a per-kset `hmms.get` call to that majority path.
-        const model = try self.hmms.get(gene);
+        // Pre-resolved at `initCache(gene)` (paid once per (gene, query),
+        // #366 lever 5). The runKSet cache-hit branch uses
+        // `cached_path.hmm.?` and never reaches here, so this hoist costs
+        // nothing on the cache-hit path.
+        const model = gc.cache_entry.model;
 
         var origin: []const u8 = "scratch";
         const trell_ptr: *Trellis = if (cached_trellis == null) blk: {
@@ -722,9 +745,9 @@ pub const DPHandler = struct {
             entry.trellis = try Trellis.initWithSeqs(allocator, model, &entry.query_seqs, null);
             errdefer entry.trellis.deinit();
 
-            // gc.cachefo is guaranteed non-null by the caller (initCache
+            // gc.cache_entry is guaranteed non-null by the caller (initCache
             // ran before the gc was built — see PerGeneCache doc-block).
-            try gc.cachefo.append(allocator, entry);
+            try gc.cache_entry.list.append(allocator, entry);
             break :blk &entry.trellis;
         } else blk: {
             // Have cache: temp trellis borrows from the caller's query_seqs
@@ -1020,11 +1043,11 @@ pub const DPHandler = struct {
                 // Hoist the three gene-keyed inner-map pointers once per
                 // gene-block. After initCache(gene), the outer string-keyed
                 // maps don't grow within this iteration so the inner-slot
-                // pointers stay stable. We deliberately do NOT hoist
-                // `self.hmms.get(gene)` — see PerGeneCache doc-block for the
-                // cache-hit-path regression rationale.
+                // pointers stay stable. The per-gene `*Model` reachable via
+                // `gc.cache_entry.model` was pre-resolved by `initCache`
+                // (#366 lever 5).
                 const gc = PerGeneCache{
-                    .cachefo = self.scratch_cachefo.getPtr(gene).?,
+                    .cache_entry = self.scratch_cachefo.getPtr(gene).?,
                     .paths = self.paths.getPtr(gene).?,
                     .scores = self.scores.getPtr(gene).?,
                 };
@@ -1047,7 +1070,7 @@ pub const DPHandler = struct {
                     try gc.scores.put(scratch, kset, cached_score);
                     origin = "cached";
                 } else {
-                    origin = try self.fillTrellis(allocator, kset, &query_seqs, gene, &gc);
+                    origin = try self.fillTrellis(allocator, kset, &query_seqs, &gc);
                 }
 
                 const gene_score = gc.scores.get(kset) orelse mathutils.NEG_INF;

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -51,6 +51,49 @@ const TrellisEntry = struct {
     trellis: Trellis,
 };
 
+/// Per-gene inner-map pointer bundle hoisted once at the top of
+/// `runKSet`'s per-gene loop iteration. Replaces 2-3 redundant
+/// `self.{scratch_cachefo,paths,scores}.getPtr(gene)` lookups in the
+/// gene-block body and inside `fillTrellis` with a single struct of
+/// pre-resolved pointers.
+///
+/// Honest cost framing: the lookups this hoist eliminates show as
+/// 0.00% of partition wall in the post-#380 perf-record (the
+/// `getIndex` symbols for value-types `AutoHashMapUnmanaged(KSet,
+/// TracebackPath)`, `AutoHashMapUnmanaged(KSet, f64)`, and
+/// `ArrayListUnmanaged(*TrellisEntry)` do not appear at the top of
+/// `/tmp/perf-1.1-results/partition-5k.perf.report`). The 24.63%
+/// `getIndex__anon_27622` bucket cited in the Phase A memo is
+/// HMMHolder's `[]const u8 → *Model` map only — a different value
+/// type, with one call per (gene, kset) on the cache-miss path that
+/// this hoist intentionally does NOT touch (hoisting it would add a
+/// `hmms.get` call on the cache-hit path where the original code
+/// uses `cached_path.hmm.?` instead). So this hoist is best framed
+/// as a code-clarity / dead-error-path-removal refactor; any wall
+/// improvement is in the noise.
+///
+/// Pointer-stability invariants (load-bearing):
+///   - `initCache(gene)` is the only site that grows
+///     `scratch_cachefo` / `paths` / `scores`. It runs immediately
+///     above the cache build at the top of each gene-block iteration.
+///   - Within one gene-block iteration, the outer string-keyed maps
+///     don't grow. Inner-map writes (`gp.put(scratch, kset, ...)`,
+///     `cache_list.append(allocator, entry)`, etc.) modify the inner
+///     map's internal pointers but don't relocate the outer-map
+///     value slot.
+///   - `.?` unwraps below would panic in `Debug`/`ReleaseSafe` if
+///     the invariant ever broke; `ReleaseFast` would silently UAF.
+///     The `partis-test.py --paired --safe` rung covers the
+///     `ReleaseSafe` build mode (originally added so the UAF risk
+///     of caching pointers across put-calls would surface loudly in
+///     CI). If you change the locking around `initCache` or add a
+///     new outer-map writer, also re-confirm via that rung.
+const PerGeneCache = struct {
+    cachefo: *std.ArrayListUnmanaged(*TrellisEntry),
+    paths: *std.AutoHashMapUnmanaged(KSet, TracebackPath),
+    scores: *std.AutoHashMapUnmanaged(KSet, f64),
+};
+
 /// Corresponds to C++ `ham::DPHandler`.
 pub const DPHandler = struct {
     algorithm: []const u8,
@@ -560,9 +603,10 @@ pub const DPHandler = struct {
 
     /// Look for a cached kset whose region sequences are a prefix of the
     /// query's per-region undigitized strings (built via `getSubSeqs`).
-    /// Returns null-kset if none found.
-    fn findPartialCacheMatch(self: *DPHandler, region: Region, gene: []const u8, kset: KSet) KSet {
-        const gene_scores = self.scores.get(gene) orelse return KSet{ .v = 0, .d = 0 };
+    /// Returns null-kset if none found. `gene_scores` is the per-gene
+    /// inner map hoisted by the caller (see `PerGeneCache`); replaces
+    /// the prior `self.scores.get(gene)` lookup at this site.
+    fn findPartialCacheMatch(_: *DPHandler, region: Region, gene_scores: *const std.AutoHashMapUnmanaged(KSet, f64), kset: KSet) KSet {
         if (gene_scores.get(kset) != null) return kset;
 
         switch (region) {
@@ -615,6 +659,7 @@ pub const DPHandler = struct {
         kset: KSet,
         query_seqs: *const Sequences,
         gene: []const u8,
+        gc: *const PerGeneCache,
     ) ![]const u8 {
         const allocator = self.scratchAllocator();
         perf_counters.bumpFillTrellis();
@@ -624,29 +669,25 @@ pub const DPHandler = struct {
         var cached_trellis: ?*const Trellis = null;
         if (!self.args.no_chunk_cache) {
             perf_counters.bumpChunkCacheLookup();
-            if (self.scratch_cachefo.getPtr(gene)) |cache_list| {
-                for (cache_list.items) |te| {
-                    const cached_seqs = te.query_seqs.seqs.items;
-                    const current_seqs = query_seqs.seqs.items;
-                    if (cached_seqs.len != current_seqs.len) continue;
-                    var all_match = true;
-                    for (cached_seqs, current_seqs) |*cached, *current| {
-                        // cached must START WITH current (prefix match)
-                        if (!std.mem.startsWith(u8, cached.undigitized, current.undigitized)) {
-                            all_match = false;
-                            break;
-                        }
-                    }
-                    if (all_match) {
-                        cached_trellis = &te.trellis;
-                        perf_counters.bumpChunkCacheHit();
+            for (gc.cachefo.items) |te| {
+                const cached_seqs = te.query_seqs.seqs.items;
+                const current_seqs = query_seqs.seqs.items;
+                if (cached_seqs.len != current_seqs.len) continue;
+                var all_match = true;
+                for (cached_seqs, current_seqs) |*cached, *current| {
+                    // cached must START WITH current (prefix match)
+                    if (!std.mem.startsWith(u8, cached.undigitized, current.undigitized)) {
+                        all_match = false;
                         break;
                     }
                 }
+                if (all_match) {
+                    cached_trellis = &te.trellis;
+                    perf_counters.bumpChunkCacheHit();
+                    break;
+                }
             }
         }
-
-        const model = try self.hmms.get(gene);
 
         // Match C++ DPHandler::FillTrellis logic exactly:
         //   - When no cached trellis: create scratch, store it, run algorithm ON THE SCRATCH directly.
@@ -659,6 +700,13 @@ pub const DPHandler = struct {
         // tmptrell is only used when borrowing from a cached trellis.
         var tmptrell: ?Trellis = null;
         defer if (tmptrell) |*t| t.deinit();
+
+        // Lazy model load. We do NOT hoist this into PerGeneCache: the
+        // original code only paid `hmms.get(gene)` on the cache-miss path
+        // (the cache-hit path in runKSet uses `cached_path.hmm.?` instead).
+        // Phase 0 reports cache-hit at 78–86% of ksets, so hoisting model
+        // would *add* a per-kset `hmms.get` call to that majority path.
+        const model = try self.hmms.get(gene);
 
         var origin: []const u8 = "scratch";
         const trell_ptr: *Trellis = if (cached_trellis == null) blk: {
@@ -674,20 +722,10 @@ pub const DPHandler = struct {
             entry.trellis = try Trellis.initWithSeqs(allocator, model, &entry.query_seqs, null);
             errdefer entry.trellis.deinit();
 
-            if (self.scratch_cachefo.getPtr(gene)) |cache_list| {
-                try cache_list.append(allocator, entry);
-                break :blk &entry.trellis;
-            } else {
-                // gene not in scratch_cachefo (shouldn't happen after initCache).
-                // Assert so safe builds (Debug, ReleaseSafe — including the
-                // rung-1 UAF-coverage run) panic loudly; ReleaseFast keeps
-                // the cleanup + error-return path as a defensive fallback.
-                std.debug.assert(false);
-                entry.trellis.deinit();
-                entry.query_seqs.deinit(allocator);
-                allocator.destroy(entry);
-                return error.GeneNotInScratchCache;
-            }
+            // gc.cachefo is guaranteed non-null by the caller (initCache
+            // ran before the gc was built — see PerGeneCache doc-block).
+            try gc.cachefo.append(allocator, entry);
+            break :blk &entry.trellis;
         } else blk: {
             // Have cache: temp trellis borrows from the caller's query_seqs
             // (no clone — lifetime is just this call). Backed by the per-kset
@@ -716,11 +754,7 @@ pub const DPHandler = struct {
                 // items don't capture the temp trellis's per-kset arena.
                 try trell_ptr.traceback(allocator, &path);
             }
-            if (self.paths.getPtr(gene)) |gene_paths| {
-                try gene_paths.put(allocator, kset, path);
-            } else {
-                path.deinit(allocator);
-            }
+            try gc.paths.put(allocator, kset, path);
             break :blk sc;
         } else blk: {
             try trell_ptr.forward();
@@ -730,9 +764,7 @@ pub const DPHandler = struct {
         const gene_choice_score = log(model.overall_prob);
         const final_score = mathutils.addWithMinusInfinities(uncorrected_score, gene_choice_score);
 
-        if (self.scores.getPtr(gene)) |gene_scores| {
-            try gene_scores.put(allocator, kset, final_score);
-        }
+        try gc.scores.put(allocator, kset, final_score);
 
         return origin;
     }
@@ -985,32 +1017,40 @@ pub const DPHandler = struct {
             for (sorted_genes) |gene| {
                 try self.initCache(gene);
 
+                // Hoist the three gene-keyed inner-map pointers once per
+                // gene-block. After initCache(gene), the outer string-keyed
+                // maps don't grow within this iteration so the inner-slot
+                // pointers stay stable. We deliberately do NOT hoist
+                // `self.hmms.get(gene)` — see PerGeneCache doc-block for the
+                // cache-hit-path regression rationale.
+                const gc = PerGeneCache{
+                    .cachefo = self.scratch_cachefo.getPtr(gene).?,
+                    .paths = self.paths.getPtr(gene).?,
+                    .scores = self.scores.getPtr(gene).?,
+                };
+
                 var origin: []const u8 = "";
-                const partial_match = self.findPartialCacheMatch(region, gene, kset);
+                const partial_match = self.findPartialCacheMatch(region, gc.scores, kset);
                 if (!partial_match.isNull()) {
                     // Copy path and score from cached kset. Both go into
                     // `self.paths` / `self.scores`, which outlive the kset
                     // — route through `scratch`, not `allocator`.
-                    if (self.paths.getPtr(gene)) |gp| {
-                        if (gp.get(partial_match)) |cached_path| {
-                            var path_copy = TracebackPath.init();
-                            errdefer path_copy.deinit(scratch);
-                            try path_copy.path.appendSlice(scratch, cached_path.path.items);
-                            path_copy.setScore(cached_path.score);
-                            path_copy.setModel(cached_path.hmm.?);
-                            try gp.put(scratch, kset, path_copy);
-                        }
+                    if (gc.paths.get(partial_match)) |cached_path| {
+                        var path_copy = TracebackPath.init();
+                        errdefer path_copy.deinit(scratch);
+                        try path_copy.path.appendSlice(scratch, cached_path.path.items);
+                        path_copy.setScore(cached_path.score);
+                        path_copy.setModel(cached_path.hmm.?);
+                        try gc.paths.put(scratch, kset, path_copy);
                     }
-                    if (self.scores.getPtr(gene)) |gs| {
-                        const cached_score = gs.get(partial_match) orelse mathutils.NEG_INF;
-                        try gs.put(scratch, kset, cached_score);
-                    }
+                    const cached_score = gc.scores.get(partial_match) orelse mathutils.NEG_INF;
+                    try gc.scores.put(scratch, kset, cached_score);
                     origin = "cached";
                 } else {
-                    origin = try self.fillTrellis(allocator, kset, &query_seqs, gene);
+                    origin = try self.fillTrellis(allocator, kset, &query_seqs, gene, &gc);
                 }
 
-                const gene_score = if (self.scores.getPtr(gene)) |gs| gs.get(kset) orelse mathutils.NEG_INF else mathutils.NEG_INF;
+                const gene_score = gc.scores.get(kset) orelse mathutils.NEG_INF;
 
                 // Debug: per-gene viterbi output
                 if (self.args.debug == 2 and std.mem.eql(u8, self.algorithm, "viterbi")) {

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -34,6 +34,117 @@ const GeneKSetKey = struct {
     kset: KSet,
 };
 
+/// Per-gene dense score grid over the kset rectangle. Replaces the
+/// `AutoHashMapUnmanaged(KSet, f64)` inner-map of `DPHandler.scores`
+/// (item 2.1 of #366). The C++ `map<KSet, double>` it descends from gave
+/// `findPartialCacheMatch` an `O(n_filled_ksets)` scan per call, called
+/// `n_genes × 3 × n_ksets` times per query — `O(n_genes × n_ksets²)`
+/// per query of map iteration. The dense grid replaces that with O(1)
+/// direct lookup and an `O(d_dim)` (V-region) or `O(v_dim)` (J-region)
+/// bounded scan, plus drops the per-cell HashMap pointer-chasing.
+///
+/// Layout: row-major `[v_dim * d_dim]` indexed as
+/// `idx = (k_v - kgrid_vmin) * d_dim + (k_d - kgrid_dmin)`. The query's
+/// `kbounds` pin both the offsets and the dims, so the grid covers
+/// every kset that `run()` will ever write.
+///
+/// "Unfilled" is tracked by a parallel `DynamicBitSetUnmanaged` rather
+/// than a NaN sentinel in `cells`. The bitset is 1 bit per cell (memset 0
+/// = 1/64 the bandwidth of a NaN memset over the f64 backing array), so
+/// the per-gene init cost stays small even when most cells go unread —
+/// which is the common case in partition workloads, where many
+/// (gene, kset) pairs are never visited.
+const ScoreGrid = struct {
+    cells: []f64,
+    filled: std.DynamicBitSetUnmanaged,
+    v_dim: usize,
+    d_dim: usize,
+
+    fn init(allocator: std.mem.Allocator, v_dim: usize, d_dim: usize) !ScoreGrid {
+        const total = v_dim * d_dim;
+        const cells = try allocator.alloc(f64, total);
+        errdefer allocator.free(cells);
+        // Cells are intentionally NOT initialised — `filled` gates every read,
+        // so an unfilled cell is never observed.
+        const filled = try std.DynamicBitSetUnmanaged.initEmpty(allocator, total);
+        return .{ .cells = cells, .filled = filled, .v_dim = v_dim, .d_dim = d_dim };
+    }
+
+    fn deinit(self: *ScoreGrid, allocator: std.mem.Allocator) void {
+        self.filled.deinit(allocator);
+        allocator.free(self.cells);
+    }
+
+    inline fn idx(self: *const ScoreGrid, v_off: usize, d_off: usize) usize {
+        return v_off * self.d_dim + d_off;
+    }
+
+    inline fn isFilled(self: *const ScoreGrid, v_off: usize, d_off: usize) bool {
+        return self.filled.isSet(self.idx(v_off, d_off));
+    }
+
+    inline fn get(self: *const ScoreGrid, v_off: usize, d_off: usize) ?f64 {
+        const i = self.idx(v_off, d_off);
+        return if (self.filled.isSet(i)) self.cells[i] else null;
+    }
+
+    inline fn put(self: *ScoreGrid, v_off: usize, d_off: usize, score: f64) void {
+        const i = self.idx(v_off, d_off);
+        self.cells[i] = score;
+        self.filled.set(i);
+    }
+};
+
+/// Per-gene dense traceback-path grid. Mirrors `ScoreGrid` for the
+/// `DPHandler.paths` map; only allocated under the viterbi algorithm
+/// (forward leaves the gene's entry absent from the outer map).
+///
+/// "Unfilled" is tracked by a parallel `DynamicBitSetUnmanaged` so the
+/// `cells` slice can be left uninitialised — skipping a per-cell
+/// `TracebackPath.init()` over `v_dim × d_dim` cells. The same logic as
+/// `ScoreGrid`: under partition-style workloads, most cells go unread,
+/// and the prior eager init was the dominant cost.
+const PathGrid = struct {
+    cells: []TracebackPath,
+    filled: std.DynamicBitSetUnmanaged,
+    v_dim: usize,
+    d_dim: usize,
+
+    fn init(allocator: std.mem.Allocator, v_dim: usize, d_dim: usize) !PathGrid {
+        const total = v_dim * d_dim;
+        const cells = try allocator.alloc(TracebackPath, total);
+        errdefer allocator.free(cells);
+        // See `ScoreGrid.init` — `filled` gates every read, cells stay garbage
+        // until written.
+        const filled = try std.DynamicBitSetUnmanaged.initEmpty(allocator, total);
+        return .{ .cells = cells, .filled = filled, .v_dim = v_dim, .d_dim = d_dim };
+    }
+
+    fn deinit(self: *PathGrid, allocator: std.mem.Allocator) void {
+        // Walk only filled cells: unfilled cells hold uninitialised memory
+        // and `TracebackPath.deinit` would read its `path` ArrayList field.
+        var it = self.filled.iterator(.{});
+        while (it.next()) |i| self.cells[i].deinit(allocator);
+        self.filled.deinit(allocator);
+        allocator.free(self.cells);
+    }
+
+    inline fn idx(self: *const PathGrid, v_off: usize, d_off: usize) usize {
+        return v_off * self.d_dim + d_off;
+    }
+
+    inline fn getPtr(self: *PathGrid, v_off: usize, d_off: usize) ?*TracebackPath {
+        const i = self.idx(v_off, d_off);
+        return if (self.filled.isSet(i)) &self.cells[i] else null;
+    }
+
+    inline fn put(self: *PathGrid, v_off: usize, d_off: usize, path: TracebackPath) void {
+        const i = self.idx(v_off, d_off);
+        self.cells[i] = path;
+        self.filled.set(i);
+    }
+};
+
 /// Cached trellis entry. Owns the Sequences the trellis was built over.
 ///
 /// The entry itself is **heap-allocated** and the cache list holds pointers
@@ -86,14 +197,29 @@ pub const DPHandler = struct {
     /// call (item 5 of #342). `scores` owns the duped key bytes; `clear()`
     /// frees keys only when iterating `scores` to avoid a triple-free.
     scratch_cachefo: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(*TrellisEntry)),
-    /// paths_: gene → (KSet → TracebackPath). Keys are borrowed (see
-    /// `scratch_cachefo` doc-block); the canonical owner is `scores`.
-    paths: std.StringHashMapUnmanaged(std.AutoHashMapUnmanaged(KSet, TracebackPath)),
-    /// scores_: gene → (KSet → f64). Owns the gene-name keys shared with
-    /// `scratch_cachefo` and `paths` (item 5 of #342).
-    scores: std.StringHashMapUnmanaged(std.AutoHashMapUnmanaged(KSet, f64)),
+    /// paths_: gene → dense kset-grid of TracebackPath (only populated under
+    /// viterbi; absent in forward). Keys are borrowed (see `scratch_cachefo`
+    /// doc-block); the canonical owner is `scores`. Item 2.1 of #366: dense
+    /// grid replaces the prior `AutoHashMapUnmanaged(KSet, TracebackPath)`.
+    paths: std.StringHashMapUnmanaged(PathGrid),
+    /// scores_: gene → dense kset-grid of f64. Owns the gene-name keys shared
+    /// with `scratch_cachefo` and `paths` (item 5 of #342). Item 2.1 of #366:
+    /// dense grid replaces the prior `AutoHashMapUnmanaged(KSet, f64)`; see
+    /// `ScoreGrid` for layout and the NaN-sentinel "unfilled" semantics.
+    scores: std.StringHashMapUnmanaged(ScoreGrid),
     /// per_gene_support_: gene → best full-annotation log-prob
     per_gene_support: std.StringHashMapUnmanaged(f64),
+
+    /// Kgrid offsets and dimensions. Set at the top of every `run()` from
+    /// `kbounds` and used by every `ScoreGrid` / `PathGrid` allocation in
+    /// the call. Stale between `run()` calls; only the live query reads them.
+    /// Stored on the handler rather than per-grid because every grid in a
+    /// query shares the same dims, and the conversion from `KSet` to
+    /// `(v_off, d_off)` happens at every read/write site.
+    kgrid_vmin: usize,
+    kgrid_dmin: usize,
+    kgrid_v_dim: usize,
+    kgrid_d_dim: usize,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -113,7 +239,21 @@ pub const DPHandler = struct {
             .paths = .{},
             .scores = .{},
             .per_gene_support = .{},
+            .kgrid_vmin = 0,
+            .kgrid_dmin = 0,
+            .kgrid_v_dim = 0,
+            .kgrid_d_dim = 0,
         };
+    }
+
+    /// Convert a KSet to its dense-grid (v_off, d_off). Asserts the kset is
+    /// inside the current query's grid bounds — every write site routes
+    /// ksets from the `runKSet` loop, which iterates over `[vmin, vmax) ×
+    /// [dmin, dmax)`, so an out-of-bounds kset here is a programmer bug.
+    inline fn kgridOff(self: *const DPHandler, kset: KSet) struct { v: usize, d: usize } {
+        std.debug.assert(kset.v >= self.kgrid_vmin and kset.v < self.kgrid_vmin + self.kgrid_v_dim);
+        std.debug.assert(kset.d >= self.kgrid_dmin and kset.d < self.kgrid_dmin + self.kgrid_d_dim);
+        return .{ .v = kset.v - self.kgrid_vmin, .d = kset.d - self.kgrid_dmin };
     }
 
     /// Per-query scratch allocator. **Always re-derive at the use site** —
@@ -160,18 +300,21 @@ pub const DPHandler = struct {
         self.scratch_cachefo.deinit(allocator);
         self.scratch_cachefo = .{};
 
-        // Free paths. Keys are shared with `scores` (see above).
+        // Free paths. Keys are shared with `scores` (see above). Item 2.1
+        // of #366: each value is now a dense `PathGrid` rather than a
+        // `AutoHashMap`; `PathGrid.deinit` walks the dense cells, deiniting
+        // every filled traceback path.
         var pit = self.paths.iterator();
         while (pit.next()) |entry| {
-            var inner_it = entry.value_ptr.iterator();
-            while (inner_it.next()) |kv| kv.value_ptr.deinit(allocator);
             entry.value_ptr.deinit(allocator);
         }
         self.paths.deinit(allocator);
         self.paths = .{};
 
         // Free scores. This is the canonical owner of the gene-name keys
-        // shared with `scratch_cachefo` and `paths`.
+        // shared with `scratch_cachefo` and `paths`. Item 2.1 of #366: each
+        // value is now a dense `ScoreGrid` (single backing slice) rather
+        // than an `AutoHashMap`.
         var sit = self.scores.iterator();
         while (sit.next()) |entry| {
             allocator.free(entry.key_ptr.*);
@@ -303,6 +446,15 @@ pub const DPHandler = struct {
         if (kbounds.vmin == 0 or kbounds.dmin == 0 or
             kbounds.vmax <= kbounds.vmin or kbounds.dmax <= kbounds.dmin)
             return error.TrivialKBounds;
+
+        // Item 2.1 of #366: pin the dense kset-grid bounds for this query.
+        // Every `ScoreGrid` / `PathGrid` allocated under `initCache` below
+        // sizes itself against these dims, and every `kgridOff` conversion
+        // resolves against these offsets.
+        self.kgrid_vmin = kbounds.vmin;
+        self.kgrid_dmin = kbounds.dmin;
+        self.kgrid_v_dim = kbounds.vmax - kbounds.vmin;
+        self.kgrid_d_dim = kbounds.dmax - kbounds.dmin;
 
         var best_scores: std.AutoHashMapUnmanaged(KSet, f64) = .{};
         defer best_scores.deinit(allocator);
@@ -549,47 +701,85 @@ pub const DPHandler = struct {
 
         const allocator = self.scratchAllocator();
         try self.scratch_cachefo.ensureUnusedCapacity(allocator, 1);
-        try self.paths.ensureUnusedCapacity(allocator, 1);
         try self.scores.ensureUnusedCapacity(allocator, 1);
 
+        // Allocate the grids before any map insertion so a mid-init OOM
+        // can't leave `scratch_cachefo` populated while `scores` is still
+        // empty — `clear()` is the canonical key owner and would miss a
+        // dangling `scratch_cachefo` entry if the order were inverted.
+        // After this block, every `putAssumeCapacity` is infallible.
+        var grid = try ScoreGrid.init(allocator, self.kgrid_v_dim, self.kgrid_d_dim);
+        errdefer grid.deinit(allocator);
+
+        // `paths` is only populated under viterbi; in forward mode the gene's
+        // entry is left absent, so `self.paths.getPtr(gene)` returns null at
+        // every read site (`fillTrellis` path-store, `findPartialCacheMatch`
+        // cache-copy block, `getPathNames`). This matches the old behaviour
+        // where the inner `AutoHashMap` was put-but-never-populated under
+        // forward — same observable, less allocation.
+        const want_paths = std.mem.eql(u8, self.algorithm, "viterbi");
+        var path_grid: PathGrid = undefined;
+        if (want_paths) {
+            try self.paths.ensureUnusedCapacity(allocator, 1);
+            path_grid = try PathGrid.init(allocator, self.kgrid_v_dim, self.kgrid_d_dim);
+        }
+        errdefer if (want_paths) path_grid.deinit(allocator);
+
         const key = try allocator.dupe(u8, gene);
+
+        // Infallible from here: every map has its capacity reserved and the
+        // grids are constructed. No partial-state window.
         self.scratch_cachefo.putAssumeCapacity(key, .{});
-        self.paths.putAssumeCapacity(key, .{});
-        self.scores.putAssumeCapacity(key, .{});
+        self.scores.putAssumeCapacity(key, grid);
+        if (want_paths) self.paths.putAssumeCapacity(key, path_grid);
     }
 
     /// Look for a cached kset whose region sequences are a prefix of the
     /// query's per-region undigitized strings (built via `getSubSeqs`).
     /// Returns null-kset if none found.
     fn findPartialCacheMatch(self: *DPHandler, region: Region, gene: []const u8, kset: KSet) KSet {
-        const gene_scores = self.scores.get(gene) orelse return KSet{ .v = 0, .d = 0 };
-        if (gene_scores.get(kset) != null) return kset;
+        const gene_scores = self.scores.getPtr(gene) orelse return KSet{ .v = 0, .d = 0 };
 
+        // Direct hit on the requested kset — same fast-path as the prior
+        // map-based version.
+        const off = self.kgridOff(kset);
+        if (gene_scores.get(off.v, off.d) != null) return kset;
+
+        // Item 2.1 of #366. The C++ source iterated `map<KSet,double>` in
+        // ascending `(v, d)` order; the Zig `AutoHashMap` was unordered, so
+        // the prior scan hand-tracked the minimum. Both produced the same
+        // logical match; the dense scan below produces it in O(d_dim) for
+        // V-region and O(v_dim) for J-region instead of O(n_filled_ksets).
         switch (region) {
             .v => {
-                // C++ map<KSet,double> iterates in ascending (v,d) order, so
-                // it returns the smallest-d match. We must replicate that.
-                var best: ?KSet = null;
-                var it = gene_scores.iterator();
-                while (it.next()) |kv| {
-                    if (kv.key_ptr.v == kset.v) {
-                        if (best == null or kv.key_ptr.d < best.?.d)
-                            best = kv.key_ptr.*;
+                // V-region: smallest filled d at fixed v. Iterate d_off in
+                // ascending order; first non-null is the smallest-d match.
+                var d_off: usize = 0;
+                while (d_off < gene_scores.d_dim) : (d_off += 1) {
+                    if (gene_scores.get(off.v, d_off) != null) {
+                        return KSet{ .v = kset.v, .d = self.kgrid_dmin + d_off };
                     }
                 }
-                if (best) |b| return b;
             },
             .j => {
-                var best: ?KSet = null;
-                var it = gene_scores.iterator();
-                while (it.next()) |kv| {
-                    if (kv.key_ptr.v + kv.key_ptr.d == kset.v + kset.d) {
-                        if (best == null or kv.key_ptr.v < best.?.v or
-                            (kv.key_ptr.v == best.?.v and kv.key_ptr.d < best.?.d))
-                            best = kv.key_ptr.*;
+                // J-region: among entries with v + d == target, smallest
+                // (v, d) lexicographically. On the diagonal each v has at
+                // most one d, so this is just the smallest filled v on the
+                // diagonal — iterate v_off ascending; for each, if the
+                // matching d is in-bounds and filled, return it.
+                const target = kset.v + kset.d;
+                var v_off: usize = 0;
+                while (v_off < gene_scores.v_dim) : (v_off += 1) {
+                    const v = self.kgrid_vmin + v_off;
+                    if (target < v) break; // ascending v means d would go negative from here on
+                    const d = target - v;
+                    if (d < self.kgrid_dmin) continue;
+                    const d_off_j = d - self.kgrid_dmin;
+                    if (d_off_j >= gene_scores.d_dim) continue;
+                    if (gene_scores.get(v_off, d_off_j) != null) {
+                        return KSet{ .v = v, .d = d };
                     }
                 }
-                if (best) |b| return b;
             },
             .d => {},
         }
@@ -717,7 +907,8 @@ pub const DPHandler = struct {
                 try trell_ptr.traceback(allocator, &path);
             }
             if (self.paths.getPtr(gene)) |gene_paths| {
-                try gene_paths.put(allocator, kset, path);
+                const off = self.kgridOff(kset);
+                gene_paths.put(off.v, off.d, path);
             } else {
                 path.deinit(allocator);
             }
@@ -731,7 +922,8 @@ pub const DPHandler = struct {
         const final_score = mathutils.addWithMinusInfinities(uncorrected_score, gene_choice_score);
 
         if (self.scores.getPtr(gene)) |gene_scores| {
-            try gene_scores.put(allocator, kset, final_score);
+            const off = self.kgridOff(kset);
+            gene_scores.put(off.v, off.d, final_score);
         }
 
         return origin;
@@ -991,26 +1183,29 @@ pub const DPHandler = struct {
                     // Copy path and score from cached kset. Both go into
                     // `self.paths` / `self.scores`, which outlive the kset
                     // — route through `scratch`, not `allocator`.
+                    const dst_off = self.kgridOff(kset);
+                    const src_off = self.kgridOff(partial_match);
                     if (self.paths.getPtr(gene)) |gp| {
-                        if (gp.get(partial_match)) |cached_path| {
+                        if (gp.getPtr(src_off.v, src_off.d)) |cached_path| {
                             var path_copy = TracebackPath.init();
                             errdefer path_copy.deinit(scratch);
                             try path_copy.path.appendSlice(scratch, cached_path.path.items);
                             path_copy.setScore(cached_path.score);
                             path_copy.setModel(cached_path.hmm.?);
-                            try gp.put(scratch, kset, path_copy);
+                            gp.put(dst_off.v, dst_off.d, path_copy);
                         }
                     }
                     if (self.scores.getPtr(gene)) |gs| {
-                        const cached_score = gs.get(partial_match) orelse mathutils.NEG_INF;
-                        try gs.put(scratch, kset, cached_score);
+                        const cached_score = gs.get(src_off.v, src_off.d) orelse mathutils.NEG_INF;
+                        gs.put(dst_off.v, dst_off.d, cached_score);
                     }
                     origin = "cached";
                 } else {
                     origin = try self.fillTrellis(allocator, kset, &query_seqs, gene);
                 }
 
-                const gene_score = if (self.scores.getPtr(gene)) |gs| gs.get(kset) orelse mathutils.NEG_INF else mathutils.NEG_INF;
+                const off = self.kgridOff(kset);
+                const gene_score = if (self.scores.getPtr(gene)) |gs| gs.get(off.v, off.d) orelse mathutils.NEG_INF else mathutils.NEG_INF;
 
                 // Debug: per-gene viterbi output
                 if (self.args.debug == 2 and std.mem.eql(u8, self.algorithm, "viterbi")) {
@@ -1190,7 +1385,8 @@ pub const DPHandler = struct {
         allocator: std.mem.Allocator,
     ) !std.ArrayListUnmanaged([]u8) {
         const gene_paths = self.paths.getPtr(gene) orelse return .{};
-        const path = gene_paths.getPtr(kset) orelse return .{};
+        const off = self.kgridOff(kset);
+        const path = gene_paths.getPtr(off.v, off.d) orelse return .{};
         return path.nameVector(allocator);
     }
 

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -14,6 +14,7 @@ const Model = @import("model.zig").Model;
 const Sequences = @import("sequences.zig").Sequences;
 const Sequence = @import("sequences.zig").Sequence;
 const mathutils = @import("mathutils.zig");
+const perf_counters = @import("perf_counters.zig");
 const Args = @import("args.zig").Args;
 const bcr = @import("bcr_utils/root.zig");
 const GermLines = bcr.GermLines;
@@ -234,6 +235,11 @@ pub const DPHandler = struct {
         const parent = self.parent_allocator;
         const run_start = std.time.milliTimestamp();
 
+        // Phase-0 diagnostics (#366): per-query counter reset. No-op when
+        // `-Dperf-counters=false` (default), so the bit-equal default build
+        // is unaffected.
+        perf_counters.reset();
+
         // Build a Sequences container that borrows from `seqvector`.
         // Each Sequence is a shallow struct-copy: slice headers are duplicated,
         // but the underlying name/header/undigitized/seqq buffers are shared
@@ -337,6 +343,7 @@ pub const DPHandler = struct {
                     n_too_long += 1;
                 } else {
                     const kset = KSet{ .v = k_v, .d = k_d };
+                    perf_counters.bumpKSet();
                     try self.runKSet(&seqs, kset, &only_genes, &best_scores, &total_scores, &best_genes);
                     n_run += 1;
                     const total_kset = total_scores.get(kset) orelse mathutils.NEG_INF;
@@ -382,6 +389,7 @@ pub const DPHandler = struct {
             if (!self.args.dont_rescale_emissions) {
                 try self.hmms.unRescaleOverallMuteFreqs(&only_genes);
             }
+            try self.dumpPerfCounters(&seqs);
             return result;
         }
 
@@ -414,7 +422,75 @@ pub const DPHandler = struct {
             try self.hmms.unRescaleOverallMuteFreqs(&only_genes);
         }
 
+        try self.dumpPerfCounters(&seqs);
         return result;
+    }
+
+    /// Phase-0 diagnostics dump (#366). No-op when `-Dperf-counters=false`.
+    /// Emits one PERFCOUNTER and one PERFCOUNTER_CACHE line per query.
+    ///
+    /// Output target: file path from `PARTIS_ZIG_PERF_LOG` env var (append).
+    /// Side-channel rather than stdout because partis captures bcrham stdout
+    /// and discards everything except recognised dbgstrs (utils.py:5896+);
+    /// the env-var redirect keeps the diagnostic output entirely outside
+    /// the partis input/output protocol so partis-test.py's parity checks
+    /// stay clean. When the env var is unset, the dump is silent.
+    fn dumpPerfCounters(self: *DPHandler, seqs: *const Sequences) !void {
+        if (!perf_counters.enabled) return;
+        const allocator = self.scratchAllocator();
+
+        const log_path = std.process.getEnvVarOwned(allocator, "PARTIS_ZIG_PERF_LOG") catch |err| switch (err) {
+            error.EnvironmentVariableNotFound => return,
+            else => return err,
+        };
+        defer allocator.free(log_path);
+
+        const name_str = try seqs.nameStr(allocator, ":");
+        defer allocator.free(name_str);
+
+        // cache_list length histogram across all genes in scratch_cachefo.
+        // Buckets are log-ish (0,1,2,3,4,5,[6-9],[10-19],[20-49],[50-99],
+        // [100-199],[200+]) — matches the order-of-magnitude questions the
+        // issue asks about chunk-cache state.
+        var buckets = [_]u64{0} ** 12;
+        var it = self.scratch_cachefo.iterator();
+        while (it.next()) |entry| {
+            const n = entry.value_ptr.items.len;
+            const idx: usize =
+                if (n == 0) 0 else if (n == 1) 1 else if (n == 2) 2 else if (n == 3) 3 else if (n == 4) 4 else if (n == 5) 5 else if (n < 10) 6 else if (n < 20) 7 else if (n < 50) 8 else if (n < 100) 9 else if (n < 200) 10 else 11;
+            buckets[idx] += 1;
+        }
+
+        // Build the PERFCOUNTER + PERFCOUNTER_CACHE block in one buffer
+        // and emit with a single writeAll. With multiple bcrham processes
+        // appending to the same log (`partis --n-procs N > 1`), splitting
+        // this into two writes would let another process slip a line
+        // between ours, separating the pair. Concatenated, the two lines
+        // share one O_APPEND atomic write.
+        const main_line = (try perf_counters.formatPerfCounters(allocator, self.algorithm, name_str, seqs.seqs.items.len)) orelse return;
+        defer allocator.free(main_line);
+        const cache_line = try std.fmt.allocPrint(
+            allocator,
+            "PERFCOUNTER_CACHE alg={s} q={s} 0={d} 1={d} 2={d} 3={d} 4={d} 5={d} 6_9={d} 10_19={d} 20_49={d} 50_99={d} 100_199={d} 200p={d}\n",
+            .{ self.algorithm, name_str, buckets[0], buckets[1], buckets[2], buckets[3], buckets[4], buckets[5], buckets[6], buckets[7], buckets[8], buckets[9], buckets[10], buckets[11] },
+        );
+        defer allocator.free(cache_line);
+        const blob = try std.mem.concat(allocator, u8, &.{ main_line, cache_line });
+        defer allocator.free(blob);
+
+        // O_APPEND on regular files: Linux serializes the
+        // seek-to-end-and-write pair at the syscall level, so each
+        // writeAll lands as one atomic append regardless of size — there
+        // is no PIPE_BUF-style upper bound for regular files. (PIPE_BUF
+        // applies to pipes, not files.) Concurrent bcrham processes
+        // therefore can't interleave the bytes of a single writeAll.
+        const log_path_z = try allocator.dupeZ(u8, log_path);
+        defer allocator.free(log_path_z);
+        const flags: std.posix.O = .{ .ACCMODE = .WRONLY, .APPEND = true, .CREAT = true };
+        const fd = try std.posix.openZ(log_path_z, flags, 0o644);
+        const file = std.fs.File{ .handle = fd };
+        defer file.close();
+        try file.writeAll(blob);
     }
 
     /// Get subsequences for one region.
@@ -541,11 +617,13 @@ pub const DPHandler = struct {
         gene: []const u8,
     ) ![]const u8 {
         const allocator = self.scratchAllocator();
+        perf_counters.bumpFillTrellis();
 
         // Look for a chunk-cached trellis. Prefix-match is on undigitized
         // strings of the cached trellis's stored query_seqs.
         var cached_trellis: ?*const Trellis = null;
         if (!self.args.no_chunk_cache) {
+            perf_counters.bumpChunkCacheLookup();
             if (self.scratch_cachefo.getPtr(gene)) |cache_list| {
                 for (cache_list.items) |te| {
                     const cached_seqs = te.query_seqs.seqs.items;
@@ -561,6 +639,7 @@ pub const DPHandler = struct {
                     }
                     if (all_match) {
                         cached_trellis = &te.trellis;
+                        perf_counters.bumpChunkCacheHit();
                         break;
                     }
                 }

--- a/packages/zig-core/src/ham/fast_math.c
+++ b/packages/zig-core/src/ham/fast_math.c
@@ -1,0 +1,80 @@
+/* fast_math.c — fast log-sum-exp via tabulated softplus.
+ *
+ * Drop-in replacement for the `log(1 + exp(d))` work in AddInLogSpace
+ * (mathutils.h:98). Replaces 1 log + 1 exp glibc call (~5–17 ns combined,
+ * arch-dependent) with a single 65 K-entry linear-interpolation lookup
+ * (~3.5–10 ns per call).
+ *
+ * Pre-flight measurements at issue #366 item 3.2:
+ *   - Zen 5 (glibc 2.39): glibc 9.6 ns → LUT64K 7.3 ns per addInLogSpace
+ *   - Broadwell:          glibc 16.7 ns → LUT64K 10.0 ns
+ *   - LUT64K accuracy: max abs error 6.5e-9 over [-30, 0] (5 orders under
+ *     the partis-test 1e-5 gate).
+ *
+ * Why a 65 K linear-interp table:
+ *   The Cephes scalar polynomial alternative (~7-15 ns) loses to modern
+ *   glibc's FMA-optimized scalar log/exp on every CPU we tested. LUT
+ *   wins because it replaces ~10 ALU ops + branches with a single load
+ *   + 1 multiply + 1 fma. Smaller LUTs (256, 4 K, 16 K) fail the worst-
+ *   case error budget; LUT64K passes by 4×. Cubic interp at 1 K entries
+ *   would also pass speed-wise but not accuracy-wise.
+ *
+ * The linear-interp arithmetic dominates over the table size in cycle
+ * count (LUT256 ≈ LUT64K on every benchmarked CPU), so going larger is
+ * effectively free as long as the hot region stays cache-resident — and
+ * it does, because real DP traffic concentrates near d = 0.
+ *
+ * Built with -O3 -ffp-contract=off so that the linear-interp arithmetic
+ * is bit-deterministic across g++/clang/zig from the same C source.
+ * (Without that flag, cross-compiler drift would be 1–2 ULP — far under
+ * the partis-test gate, but bit-equality between backends is cheap to
+ * keep so we keep it.)
+ *
+ * Mirrored on the Zig side at packages/zig-core/src/ham/fast_math.c.
+ * Both sides MUST stay in sync; the table is data so cross-backend
+ * parity is trivial as long as the same source compiles to both.
+ */
+#include <math.h>
+
+/* Range of d for which the table covers softplus(d) = log(1 + exp(d))
+ * directly. Outside this range, we use the closed-form fall-throughs:
+ *   d < LUT_LO:  exp(d) is well under double precision, softplus ≈ 0.
+ *   d > 0:       use the symmetry softplus(d) = d + softplus(-d).
+ *
+ * Within addInLogSpace's standard form (see mathutils.h AddInLogSpace),
+ * the argument is always (smaller - larger) ≤ 0. The d > 0 branch is
+ * defensive — should not be exercised in practice, but keeps the
+ * function safe to call independently.
+ */
+#define LUT_N  65536
+#define LUT_LO -30.0
+#define LUT_HI 0.0
+
+static double softplus_lut[LUT_N + 1];
+
+/* (LUT_N / |LUT_LO|) precomputed for the index calculation. Using a
+ * macro keeps it a compile-time constant, which the compiler can fold
+ * into the multiply at the call site. */
+#define LUT_SCALE ((double) LUT_N / -(LUT_LO))
+
+__attribute__((constructor))
+static void init_softplus_lut(void) {
+    /* log1p(exp(d)) is the numerically stable form of log(1 + exp(d))
+     * for the table-build phase. Build is one-shot at process start. */
+    for (int i = 0; i <= LUT_N; ++i) {
+        double d = LUT_LO + (LUT_HI - LUT_LO) * (double) i / (double) LUT_N;
+        softplus_lut[i] = log1p(exp(d));
+    }
+}
+
+double fast_softplus(double d) {
+    if (d < LUT_LO) return 0.0;
+    if (d > 0.0)    return d + fast_softplus(-d);   /* symmetry */
+    /* d ∈ [LUT_LO, 0] — index in [0, LUT_N] */
+    double t = (d - LUT_LO) * LUT_SCALE;
+    int i = (int) t;
+    double frac = t - (double) i;
+    double y0 = softplus_lut[i];
+    double y1 = softplus_lut[i + 1];
+    return y0 + frac * (y1 - y0);
+}

--- a/packages/zig-core/src/ham/fast_math.c
+++ b/packages/zig-core/src/ham/fast_math.c
@@ -73,6 +73,14 @@ double fast_softplus(double d) {
     /* d ∈ [LUT_LO, 0] — index in [0, LUT_N] */
     double t = (d - LUT_LO) * LUT_SCALE;
     int i = (int) t;
+    /* Clamp `i` so `i+1` stays in bounds. At d == 0 (or d so close to 0
+     * that float rounding gives t == LUT_N), the unclamped i would equal
+     * LUT_N and the `softplus_lut[i+1]` read would be one past the array.
+     * The production result was correct only because `frac == 0` masked
+     * the OOB read; Debug-mode bounds checks fired. With the clamp,
+     * frac becomes 1.0 at the boundary and y0 + 1.0*(y1-y0) = y1 =
+     * softplus_lut[LUT_N], identical to the unclamped value. */
+    if (i >= LUT_N) i = LUT_N - 1;
     double frac = t - (double) i;
     double y0 = softplus_lut[i];
     double y1 = softplus_lut[i + 1];

--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -211,7 +211,7 @@ pub const Glomerator = struct {
                     is_seed_missing,
                     only_genes.items,
                     kbounds,
-                    @floatCast(qrow.mut_freq),
+                    qrow.mut_freq,
                     @intCast(@max(0, qrow.cdr3_length)),
                     null, null,
                 );
@@ -233,7 +233,7 @@ pub const Glomerator = struct {
                 is_seed_missing,
                 only_genes.items,
                 kbounds,
-                @floatCast(qrow.mut_freq),
+                qrow.mut_freq,
                 @intCast(@max(0, qrow.cdr3_length)),
                 null, null,
             );
@@ -344,7 +344,7 @@ pub const Glomerator = struct {
     /// Run full hierarchical clustering and write output.
     /// Corresponds to C++ `Glomerator::Cluster`.
     pub fn cluster(self: *Glomerator) !void {
-        if (self.args.logprob_ratio_threshold == -std.math.inf(f32)) {
+        if (self.args.logprob_ratio_threshold == -std.math.inf(f64)) {
             return error.LogprobRatioThresholdNotSet;
         }
 
@@ -1214,7 +1214,7 @@ pub const Glomerator = struct {
             is_seed_missing,
             only_genes_list.items,
             kbounds,
-            @floatCast(mute_freq_total / @as(f64, @floatFromInt(n_names))),
+            mute_freq_total / @as(f64, @floatFromInt(n_names)),
             cdr3_length,
             null, null,
         );
@@ -1279,7 +1279,7 @@ pub const Glomerator = struct {
         const n_a_f64: f64 = @floatFromInt(ref_a.nSeqs());
         const n_b_f64: f64 = @floatFromInt(ref_b.nSeqs());
         const n_total_f64: f64 = n_a_f64 + n_b_f64;
-        const joint_mute_freq: f32 = @floatCast((n_a_f64 * @as(f64, ref_a.mute_freq) + n_b_f64 * @as(f64, ref_b.mute_freq)) / n_total_f64);
+        const joint_mute_freq: f64 = (n_a_f64 * ref_a.mute_freq + n_b_f64 * ref_b.mute_freq) / n_total_f64;
         const is_seed_missing = !ham_text.inString(self.args.seed_unique_id, joint_name, ":");
 
         var key_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
@@ -1460,8 +1460,10 @@ pub const Glomerator = struct {
         // C++ caches the subset in tmp_cachefo_ using the parent cluster's attributes
         // (only_genes, kbounds, mute_freq, cdr3_length). This is important because
         // later getCachefo() calls for the subset will find this entry instead of
-        // rebuilding from singles, and the parent's mute_freq (which carries f32
-        // merge cascade truncation) must be used for consistency with C++.
+        // rebuilding from singles, so the parent's mute_freq (the weighted-average
+        // value carried through the merge cascade) must be used for consistency
+        // with C++. Pre-#377 both backends stored mute_freq as f32, so the cascade
+        // also accumulated f32 truncation; #377 promoted both to f64.
         const cacheref = try self.getCachefo(queries);
         {
             var sub_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};

--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -468,10 +468,17 @@ pub const Glomerator = struct {
             }
 
             if (logprob_str.len > 0) {
-                // C++ uses stof() which parses to float32 then widens to double.
-                // We must match that precision loss.
-                const val32: f32 = std.fmt.parseFloat(f32, logprob_str) catch continue;
-                const val: f64 = @as(f64, val32);
+                // C++ uses stod() (since ham f41e055 "fix precision: stof→stod for cache reads"):
+                // log_probs_ is map<string,double> and the cache file is written with setprecision(20).
+                // Parse as f64 to preserve full precision (the previous f32 truncation drove the
+                // 30k Zig-vs-C++ partition divergence — issue #375).
+                // `catch` warns and skips: a corrupted/truncated cache line shouldn't kill the
+                // run, but it should be visible. Cache files written with setprecision(20) are
+                // valid ASCII decimal so this should not fire under normal operation.
+                const val: f64 = std.fmt.parseFloat(f64, logprob_str) catch |e| {
+                    std.debug.print("WARN cache logprob parse failed for {s}: {} (skipping)\n", .{ query, e });
+                    continue;
+                };
                 const gop_lp = try self.log_probs.getOrPut(allocator, query);
                 if (!gop_lp.found_existing) gop_lp.key_ptr.* = try allocator.dupe(u8, query);
                 gop_lp.value_ptr.* = val;
@@ -480,9 +487,11 @@ pub const Glomerator = struct {
             }
 
             if (naive_hfrac_str.len > 0) {
-                // C++ uses stof() which parses to float32 then widens to double.
-                const val32: f32 = std.fmt.parseFloat(f32, naive_hfrac_str) catch continue;
-                const val: f64 = @as(f64, val32);
+                // C++ uses stod() (see logprob branch above).
+                const val: f64 = std.fmt.parseFloat(f64, naive_hfrac_str) catch |e| {
+                    std.debug.print("WARN cache naive_hfrac parse failed for {s}: {} (skipping)\n", .{ query, e });
+                    continue;
+                };
                 const gop_nh = try self.naive_hfracs.getOrPut(allocator, query);
                 if (!gop_nh.found_existing) gop_nh.key_ptr.* = try allocator.dupe(u8, query);
                 gop_nh.value_ptr.* = val;

--- a/packages/zig-core/src/ham/glomerator/query.zig
+++ b/packages/zig-core/src/ham/glomerator/query.zig
@@ -22,7 +22,7 @@ pub const Query = struct {
     seed_missing: bool,
     only_genes: std.ArrayListUnmanaged([]u8),
     kbounds: KBounds,
-    mute_freq: f32,
+    mute_freq: f64,
     cdr3_length: usize,
     /// Names of the two parent queries (may be empty when not set).
     parents: ?[2][]u8,
@@ -51,7 +51,7 @@ pub const Query = struct {
         seed_missing: bool,
         only_genes: []const []const u8,
         kbounds: KBounds,
-        mute_freq: f32,
+        mute_freq: f64,
         cdr3_length: usize,
         parent1: ?[]const u8,
         parent2: ?[]const u8,

--- a/packages/zig-core/src/ham/mathutils.zig
+++ b/packages/zig-core/src/ham/mathutils.zig
@@ -13,6 +13,7 @@
 
 const std = @import("std");
 const math = std.math;
+const perf_counters = @import("perf_counters.zig");
 
 // Use glibc log/exp via C wrapper (glibc_math.c) to match C++ bcrham bit-for-bit.
 // Zig's `extern fn log/exp` resolves to compiler-rt (bundled as local 't' symbols),
@@ -64,8 +65,13 @@ pub fn addWithMinusInfinities(first: f64, second: f64) f64 {
 /// Implements the log-space *or* operation (a OR b = a + b in probability space).
 /// Corresponds to C++ `ham::AddInLogSpace<T>(T first, T second)`.
 pub fn addInLogSpace(first: f64, second: f64) f64 {
+    perf_counters.bumpAddInLogSpace();
     if (first == NEG_INF) return second;
     if (second == NEG_INF) return first;
+    // Past both early-outs: this call does exactly 1 log + 1 exp. Bump
+    // the work counter separately so item-3.2 cost predictions can be
+    // priced against actual transcendental work, not call rate.
+    perf_counters.bumpAddInLogSpaceLogExp();
     if (first > second) {
         return first + log(1.0 + exp(second - first));
     } else {

--- a/packages/zig-core/src/ham/mathutils.zig
+++ b/packages/zig-core/src/ham/mathutils.zig
@@ -24,6 +24,15 @@ extern fn glibc_exp(x: f64) f64;
 pub const log = glibc_log;
 pub const exp = glibc_exp;
 
+// fast_softplus(d) = log(1 + exp(d)), via 64K-entry linear-interp LUT.
+// Implemented in fast_math.c; mirrored on the C++ side at
+// packages/ham/src/fast_math.c. Replaces 1 log + 1 exp glibc call inside
+// addInLogSpace with a single load + 1 mul + 1 fma — ~22-40% speedup
+// per addInLogSpace call across Zen 3-5 and Intel Broadwell. Accuracy
+// 6.5e-9 max abs over [-30, 0] (5 orders under partis-test 1e-5 gate).
+// See fast_math.c for the design notes (issue #366 item 3.2).
+extern fn fast_softplus(d: f64) f64;
+
 /// Negative infinity constant for log-probability computations.
 /// Replaces the verbose `-std.math.inf(f64)` throughout the codebase.
 pub const NEG_INF: f64 = -math.inf(f64);
@@ -68,14 +77,15 @@ pub fn addInLogSpace(first: f64, second: f64) f64 {
     perf_counters.bumpAddInLogSpace();
     if (first == NEG_INF) return second;
     if (second == NEG_INF) return first;
-    // Past both early-outs: this call does exactly 1 log + 1 exp. Bump
-    // the work counter separately so item-3.2 cost predictions can be
-    // priced against actual transcendental work, not call rate.
+    // Past both early-outs: one call to fast_softplus (LUT lookup, no glibc
+    // log/exp). The counter name kept its original log+exp suffix because
+    // the call site is still the place where item-3.2's transcendental work
+    // used to live — re-naming would invalidate prior #368 measurements.
     perf_counters.bumpAddInLogSpaceLogExp();
     if (first > second) {
-        return first + log(1.0 + exp(second - first));
+        return first + fast_softplus(second - first);
     } else {
-        return second + log(1.0 + exp(first - second));
+        return second + fast_softplus(first - second);
     }
 }
 

--- a/packages/zig-core/src/ham/perf_counters.zig
+++ b/packages/zig-core/src/ham/perf_counters.zig
@@ -1,0 +1,165 @@
+/// ham/perf_counters.zig — Phase-0 diagnostics counters for issue #366.
+///
+/// The whole module is gated on the `-Dperf-counters` build option (see
+/// `build.zig`). When the option is `false` (default), `enabled` is a
+/// comptime `false` and every `if (enabled) { ... }` block in the hot
+/// path compiles to nothing — bit-equality with the un-instrumented build
+/// is preserved.
+///
+/// Counters cover the metrics requested in #366 phase 0.1 / 0.2:
+///
+///   - addInLogSpace_calls          — `mathutils.zig:addInLogSpace` entry
+///   - addInLogSpace_log_exp_calls  — calls past both NEG_INF early-outs
+///                                    (each = 1 log + 1 exp of work)
+///   - fillTrellis_calls            — `dp_handler.zig:fillTrellis` entry
+///   - n_ksets                      — `dp_handler.zig:run` kset loop
+///   - chunk_cache_lookups/hits     — `dp_handler.zig:fillTrellis` cache
+///                                    branch entry / prefix-match success
+///   - active_state_hist[count]     — `trellis.zig` middleViterbiVals/
+///                                    middleForwardVals
+///
+/// The `_calls` vs `_log_exp_calls` split for `addInLogSpace` matters for
+/// item-3.2 costing: at function entry the call may still hit a cheap
+/// `NEG_INF` short-circuit and do zero transcendental work. The first
+/// counter is the call rate; the second is the rate of work that an
+/// item-3.2 log/exp approximation would actually replace.
+///
+/// State is process-global and reset at start of each `DPHandler.run()`.
+/// `formatPerfCounters` returns one heap-allocated PERFCOUNTER line per
+/// query; caller writes it to the destination it picks (current dump site
+/// is the file at `PARTIS_ZIG_PERF_LOG`, opened O_APPEND to keep parallel
+/// bcrham processes non-clobbering — see `dp_handler.zig:dumpPerfCounters`).
+///
+/// SAFETY: the counters below are plain `pub var` globals, NOT atomics.
+/// Every caller must run single-threaded within a process. bcrham is
+/// single-threaded by design (#342 item 1 investigated and rejected
+/// `smp_allocator`); cross-process parallelism via `partis --n-procs N`
+/// runs each bcrham in its own address space, so the globals stay
+/// per-process. If a future caller introduces threading inside a single
+/// bcrham process, this module must grow atomic counters or per-thread
+/// shadow state.
+const std = @import("std");
+const build_options = @import("build_options");
+
+pub const enabled: bool = build_options.perf_counters;
+
+/// Length of the active-state histogram. State indices in this codebase
+/// are bounded by `state.zig:STATE_MAX = 500`; one extra slot for 500 itself.
+const HIST_LEN: usize = 501;
+
+pub var addInLogSpace_calls: u64 = 0;
+pub var addInLogSpace_log_exp_calls: u64 = 0;
+pub var fillTrellis_calls: u64 = 0;
+pub var n_ksets: u64 = 0;
+pub var chunk_cache_lookups: u64 = 0;
+pub var chunk_cache_hits: u64 = 0;
+pub var active_state_hist: [HIST_LEN]u64 = [_]u64{0} ** HIST_LEN;
+
+pub fn reset() void {
+    if (!enabled) return;
+    addInLogSpace_calls = 0;
+    addInLogSpace_log_exp_calls = 0;
+    fillTrellis_calls = 0;
+    n_ksets = 0;
+    chunk_cache_lookups = 0;
+    chunk_cache_hits = 0;
+    // NB: explicit loop instead of `@memset(&active_state_hist, 0)` —
+    // Zig 0.15.2 hits an x86_64 codegen bug ("no encoding found for:
+    // none mov m64 m64 none none") on a Debug @memset over a fixed-size
+    // global u64 array. The loop sidesteps the bug and any optimizer
+    // will turn it back into a memset under ReleaseFast/ReleaseSafe.
+    var i: usize = 0;
+    while (i < HIST_LEN) : (i += 1) active_state_hist[i] = 0;
+}
+
+pub inline fn bumpAddInLogSpace() void {
+    if (enabled) addInLogSpace_calls += 1;
+}
+
+pub inline fn bumpAddInLogSpaceLogExp() void {
+    if (enabled) addInLogSpace_log_exp_calls += 1;
+}
+
+pub inline fn bumpFillTrellis() void {
+    if (enabled) fillTrellis_calls += 1;
+}
+
+pub inline fn bumpKSet() void {
+    if (enabled) n_ksets += 1;
+}
+
+pub inline fn bumpChunkCacheLookup() void {
+    if (enabled) chunk_cache_lookups += 1;
+}
+
+pub inline fn bumpChunkCacheHit() void {
+    if (enabled) chunk_cache_hits += 1;
+}
+
+pub inline fn recordActiveStates(n: usize) void {
+    if (!enabled) return;
+    const idx = if (n >= HIST_LEN) HIST_LEN - 1 else n;
+    active_state_hist[idx] += 1;
+}
+
+/// Compute (median, p95, max, total_positions) over the active-state histogram.
+fn activeStateStats() struct { median: usize, p95: usize, max: usize, total: u64 } {
+    var total: u64 = 0;
+    for (active_state_hist) |c| total += c;
+    if (total == 0) return .{ .median = 0, .p95 = 0, .max = 0, .total = 0 };
+    const median_target = (total + 1) / 2;
+    const p95_target = (total * 95 + 99) / 100;
+    var cum: u64 = 0;
+    var median: usize = 0;
+    var p95: usize = 0;
+    var max_idx: usize = 0;
+    var i: usize = 0;
+    while (i < HIST_LEN) : (i += 1) {
+        if (active_state_hist[i] == 0) continue;
+        max_idx = i;
+        const next_cum = cum + active_state_hist[i];
+        if (cum < median_target and median_target <= next_cum) median = i;
+        if (cum < p95_target and p95_target <= next_cum) p95 = i;
+        cum = next_cum;
+    }
+    return .{ .median = median, .p95 = p95, .max = max_idx, .total = total };
+}
+
+/// Format the per-query counter summary as a heap-allocated `[]u8` (caller frees).
+/// Returns null when counters are disabled (caller skips the write).
+/// Format is intentionally trivial-to-grep:
+///   PERFCOUNTER alg=... q=... n_seqs=... ksets=... fillTrellis=... \
+///       chunk_hits=H/L addInLogSpace=... addInLogSpace_log_exp=... \
+///       active_states_med=... active_states_p95=... active_states_max=... \
+///       active_states_positions=...
+///
+/// `chunk_hits=H/L`: H = prefix-match successes, L = lookup attempts (the
+/// `if (!no_chunk_cache)` branch entries in fillTrellis). Hit rate is H/L.
+pub fn formatPerfCounters(
+    allocator: std.mem.Allocator,
+    algorithm: []const u8,
+    query_name: []const u8,
+    n_seqs: usize,
+) !?[]u8 {
+    if (!enabled) return null;
+    const stats = activeStateStats();
+    return try std.fmt.allocPrint(
+        allocator,
+        "PERFCOUNTER alg={s} q={s} n_seqs={d} ksets={d} fillTrellis={d} chunk_hits={d}/{d} addInLogSpace={d} addInLogSpace_log_exp={d} active_states_med={d} active_states_p95={d} active_states_max={d} active_states_positions={d}\n",
+        .{
+            algorithm,
+            query_name,
+            n_seqs,
+            n_ksets,
+            fillTrellis_calls,
+            chunk_cache_hits,
+            chunk_cache_lookups,
+            addInLogSpace_calls,
+            addInLogSpace_log_exp_calls,
+            stats.median,
+            stats.p95,
+            stats.max,
+            stats.total,
+        },
+    );
+}

--- a/packages/zig-core/src/ham/text.zig
+++ b/packages/zig-core/src/ham/text.zig
@@ -117,14 +117,12 @@ pub fn intify(allocator: std.mem.Allocator, strlist: []const []const u8) ![]i32 
 }
 
 /// Converts a slice of strings to a slice of f64.
-/// C++ uses stof (f32 precision) but returns vector<double>; we parse as f32 then widen to f64 to match.
+/// C++ uses stod (full f64 precision) since ham f41e055 "fix precision: stof→stod for cache reads".
 /// Corresponds to C++ `ham::Floatify(vector<string> strlist)`.
 pub fn floatify(allocator: std.mem.Allocator, strlist: []const []const u8) ![]f64 {
     const result = try allocator.alloc(f64, strlist.len);
     for (strlist, 0..) |s, i| {
-        // C++ uses stof (single-precision parse) — match that precision by parsing as f32 then widening
-        const f32_val = try std.fmt.parseFloat(f32, s);
-        result[i] = @as(f64, f32_val);
+        result[i] = try std.fmt.parseFloat(f64, s);
     }
     return result;
 }

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -13,6 +13,7 @@ const Sequences = @import("sequences.zig").Sequences;
 const Sequence = @import("sequences.zig").Sequence;
 const TracebackPath = @import("traceback_path.zig").TracebackPath;
 const mathutils = @import("mathutils.zig");
+const perf_counters = @import("perf_counters.zig");
 
 /// DP trellis for Forward/Viterbi algorithms.
 /// Corresponds to C++ `ham::Trellis`.
@@ -365,6 +366,7 @@ pub const Trellis = struct {
         next_states: *std.ArrayListUnmanaged(usize),
         position: usize,
     ) !void {
+        perf_counters.recordActiveStates(current_states.items.len);
         // See viterbi(): cache borrowed seqs pointer in a local for the inner loop.
         const seqs = self.seqs;
         for (current_states.items) |i_st_cur| {
@@ -399,6 +401,7 @@ pub const Trellis = struct {
         next_states: *std.ArrayListUnmanaged(usize),
         position: usize,
     ) !void {
+        perf_counters.recordActiveStates(current_states.items.len);
         // See viterbi(): cache borrowed seqs pointer in a local for the inner loop.
         const seqs = self.seqs;
         for (current_states.items) |i_st_cur| {

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -65,6 +65,18 @@ pub const Trellis = struct {
     scoring_current: []f64,
     scoring_previous: []f64,
 
+    /// Indices into scoring_current that may hold non-NEG_INF values
+    /// (a SUPERSET of truly-dirty slots — see `swapColumnsActive`). Mirrors
+    /// the swap of scoring_current ↔ scoring_previous so the sparse clear
+    /// in `swapColumnsActive` only touches slots that were active two
+    /// iterations ago, instead of the full n_states column. Item 1.1 of
+    /// #366: at rung-2 medians (~50 active states / 500 n_states) this
+    /// drops the per-position memset from O(n_states) to O(active).
+    scoring_current_dirty: std.ArrayListUnmanaged(usize),
+    /// Indices into scoring_previous that may hold non-NEG_INF values.
+    /// See `scoring_current_dirty`.
+    scoring_previous_dirty: std.ArrayListUnmanaged(usize),
+
     /// Scratch bitset for deduplicating next_states additions.
     next_seen: state_mod.StateBitset,
 
@@ -118,6 +130,8 @@ pub const Trellis = struct {
             .viterbi_indices = .{},
             .scoring_current = scoring_current,
             .scoring_previous = scoring_previous,
+            .scoring_current_dirty = .{},
+            .scoring_previous_dirty = .{},
             .next_seen = state_mod.StateBitset.initEmpty(),
             .allocator = allocator,
         };
@@ -132,6 +146,8 @@ pub const Trellis = struct {
         self.viterbi_indices.deinit(allocator);
         allocator.free(self.scoring_current);
         allocator.free(self.scoring_previous);
+        self.scoring_current_dirty.deinit(allocator);
+        self.scoring_previous_dirty.deinit(allocator);
     }
 
     /// Run the Viterbi algorithm.
@@ -174,9 +190,13 @@ pub const Trellis = struct {
         @memset(self.traceback_table, -1);
         self.traceback_n_states = n_states;
 
-        // Reset scoring columns
+        // Reset scoring columns. Dirty lists pair with the buffers and start
+        // empty: the full memset establishes the all-NEG_INF invariant that
+        // the sparse clear in `swapColumnsActive` relies on.
         @memset(self.scoring_current, mathutils.NEG_INF);
         @memset(self.scoring_previous, mathutils.NEG_INF);
+        self.scoring_current_dirty.clearRetainingCapacity();
+        self.scoring_previous_dirty.clearRetainingCapacity();
 
         var current_states = std.ArrayListUnmanaged(usize){};
         defer current_states.deinit(allocator);
@@ -192,6 +212,7 @@ pub const Trellis = struct {
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
+            try self.scoring_current_dirty.append(allocator, i_st);
             self.cacheViterbiVals(0, dpval, i_st);
             // Mark outbound transitions for next position (deduplicated)
             for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
@@ -242,9 +263,11 @@ pub const Trellis = struct {
         try self.forward_log_probs.resize(allocator, seq_len);
         @memset(self.forward_log_probs.items, mathutils.NEG_INF);
 
-        // Reset scoring columns
+        // Reset scoring columns. See `viterbi()` for the dirty-list invariant.
         @memset(self.scoring_current, mathutils.NEG_INF);
         @memset(self.scoring_previous, mathutils.NEG_INF);
+        self.scoring_current_dirty.clearRetainingCapacity();
+        self.scoring_previous_dirty.clearRetainingCapacity();
 
         var current_states = std.ArrayListUnmanaged(usize){};
         defer current_states.deinit(allocator);
@@ -260,6 +283,7 @@ pub const Trellis = struct {
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
+            try self.scoring_current_dirty.append(allocator, i_st);
             // Mark outbound transitions for next position (deduplicated)
             for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
                 if (!self.next_seen.isSet(j)) {
@@ -330,11 +354,23 @@ pub const Trellis = struct {
         current_states: *std.ArrayListUnmanaged(usize),
         next_states: *std.ArrayListUnmanaged(usize),
     ) !void {
-        // Swap scoring_current ↔ scoring_previous
-        const tmp = self.scoring_previous;
-        self.scoring_previous = self.scoring_current;
-        self.scoring_current = tmp;
-        @memset(self.scoring_current, mathutils.NEG_INF);
+        // Swap scoring_current ↔ scoring_previous, and the parallel dirty
+        // lists. After the swap, `scoring_current` is the buffer that was
+        // last written *two* iterations ago (or position-0 init); only the
+        // slots in `scoring_current_dirty` (the freshly-swapped-in list) can
+        // be non-NEG_INF, so a sparse clear over those slots restores the
+        // all-NEG_INF invariant. Item 1.1 of #366.
+        std.mem.swap([]f64, &self.scoring_current, &self.scoring_previous);
+        std.mem.swap(
+            std.ArrayListUnmanaged(usize),
+            &self.scoring_current_dirty,
+            &self.scoring_previous_dirty,
+        );
+
+        for (self.scoring_current_dirty.items) |idx| {
+            self.scoring_current[idx] = mathutils.NEG_INF;
+        }
+        self.scoring_current_dirty.clearRetainingCapacity();
 
         // Clear next_seen for all indices that were in next_states
         // (they will become current_states; next_seen tracks what's queued for the NEW next)
@@ -373,6 +409,12 @@ pub const Trellis = struct {
             const st_cur = self.hmm.stateByIndex(i_st_cur);
             const emission_val = st_cur.emissionLogprobSeqs(seqs, position);
             if (std.math.isNegativeInf(emission_val)) continue;
+            // Track for the sparse clear in `swapColumnsActive`. This is a
+            // SUPERSET of slots we actually write: if every i_st_prev has
+            // NEG_INF prev_val, no write happens but i_st_cur is still in the
+            // dirty list. Clearing an already-NEG_INF slot is a no-op, so the
+            // superset is bit-equal.
+            try self.scoring_current_dirty.append(allocator, i_st_cur);
             for (st_cur.from_state_indices.items) |i_st_prev| {
                 const prev_val = self.scoring_previous[i_st_prev];
                 if (std.math.isNegativeInf(prev_val)) continue;
@@ -408,6 +450,8 @@ pub const Trellis = struct {
             const st_cur = self.hmm.stateByIndex(i_st_cur);
             const emission_val = st_cur.emissionLogprobSeqs(seqs, position);
             if (std.math.isNegativeInf(emission_val)) continue;
+            // See `middleViterbiVals` for the dirty-list invariant.
+            try self.scoring_current_dirty.append(allocator, i_st_cur);
             for (st_cur.from_state_indices.items) |i_st_prev| {
                 const prev_val = self.scoring_previous[i_st_prev];
                 if (std.math.isNegativeInf(prev_val)) continue;

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -182,6 +182,14 @@ pub const Trellis = struct {
         defer current_states.deinit(allocator);
         var next_states = std.ArrayListUnmanaged(usize){};
         defer next_states.deinit(allocator);
+        // Third list for the sparse-memset three-way rotation in
+        // swapColumnsActive (#366 item 1.1). Holds the candidate-set used
+        // as input to the previous middleViterbiVals call; rotates into
+        // the role of "dirty-list for two swaps from now" so the sparse
+        // clear has the right indices in hand at every iteration without
+        // any per-active-state bookkeeping in the hot inner loop.
+        var prev_current_states = std.ArrayListUnmanaged(usize){};
+        defer prev_current_states.deinit(allocator);
 
         // Position 0: transitions from init state
         const init_st = self.hmm.initial orelse return error.NoInitState;
@@ -192,6 +200,16 @@ pub const Trellis = struct {
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
+            // Track which slots the init code wrote, so the three-way list
+            // rotation in swapColumnsActive can derive iter-2's dirty-list
+            // (= these init writes) without a separate `init_written_states`
+            // list. Treats init as a virtual "iteration 0": its
+            // current_states output is the indices it wrote, and rotates
+            // into prev_current_states at swap #1 → ready for sparse-clear
+            // at swap #2 when the buffer swap exposes these slots in
+            // scoring_current. This is the small refinement of the plan's
+            // "option (b)" (init memset alone leaves swap #2's clear empty).
+            try current_states.append(allocator, i_st);
             self.cacheViterbiVals(0, dpval, i_st);
             // Mark outbound transitions for next position (deduplicated)
             for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
@@ -205,10 +223,10 @@ pub const Trellis = struct {
         // Positions 1..seq_len-1
         var position: usize = 1;
         while (position < seq_len) : (position += 1) {
-            try self.swapColumnsActive(allocator, &current_states, &next_states);
+            self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
             try self.middleViterbiVals(allocator, current_states, &next_states, position);
         }
-        try self.swapColumnsActive(allocator, &current_states, &next_states);
+        self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
 
         // Compute ending probability
         self.ending_viterbi_pointer = -1;
@@ -250,6 +268,10 @@ pub const Trellis = struct {
         defer current_states.deinit(allocator);
         var next_states = std.ArrayListUnmanaged(usize){};
         defer next_states.deinit(allocator);
+        // Third list for the sparse-memset three-way rotation in
+        // swapColumnsActive (#366 item 1.1); see viterbi() for the rationale.
+        var prev_current_states = std.ArrayListUnmanaged(usize){};
+        defer prev_current_states.deinit(allocator);
 
         // Position 0: transitions from init state
         const init_st = self.hmm.initial orelse return error.NoInitState;
@@ -260,6 +282,10 @@ pub const Trellis = struct {
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
+            // Track which slots the init code wrote so the three-way list
+            // rotation can derive iter-2's dirty-list. See viterbi() for
+            // the longer rationale; same logic applies here verbatim.
+            try current_states.append(allocator, i_st);
             // Mark outbound transitions for next position (deduplicated)
             for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
                 if (!self.next_seen.isSet(j)) {
@@ -273,10 +299,10 @@ pub const Trellis = struct {
         // Positions 1..seq_len-1
         var position: usize = 1;
         while (position < seq_len) : (position += 1) {
-            try self.swapColumnsActive(allocator, &current_states, &next_states);
+            self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
             try self.middleForwardVals(allocator, current_states, &next_states, position);
         }
-        try self.swapColumnsActive(allocator, &current_states, &next_states);
+        self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
 
         // Compute ending probability
         self.ending_forward_log_prob = mathutils.NEG_INF;
@@ -326,28 +352,60 @@ pub const Trellis = struct {
 
     fn swapColumnsActive(
         self: *Trellis,
-        allocator: std.mem.Allocator,
         current_states: *std.ArrayListUnmanaged(usize),
         next_states: *std.ArrayListUnmanaged(usize),
-    ) !void {
-        // Swap scoring_current ↔ scoring_previous
+        prev_current_states: *std.ArrayListUnmanaged(usize),
+    ) void {
+        // Swap scoring_current ↔ scoring_previous.
         const tmp = self.scoring_previous;
         self.scoring_previous = self.scoring_current;
         self.scoring_current = tmp;
-        @memset(self.scoring_current, mathutils.NEG_INF);
+
+        // Sparse-clear scoring_current at the indices written two iterations
+        // ago (= the contents of prev_current_states at entry). After the
+        // buffer swap, scoring_current is the buffer that held those writes,
+        // so only those slots could hold non-NEG_INF; clearing them restores
+        // the same post-condition the previous full @memset gave (entire
+        // buffer NEG_INF before middle{Viterbi,Forward}Vals at iteration N
+        // writes through its current_states subset).
+        //
+        // This is the #366 item 1.1 sparse-memset path. Hot-path discipline
+        // (the rule that #369 violated): no `try`, no allocation, no fallible
+        // op in this loop — it must compile to a tight indexed store. The
+        // dirty-list arrives in `prev_current_states` as a zero-cost side
+        // effect of the three-way list rotation below; no per-active-state
+        // bookkeeping inside middle{Viterbi,Forward}Vals.
+        for (prev_current_states.items) |j| self.scoring_current[j] = mathutils.NEG_INF;
 
         // Clear next_seen for all indices that were in next_states
         // (they will become current_states; next_seen tracks what's queued for the NEW next)
         for (next_states.items) |j| self.next_seen.unset(j);
 
-        // current_states ← next_states; next_states ← empty
-        // Swap the backing allocations to avoid reallocation
-        const old_current_items = current_states.items;
-        const old_current_cap = current_states.capacity;
+        // Three-way list rotation: prev_current ← current, current ← next,
+        // next ← (old prev_current, then cleared). After this rotation:
+        //   - current_states.items = the candidate-set for the NEXT
+        //     middle{Viterbi,Forward}Vals call (i.e., what was in
+        //     next_states at entry, populated by the previous iteration);
+        //   - prev_current_states.items = the candidate-set that was just
+        //     used as input to the previous middle{...}Vals call. Those
+        //     indices name the slots in scoring_previous (post-rotation),
+        //     and will become the dirty-list for the sparse-clear two
+        //     swaps from now (when those slots have rotated back into
+        //     scoring_current via the next two buffer swaps).
+        //   - next_states is empty (clearRetainingCapacity), ready for
+        //     the next middle{...}Vals to populate the iteration-after-next
+        //     candidate set.
+        //
+        // ArrayListUnmanaged is two POD fields (items: []usize, capacity:
+        // usize); this is allocation-free struct-field assignment, no `try`.
+        const tmp_items = prev_current_states.items;
+        const tmp_capacity = prev_current_states.capacity;
+        prev_current_states.items = current_states.items;
+        prev_current_states.capacity = current_states.capacity;
         current_states.items = next_states.items;
         current_states.capacity = next_states.capacity;
-        next_states.items = old_current_items;
-        next_states.capacity = old_current_cap;
+        next_states.items = tmp_items;
+        next_states.capacity = tmp_capacity;
         next_states.clearRetainingCapacity();
         // Sort current_states in ascending order to match C++ bitset iteration
         // (0..n_states). This is critical: cacheForwardVals accumulates
@@ -356,7 +414,6 @@ pub const Trellis = struct {
         // produce different results. The cached forward_log_probs values are
         // then read by chunk-cached trellises via endingForwardLogProbAt().
         std.mem.sort(usize, current_states.items, {}, std.sort.asc(usize));
-        _ = allocator; // backing storage reuse avoids new allocations
     }
 
     fn middleViterbiVals(

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -65,18 +65,6 @@ pub const Trellis = struct {
     scoring_current: []f64,
     scoring_previous: []f64,
 
-    /// Indices into scoring_current that may hold non-NEG_INF values
-    /// (a SUPERSET of truly-dirty slots — see `swapColumnsActive`). Mirrors
-    /// the swap of scoring_current ↔ scoring_previous so the sparse clear
-    /// in `swapColumnsActive` only touches slots that were active two
-    /// iterations ago, instead of the full n_states column. Item 1.1 of
-    /// #366: at rung-2 medians (~50 active states / 500 n_states) this
-    /// drops the per-position memset from O(n_states) to O(active).
-    scoring_current_dirty: std.ArrayListUnmanaged(usize),
-    /// Indices into scoring_previous that may hold non-NEG_INF values.
-    /// See `scoring_current_dirty`.
-    scoring_previous_dirty: std.ArrayListUnmanaged(usize),
-
     /// Scratch bitset for deduplicating next_states additions.
     next_seen: state_mod.StateBitset,
 
@@ -130,8 +118,6 @@ pub const Trellis = struct {
             .viterbi_indices = .{},
             .scoring_current = scoring_current,
             .scoring_previous = scoring_previous,
-            .scoring_current_dirty = .{},
-            .scoring_previous_dirty = .{},
             .next_seen = state_mod.StateBitset.initEmpty(),
             .allocator = allocator,
         };
@@ -146,8 +132,6 @@ pub const Trellis = struct {
         self.viterbi_indices.deinit(allocator);
         allocator.free(self.scoring_current);
         allocator.free(self.scoring_previous);
-        self.scoring_current_dirty.deinit(allocator);
-        self.scoring_previous_dirty.deinit(allocator);
     }
 
     /// Run the Viterbi algorithm.
@@ -190,13 +174,9 @@ pub const Trellis = struct {
         @memset(self.traceback_table, -1);
         self.traceback_n_states = n_states;
 
-        // Reset scoring columns. Dirty lists pair with the buffers and start
-        // empty: the full memset establishes the all-NEG_INF invariant that
-        // the sparse clear in `swapColumnsActive` relies on.
+        // Reset scoring columns
         @memset(self.scoring_current, mathutils.NEG_INF);
         @memset(self.scoring_previous, mathutils.NEG_INF);
-        self.scoring_current_dirty.clearRetainingCapacity();
-        self.scoring_previous_dirty.clearRetainingCapacity();
 
         var current_states = std.ArrayListUnmanaged(usize){};
         defer current_states.deinit(allocator);
@@ -212,7 +192,6 @@ pub const Trellis = struct {
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
-            try self.scoring_current_dirty.append(allocator, i_st);
             self.cacheViterbiVals(0, dpval, i_st);
             // Mark outbound transitions for next position (deduplicated)
             for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
@@ -263,11 +242,9 @@ pub const Trellis = struct {
         try self.forward_log_probs.resize(allocator, seq_len);
         @memset(self.forward_log_probs.items, mathutils.NEG_INF);
 
-        // Reset scoring columns. See `viterbi()` for the dirty-list invariant.
+        // Reset scoring columns
         @memset(self.scoring_current, mathutils.NEG_INF);
         @memset(self.scoring_previous, mathutils.NEG_INF);
-        self.scoring_current_dirty.clearRetainingCapacity();
-        self.scoring_previous_dirty.clearRetainingCapacity();
 
         var current_states = std.ArrayListUnmanaged(usize){};
         defer current_states.deinit(allocator);
@@ -283,7 +260,6 @@ pub const Trellis = struct {
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
-            try self.scoring_current_dirty.append(allocator, i_st);
             // Mark outbound transitions for next position (deduplicated)
             for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
                 if (!self.next_seen.isSet(j)) {
@@ -354,23 +330,11 @@ pub const Trellis = struct {
         current_states: *std.ArrayListUnmanaged(usize),
         next_states: *std.ArrayListUnmanaged(usize),
     ) !void {
-        // Swap scoring_current ↔ scoring_previous, and the parallel dirty
-        // lists. After the swap, `scoring_current` is the buffer that was
-        // last written *two* iterations ago (or position-0 init); only the
-        // slots in `scoring_current_dirty` (the freshly-swapped-in list) can
-        // be non-NEG_INF, so a sparse clear over those slots restores the
-        // all-NEG_INF invariant. Item 1.1 of #366.
-        std.mem.swap([]f64, &self.scoring_current, &self.scoring_previous);
-        std.mem.swap(
-            std.ArrayListUnmanaged(usize),
-            &self.scoring_current_dirty,
-            &self.scoring_previous_dirty,
-        );
-
-        for (self.scoring_current_dirty.items) |idx| {
-            self.scoring_current[idx] = mathutils.NEG_INF;
-        }
-        self.scoring_current_dirty.clearRetainingCapacity();
+        // Swap scoring_current ↔ scoring_previous
+        const tmp = self.scoring_previous;
+        self.scoring_previous = self.scoring_current;
+        self.scoring_current = tmp;
+        @memset(self.scoring_current, mathutils.NEG_INF);
 
         // Clear next_seen for all indices that were in next_states
         // (they will become current_states; next_seen tracks what's queued for the NEW next)
@@ -409,12 +373,6 @@ pub const Trellis = struct {
             const st_cur = self.hmm.stateByIndex(i_st_cur);
             const emission_val = st_cur.emissionLogprobSeqs(seqs, position);
             if (std.math.isNegativeInf(emission_val)) continue;
-            // Track for the sparse clear in `swapColumnsActive`. This is a
-            // SUPERSET of slots we actually write: if every i_st_prev has
-            // NEG_INF prev_val, no write happens but i_st_cur is still in the
-            // dirty list. Clearing an already-NEG_INF slot is a no-op, so the
-            // superset is bit-equal.
-            try self.scoring_current_dirty.append(allocator, i_st_cur);
             for (st_cur.from_state_indices.items) |i_st_prev| {
                 const prev_val = self.scoring_previous[i_st_prev];
                 if (std.math.isNegativeInf(prev_val)) continue;
@@ -450,8 +408,6 @@ pub const Trellis = struct {
             const st_cur = self.hmm.stateByIndex(i_st_cur);
             const emission_val = st_cur.emissionLogprobSeqs(seqs, position);
             if (std.math.isNegativeInf(emission_val)) continue;
-            // See `middleViterbiVals` for the dirty-list invariant.
-            try self.scoring_current_dirty.append(allocator, i_st_cur);
             for (st_cur.from_state_indices.items) |i_st_prev| {
                 const prev_val = self.scoring_previous[i_st_prev];
                 if (std.math.isNegativeInf(prev_val)) continue;

--- a/partis/partitiondriver.py
+++ b/partis/partitiondriver.py
@@ -37,6 +37,17 @@ from .hist import Hist
 from . import seqfileopener
 
 # ----------------------------------------------------------------------------------------
+# Process-global accumulator for bcrham subprocess wall time, used to print a
+# "bcrham time: X (Y% of total)" summary alongside the final "total time:" line
+# in bin/partis. Phase 0 of issue #366 deferred pinning the bcrham fraction
+# pending partis-level timing instrumentation; this is that instrumentation.
+_cumul_bcrham_time = 0.0
+_cumul_bcrham_calls = 0
+
+def get_bcrham_summary():
+    return _cumul_bcrham_time, _cumul_bcrham_calls
+
+# ----------------------------------------------------------------------------------------
 class PartitionDriver(object):
     """ Class to parse input files, start bcrham jobs, and parse/interpret bcrham output for annotation and partitioning """
     def __init__(self, args, glfo, input_info, simglfo, reco_info):
@@ -1390,7 +1401,11 @@ class PartitionDriver(object):
                    'outfname' : get_outfname(iproc),
                    'dbgfo' : self.bcrham_proc_info[iproc]}
                   for iproc in range(n_procs)]
+        run_start = time.time()
         utils.run_cmds(cmdfos, batch_system=self.args.batch_system, batch_options=self.args.batch_options, batch_config_fname=self.args.batch_config_fname, debug='print' if self.args.debug else None)
+        global _cumul_bcrham_time, _cumul_bcrham_calls
+        _cumul_bcrham_time += time.time() - run_start
+        _cumul_bcrham_calls += 1
         self.print_partition_dbgfo()
 
         self.check_wait_times(time.time()-start)


### PR DESCRIPTION
**This PR is for documentation only.** The optimization works and parity is clean, but the wall improvement does not clear the 5% bar from #366, so it should not merge. Open so the diff and CI numbers are linkable from #366.

## What this does

Bundles the chunk-cache list with the gene's `*Model` into a new `ScratchCacheEntry` value type for `scratch_cachefo`. The model is pre-resolved in `initCache(gene)` (which runs once per `(gene, query)`) instead of `fillTrellis` calling `self.hmms.get(gene)` on every cache-miss kset.

The `runKSet` cache-hit branch is unchanged — it uses `cached_path.hmm.?` and never calls `hmms.get` — so the hoist costs nothing on the cache-hit path (which Phase 0 shows is 78–86% of ksets). The `gene` parameter on `fillTrellis` falls out as unused.

Motivation: post-#380 perf-record attributes 24.63% to `getIndex__anon_27622`, the `getIndex` instantiation for HMMHolder's `[]const u8 → *Model` map. The hoist reduces `hmms.get` calls per 5k partition from ~5M (one per `fillTrellis`) to ~1.5M (one per `(gene, query)`).

## Why not ship

Wall measurement (5k paired partition, n=5 each, randomized order `L B B L L L L B B B`, pooled against prior n=6 baseline from May 8–9):

| metric | n | central Δ | 95% CI | clears ship bar? |
|---|---|---|---|---|
| `bcrham_s` pooled | 11 / 5 | +1.89% | [-1.36%, +4.96%] | no — in ±2% noise band, CI straddles zero |
| `bcrham_s` same-session | 5 / 5 | +2.97% | [-0.03%, +5.82%] | no — CI straddles zero |
| `step3_bcrham_s` (30-call partition step) | 5 / 5 | +4.00% | [+0.76%, +7.24%] | no — CI clears zero but central below 5% |
| `wall_s` | 5 / 5 | +2.19% | [-0.26%, +4.49%] | no — CI straddles zero |

Sign convention: Δ = `baseline − lever5`, positive = lever5 faster. Bootstrap is 10 000 resamples, seed 42.

The optimization is almost certainly real (the central estimate is consistently positive across all four framings, and on the dominant partition step alone the CI clears zero), but the magnitude does not meet the prompt's pre-committed 5% bar.

## Why the upside was smaller than the perf bucket suggested

The 24.63% perf-record bucket implicates `hmms.get` more strongly than the wall delta confirms. Two plausible reasons:

1. The call is `O(1)`-ish but not free, and the inner-loop body it gates already amortizes well. The 78–86% chunk-cache hit-rate across ksets means most `fillTrellis` invocations spend their time in the chunk-cache prefix scan and (when the scan misses) the trellis fill, not in the hmms lookup itself.
2. Branch / icache / TLB effects of the un-hoisted call may already be hidden by the surrounding hot loop, so removing the call returns less than its perf-attribution suggests.

## Verification

| Gate | Result |
|---|---|
| `zig build -Doptimize=ReleaseFast` | clean |
| `zig build -Doptimize=ReleaseSafe` | clean |
| `zig build test` | clean |
| `partis-test.py --quick --zig` (ReleaseFast) | ok |
| `partis-test.py --quick --zig` (ReleaseSafe) | ok |
| `partis-test.py --paired --zig` | only pre-existing diffs (verified by stash + rerun: production-result diffs identical between baseline and lever5) |
| 30k Zig parity vs `/tmp/parity-30k-377-zig` | **igh: 10750 events identical, igk: 10813 events identical** (igl had no events for this input) |

## C++ port consideration

`packages/ham/src/dphandler.cc` has the same shape (`scratch_cachefo_` map, `InitCache`, `FillTrellis` calling `hmms_.Get(gene)`). Structurally portable — ~50–100 lines — but carries the lockstep-with-Zig maintenance cost. Not worth it for a noise-band win.

## Next lever to consider

Glomerator at ~10% is the next-largest direct symbol per the post-#380 perf-record.

## Artifacts

- Decision memo: `/tmp/perf-1.1-results/lever5-decision.md`
- Wall-bench driver + log: `/tmp/lever5-bench-driver.{sh,log}`
- Per-run logs: `/tmp/lever5-bench-{baseline,lever5}/run-{1..5}/run.log`
- 30k parity output: `/tmp/parity-30k-lever5-zig/` (compared identical to `/tmp/parity-30k-377-zig/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)