### PR TITLE
zig: cycle-precise sub-phase timing for fillTrellis / runKSet / Glomerator (#366 Phase B)

### DIFF
--- a/bin/zig-perf-counters-aggregate.py
+++ b/bin/zig-perf-counters-aggregate.py
@@ -6,8 +6,8 @@ calls, addInLogSpace+log_exp work calls, active-state distribution stats, and
 chunk-cache hit rate. Plus a chunk-cache prefix-list-length histogram across
 all queries.
 
-For Phase-B (added after the issue #366 lever-5 close — see
-/tmp/perf-1.1-results/next-steps-plan.md), also aggregates
+For Phase-B (added after the issue #366 lever-5 close, PR
+https://github.com/psathyrella/partis/pull/383), also aggregates
 PERFCOUNTER_TIMING lines: cycle-precise nanosecond accumulators for
 fillTrellis sub-phases (chunkScan / init / tmpInit / viterbi / forward /
 traceback / put) and the runKSet cache-hit branch (cachedPath). The
@@ -251,7 +251,8 @@ def main(path):
                 # findPartialCacheMatch, regional_total/best updates, the
                 # debug-output and fillRecoEvent assembly. Anything inside
                 # runKSet body but outside fillTrellis() and cachedPath_ns.
-                trow("  (runKSet plumbing)", tot_rks - inner_timed, denom)
+                trow("  (runKSet body, excl. fillTrellis+cachedPath)",
+                     tot_rks - inner_timed, denom)
 
     # Phase-B' outermost perimeter: one PERFCOUNTER_GLOMERATOR per bcrham
     # invocation that ran Glomerator.cluster() or cacheNaiveSeqs(). The
@@ -264,8 +265,13 @@ def main(path):
             tot_glom = sum(r["glomerator_total_ns"] for r in rows)
             tot_dp = sum(r["cumul_dpHandler_run_ns"] for r in rows)
             n_proc = len(rows)
+            # `glomerator_total` is summed across bcrham procs, not elapsed
+            # wall — without the mean-per-proc column readers can mis-read
+            # a 152s sum as a single-process wall claim. Both reported.
+            mean_glom = tot_glom / n_proc if n_proc else 0
             print(f"  kind={kind}, n_bcrham_procs={n_proc}, "
-                  f"glomerator_total={tot_glom / 1e9:.3f}s "
+                  f"mean_glom_per_proc={mean_glom / 1e9:.3f}s, "
+                  f"sum_glomerator_total={tot_glom / 1e9:.3f}s "
                   f"(cumul_dpHandler_run={tot_dp / 1e9:.3f}s, "
                   f"driver_overhead={(tot_glom - tot_dp) / 1e9:.3f}s, "
                   f"driver_overhead_pct={100 * (tot_glom - tot_dp) / tot_glom if tot_glom else 0:.1f}%)")

--- a/bin/zig-perf-counters-aggregate.py
+++ b/bin/zig-perf-counters-aggregate.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python3
-"""Aggregate PERFCOUNTER + PERFCOUNTER_CACHE lines from a perf log file.
+"""Aggregate PERFCOUNTER / PERFCOUNTER_CACHE / PERFCOUNTER_TIMING lines.
 
 Per-query summary: median/p95/max of ksets, fillTrellis calls, addInLogSpace
 calls, addInLogSpace+log_exp work calls, active-state distribution stats, and
 chunk-cache hit rate. Plus a chunk-cache prefix-list-length histogram across
 all queries.
+
+For Phase-B (added after the issue #366 lever-5 close — see
+/tmp/perf-1.1-results/next-steps-plan.md), also aggregates
+PERFCOUNTER_TIMING lines: cycle-precise nanosecond accumulators for
+fillTrellis sub-phases (chunkScan / init / tmpInit / viterbi / forward /
+traceback / put) and the runKSet cache-hit branch (cachedPath). The
+timing report is what we should have had before pulling lever 5: it
+divides time spent between cache-hit and cache-miss paths, and within
+the cache-miss path between trellis init, the DP itself, and traceback.
 
 The log file is produced by partis-zig-core when built with
 -Dperf-counters=true and run with PARTIS_ZIG_PERF_LOG=<path> in the env. See
@@ -43,6 +52,16 @@ def stats(xs):
     }
 
 
+# Fields on PERFCOUNTER_TIMING line that hold per-query ns accumulators.
+# fillTrellis_total is the parent (sub-phases sum into it modulo work
+# outside the sub-timers, like the model load); cachedPath is a sibling
+# (the runKSet branch that bypasses fillTrellis entirely).
+TIMING_SUBPHASES = (
+    "chunkScan_ns", "init_ns", "tmpInit_ns",
+    "viterbi_ns", "forward_ns", "traceback_ns", "put_ns",
+)
+
+
 def main(path):
     by_alg = defaultdict(lambda: {
         "ksets": [], "fillTrellis": [], "addInLogSpace": [],
@@ -51,12 +70,27 @@ def main(path):
         "n_seqs": [],
     })
     cache_buckets = defaultdict(lambda: defaultdict(int))
+    # timing[alg][field] = list of per-query ns values
+    timing = defaultdict(lambda: defaultdict(list))
+    # glomerator[kind] = list of {glomerator_total_ns, cumul_dpHandler_run_ns}
+    glomerator = defaultdict(list)
     n_lines = 0
     n_cache_lines = 0
+    n_timing_lines = 0
+    n_glom_lines = 0
 
     for line in open(path):
         line = line.strip()
         if not line:
+            continue
+        if line.startswith("PERFCOUNTER_GLOMERATOR"):
+            n_glom_lines += 1
+            kv = parse_kv(line[len("PERFCOUNTER_GLOMERATOR "):])
+            kind = kv.get("kind", "?")
+            glomerator[kind].append({
+                "glomerator_total_ns": int(kv["glomerator_total_ns"]),
+                "cumul_dpHandler_run_ns": int(kv["cumul_dpHandler_run_ns"]),
+            })
             continue
         if line.startswith("PERFCOUNTER_CACHE"):
             n_cache_lines += 1
@@ -66,6 +100,23 @@ def main(path):
                 if k in ("alg", "q"):
                     continue
                 cache_buckets[alg][k] += int(v)
+            continue
+        if line.startswith("PERFCOUNTER_TIMING"):
+            n_timing_lines += 1
+            kv = parse_kv(line[len("PERFCOUNTER_TIMING "):])
+            alg = kv.get("alg", "?")
+            t = timing[alg]
+            t["fillTrellis_total_ns"].append(int(kv["fillTrellis_total_ns"]))
+            t["cachedPath_ns"].append(int(kv["cachedPath_ns"]))
+            for k in TIMING_SUBPHASES:
+                t[k].append(int(kv[k]))
+            # Outer-perimeter accumulators (older logs omit these; default 0).
+            t["runKSet_total_ns"].append(int(kv.get("runKSet_total_ns", "0")))
+            t["dpHandler_run_total_ns"].append(int(kv.get("dpHandler_run_total_ns", "0")))
+            # Phase-B'' deeper-DP timers (older logs omit; default 0).
+            for k in ("viterbi_init_ns", "viterbi_ending_ns",
+                      "forward_init_ns", "forward_ending_ns"):
+                t[k].append(int(kv.get(k, "0")))
             continue
         if not line.startswith("PERFCOUNTER"):
             continue
@@ -86,7 +137,7 @@ def main(path):
         d["active_max"].append(int(kv["active_states_max"]))
         d["active_positions"].append(int(kv["active_states_positions"]))
 
-    print(f"# parsed {n_lines} PERFCOUNTER + {n_cache_lines} PERFCOUNTER_CACHE lines from {path}")
+    print(f"# parsed {n_lines} PERFCOUNTER + {n_cache_lines} PERFCOUNTER_CACHE + {n_timing_lines} PERFCOUNTER_TIMING + {n_glom_lines} PERFCOUNTER_GLOMERATOR lines from {path}")
     for alg, d in by_alg.items():
         nq = len(d["ksets"])
         print(f"\n## algorithm={alg}, n_queries={nq}")
@@ -126,6 +177,98 @@ def main(path):
                 pct = 100 * v / total if total else 0
                 print(f"    {k:>8}: {v:>10,d}  ({pct:>5.1f}%)")
             print(f"    {'total':>8}: {total:>10,d}")
+
+    # Phase-B timing report: where is bcrham wall actually going inside
+    # the Zig core? Sub-phases sum into fillTrellis_total; cachedPath is
+    # the sibling runKSet branch that bypasses fillTrellis entirely. The
+    # denominator we want for "%" is "all time the Zig core spent doing
+    # DP-ish work for this query," which is fillTrellis_total + cachedPath.
+    # Anything not in that sum is runKSet glue, findPartialCacheMatch,
+    # sorted-gene plumbing, etc. — out of the timed perimeter.
+    if timing:
+        print("\n## sub-phase timing (Phase-B, PERFCOUNTER_TIMING)")
+        # Three concentric perimeters, biggest first:
+        #   dpHandler_run_total ⊇ Σ runKSet_total ⊇ Σ fillTrellis_total + Σ cachedPath
+        # Each "_overhead" row is the residual between a perimeter and the
+        # sum of its inner pieces — i.e. work in the outer that isn't in
+        # any inner sub-bucket. Denominator is dpHandler_run_total when
+        # present (so % adds up over all reported rows); falls back to
+        # fillTrellis_total + cachedPath for older logs without outer
+        # timers.
+        for alg, t in timing.items():
+            tot_run = sum(t.get("dpHandler_run_total_ns", []))
+            tot_rks = sum(t.get("runKSet_total_ns", []))
+            tot_fill = sum(t["fillTrellis_total_ns"])
+            tot_cached = sum(t["cachedPath_ns"])
+            inner_timed = tot_fill + tot_cached
+            denom = tot_run if tot_run > 0 else inner_timed
+            print(f"  alg={alg}, n_queries={len(t['fillTrellis_total_ns'])}, "
+                  f"dpHandler_run_total={tot_run / 1e9:.3f}s "
+                  f"(runKSet={tot_rks / 1e9:.3f}s, "
+                  f"fillTrellis+cachedPath={inner_timed / 1e9:.3f}s)")
+
+            def trow(name, ns, denom):
+                pct = (100 * ns / denom) if denom else 0
+                print(f"    {name:<32}  {ns / 1e9:>9.3f}s  ({pct:>5.1f}% of timed)")
+
+            if tot_run > 0:
+                trow("dpHandler_run_total (outer)", tot_run, denom)
+                # Pre/post-runKSet work inside run(): Sequences build,
+                # only_genes map, rescaleOverallMuteFreqs, fillRecoEvent,
+                # Result.finalize, debug summary.
+                trow("  (run()-body pre/post-runKSet)", tot_run - tot_rks, denom)
+                trow("runKSet_total (Σ ksets)", tot_rks, denom)
+            trow("  fillTrellis_total (Σ misses+chunks)", tot_fill, denom)
+            for k in TIMING_SUBPHASES:
+                trow(f"    {k}", sum(t[k]), denom)
+                # Phase-B'' DP-body sub-split (init + ending → position
+                # loop derived as residual). Only meaningful for the
+                # viterbi/forward rows.
+                if k == "viterbi_ns":
+                    vi = sum(t.get("viterbi_init_ns", [0]))
+                    ve = sum(t.get("viterbi_ending_ns", [0]))
+                    vp = sum(t[k]) - vi - ve
+                    trow("      viterbi_init_ns", vi, denom)
+                    trow("      viterbi_positionLoop_ns (derived)", vp, denom)
+                    trow("      viterbi_ending_ns", ve, denom)
+                elif k == "forward_ns":
+                    fi = sum(t.get("forward_init_ns", [0]))
+                    fe = sum(t.get("forward_ending_ns", [0]))
+                    fp = sum(t[k]) - fi - fe
+                    trow("      forward_init_ns", fi, denom)
+                    trow("      forward_positionLoop_ns (derived)", fp, denom)
+                    trow("      forward_ending_ns", fe, denom)
+            sub_sum = sum(sum(t[k]) for k in TIMING_SUBPHASES)
+            unaccounted_fill = tot_fill - sub_sum
+            # The model load (`self.hmms.get(gene)`) sits between the
+            # chunk scan and the init/tmpInit; it's not timed. So
+            # fillTrellis_total − Σ sub-phases is the un-timed remainder,
+            # mostly that lookup plus the addWithMinusInfinities math.
+            trow("    (fillTrellis untimed)", unaccounted_fill, denom)
+            trow("  cachedPath (sibling, Σ hits)", tot_cached, denom)
+            if tot_rks > 0:
+                # runKSet plumbing: sorted_genes alloc/sort, regions loop,
+                # findPartialCacheMatch, regional_total/best updates, the
+                # debug-output and fillRecoEvent assembly. Anything inside
+                # runKSet body but outside fillTrellis() and cachedPath_ns.
+                trow("  (runKSet plumbing)", tot_rks - inner_timed, denom)
+
+    # Phase-B' outermost perimeter: one PERFCOUNTER_GLOMERATOR per bcrham
+    # invocation that ran Glomerator.cluster() or cacheNaiveSeqs(). The
+    # `cumul_dpHandler_run_ns` is the sum of every DPHandler.run() body
+    # time during that bcrham process; the residual is Glomerator driver
+    # overhead — merge decisions, partition I/O, hfrac calculations.
+    if glomerator:
+        print("\n## Glomerator wrapper (Phase-B', PERFCOUNTER_GLOMERATOR)")
+        for kind, rows in glomerator.items():
+            tot_glom = sum(r["glomerator_total_ns"] for r in rows)
+            tot_dp = sum(r["cumul_dpHandler_run_ns"] for r in rows)
+            n_proc = len(rows)
+            print(f"  kind={kind}, n_bcrham_procs={n_proc}, "
+                  f"glomerator_total={tot_glom / 1e9:.3f}s "
+                  f"(cumul_dpHandler_run={tot_dp / 1e9:.3f}s, "
+                  f"driver_overhead={(tot_glom - tot_dp) / 1e9:.3f}s, "
+                  f"driver_overhead_pct={100 * (tot_glom - tot_dp) / tot_glom if tot_glom else 0:.1f}%)")
 
 
 if __name__ == "__main__":

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -282,6 +282,12 @@ pub const DPHandler = struct {
         // `-Dperf-counters=false` (default), so the bit-equal default build
         // is unaffected.
         perf_counters.reset();
+        // Phase-B outer-perimeter timer: total time inside this run() body
+        // (excluding the reset() above). Tick AFTER reset so reset doesn't
+        // wipe it. Read in `dumpPerfCounters` via a final `addElapsed` at
+        // each exit point that dumps; non-dumping early returns leak the
+        // tick but contribute zero work.
+        const t_run = perf_counters.tick();
 
         // Build a Sequences container that borrows from `seqvector`.
         // Each Sequence is a shallow struct-copy: slice headers are duplicated,
@@ -432,6 +438,13 @@ pub const DPHandler = struct {
             if (!self.args.dont_rescale_emissions) {
                 try self.hmms.unRescaleOverallMuteFreqs(&only_genes);
             }
+            perf_counters.addElapsed(&perf_counters.dpHandler_run_total_ns, t_run);
+            // Accumulate into the process-lifetime counter for Glomerator
+            // attribution. dpHandler_run_total_ns gets reset() to zero on
+            // the next run() entry, so we mirror it here BEFORE the reset.
+            if (perf_counters.enabled) {
+                perf_counters.cumul_dpHandler_run_ns +%= perf_counters.dpHandler_run_total_ns;
+            }
             try self.dumpPerfCounters(&seqs);
             return result;
         }
@@ -465,6 +478,12 @@ pub const DPHandler = struct {
             try self.hmms.unRescaleOverallMuteFreqs(&only_genes);
         }
 
+        perf_counters.addElapsed(&perf_counters.dpHandler_run_total_ns, t_run);
+        // See the no-path early-return above for the rationale: mirror
+        // into the process-lifetime cumul before the next reset() fires.
+        if (perf_counters.enabled) {
+            perf_counters.cumul_dpHandler_run_ns +%= perf_counters.dpHandler_run_total_ns;
+        }
         try self.dumpPerfCounters(&seqs);
         return result;
     }
@@ -504,12 +523,13 @@ pub const DPHandler = struct {
             buckets[idx] += 1;
         }
 
-        // Build the PERFCOUNTER + PERFCOUNTER_CACHE block in one buffer
-        // and emit with a single writeAll. With multiple bcrham processes
-        // appending to the same log (`partis --n-procs N > 1`), splitting
-        // this into two writes would let another process slip a line
-        // between ours, separating the pair. Concatenated, the two lines
-        // share one O_APPEND atomic write.
+        // Build the PERFCOUNTER + PERFCOUNTER_CACHE + PERFCOUNTER_TIMING
+        // block in one buffer and emit with a single writeAll. With
+        // multiple bcrham processes appending to the same log
+        // (`partis --n-procs N > 1`), splitting this into multiple writes
+        // would let another process slip a line between ours, separating
+        // the trio. Concatenated, all three share one O_APPEND atomic
+        // write.
         const main_line = (try perf_counters.formatPerfCounters(allocator, self.algorithm, name_str, seqs.seqs.items.len)) orelse return;
         defer allocator.free(main_line);
         const cache_line = try std.fmt.allocPrint(
@@ -518,7 +538,9 @@ pub const DPHandler = struct {
             .{ self.algorithm, name_str, buckets[0], buckets[1], buckets[2], buckets[3], buckets[4], buckets[5], buckets[6], buckets[7], buckets[8], buckets[9], buckets[10], buckets[11] },
         );
         defer allocator.free(cache_line);
-        const blob = try std.mem.concat(allocator, u8, &.{ main_line, cache_line });
+        const timing_line = (try perf_counters.formatPerfCountersTiming(allocator, self.algorithm, name_str, seqs.seqs.items.len)) orelse return;
+        defer allocator.free(timing_line);
+        const blob = try std.mem.concat(allocator, u8, &.{ main_line, cache_line, timing_line });
         defer allocator.free(blob);
 
         // O_APPEND on regular files: Linux serializes the
@@ -663,12 +685,19 @@ pub const DPHandler = struct {
     ) ![]const u8 {
         const allocator = self.scratchAllocator();
         perf_counters.bumpFillTrellis();
+        // Phase-B: time the whole fillTrellis body so we can divide the
+        // chunkScan/init/tmpInit/viterbi/forward/traceback/put numbers by
+        // their parent total instead of by bcrham wall (which includes
+        // runKSet overhead and the cache-hit path).
+        const t_total = perf_counters.tick();
+        defer perf_counters.addElapsed(&perf_counters.fillTrellis_total_ns, t_total);
 
         // Look for a chunk-cached trellis. Prefix-match is on undigitized
         // strings of the cached trellis's stored query_seqs.
         var cached_trellis: ?*const Trellis = null;
         if (!self.args.no_chunk_cache) {
             perf_counters.bumpChunkCacheLookup();
+            const t_scan = perf_counters.tick();
             for (gc.cachefo.items) |te| {
                 const cached_seqs = te.query_seqs.seqs.items;
                 const current_seqs = query_seqs.seqs.items;
@@ -687,6 +716,7 @@ pub const DPHandler = struct {
                     break;
                 }
             }
+            perf_counters.addElapsed(&perf_counters.fillTrellis_chunkScan_ns, t_scan);
         }
 
         // Match C++ DPHandler::FillTrellis logic exactly:
@@ -715,6 +745,7 @@ pub const DPHandler = struct {
             // from the entry's heap address, so `trellis.seqs = &entry.query_seqs`
             // stays valid across cache_list appends (which only move the *entry
             // pointers in the list, not the entries themselves).
+            const t_init = perf_counters.tick();
             const entry = try allocator.create(TrellisEntry);
             errdefer allocator.destroy(entry);
             entry.query_seqs = try query_seqs.clone(allocator);
@@ -725,6 +756,7 @@ pub const DPHandler = struct {
             // gc.cachefo is guaranteed non-null by the caller (initCache
             // ran before the gc was built — see PerGeneCache doc-block).
             try gc.cachefo.append(allocator, entry);
+            perf_counters.addElapsed(&perf_counters.fillTrellis_init_ns, t_init);
             break :blk &entry.trellis;
         } else blk: {
             // Have cache: temp trellis borrows from the caller's query_seqs
@@ -737,14 +769,18 @@ pub const DPHandler = struct {
             // The path items below are explicitly routed through `allocator`
             // (per-query scratch), not `kset_alloc`, since they're stored in
             // `self.paths` and outlive the kset. (Item 4, #342.)
+            const t_tmpInit = perf_counters.tick();
             tmptrell = try Trellis.initWithSeqs(kset_alloc, model, query_seqs, cached_trellis);
+            perf_counters.addElapsed(&perf_counters.fillTrellis_tmpInit_ns, t_tmpInit);
             origin = "chunk";
             break :blk &tmptrell.?;
         };
 
         // Run the algorithm on trell_ptr
         const uncorrected_score: f64 = if (std.mem.eql(u8, self.algorithm, "viterbi")) blk: {
+            const t_vit = perf_counters.tick();
             try trell_ptr.viterbi();
+            perf_counters.addElapsed(&perf_counters.fillTrellis_viterbi_ns, t_vit);
             const sc = trell_ptr.ending_viterbi_log_prob;
             // Store traceback path
             var path = TracebackPath.initWithModel(model);
@@ -752,19 +788,27 @@ pub const DPHandler = struct {
             if (sc != mathutils.NEG_INF) {
                 // Explicitly pass `allocator` (per-query scratch) so the path's
                 // items don't capture the temp trellis's per-kset arena.
+                const t_tb = perf_counters.tick();
                 try trell_ptr.traceback(allocator, &path);
+                perf_counters.addElapsed(&perf_counters.fillTrellis_traceback_ns, t_tb);
             }
+            const t_put_p = perf_counters.tick();
             try gc.paths.put(allocator, kset, path);
+            perf_counters.addElapsed(&perf_counters.fillTrellis_put_ns, t_put_p);
             break :blk sc;
         } else blk: {
+            const t_fwd = perf_counters.tick();
             try trell_ptr.forward();
+            perf_counters.addElapsed(&perf_counters.fillTrellis_forward_ns, t_fwd);
             break :blk trell_ptr.ending_forward_log_prob;
         };
 
         const gene_choice_score = log(model.overall_prob);
         const final_score = mathutils.addWithMinusInfinities(uncorrected_score, gene_choice_score);
 
+        const t_put_s = perf_counters.tick();
         try gc.scores.put(allocator, kset, final_score);
+        perf_counters.addElapsed(&perf_counters.fillTrellis_put_ns, t_put_s);
 
         return origin;
     }
@@ -909,6 +953,13 @@ pub const DPHandler = struct {
         total_scores: *std.AutoHashMapUnmanaged(KSet, f64),
         best_genes: *std.AutoHashMapUnmanaged(KSet, std.AutoHashMapUnmanaged(Region, []u8)),
     ) !void {
+        // Phase-B outer-perimeter: time the full runKSet body. Pair with
+        // fillTrellis_total_ns + cachedPath_ns to expose runKSet plumbing
+        // (sorted_genes, findPartialCacheMatch, regional_total updates,
+        // per-region sub-seq clones, debug output) as the residual.
+        const t_kset = perf_counters.tick();
+        defer perf_counters.addElapsed(&perf_counters.runKSet_total_ns, t_kset);
+
         const scratch = self.scratchAllocator();
         var kset_arena = std.heap.ArenaAllocator.init(self.parent_allocator);
         defer kset_arena.deinit();
@@ -1032,6 +1083,10 @@ pub const DPHandler = struct {
                 var origin: []const u8 = "";
                 const partial_match = self.findPartialCacheMatch(region, gc.scores, kset);
                 if (!partial_match.isNull()) {
+                    // Phase-B: time the cache-hit path so we can compare it
+                    // to fillTrellis_total_ns. Excludes findPartialCacheMatch
+                    // above (which runs on both branches).
+                    const t_cached = perf_counters.tick();
                     // Copy path and score from cached kset. Both go into
                     // `self.paths` / `self.scores`, which outlive the kset
                     // — route through `scratch`, not `allocator`.
@@ -1046,6 +1101,7 @@ pub const DPHandler = struct {
                     const cached_score = gc.scores.get(partial_match) orelse mathutils.NEG_INF;
                     try gc.scores.put(scratch, kset, cached_score);
                     origin = "cached";
+                    perf_counters.addElapsed(&perf_counters.cachedPath_ns, t_cached);
                 } else {
                     origin = try self.fillTrellis(allocator, kset, &query_seqs, gene, &gc);
                 }

--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -39,6 +39,12 @@ fn sortPartition(part: *Partition) void {
 /// driver overhead. `kind` is `"cluster"` or `"cacheNaiveSeqs"` so the
 /// aggregator can keep the two modes separate. No-op when counters off or
 /// when the env var is unset (same gate as `dumpPerfCounters`).
+///
+/// Returns `!void` so the caller can choose how to handle failure. Callers
+/// in this module use a defer with `catch reportGlomeratorCountersError`
+/// (below) — they can't propagate via `defer` anyway, so the lowest-noise
+/// useful behavior is to print a one-line diagnostic to stderr instead of
+/// silently dropping the dump. (Advisory from PR #383 review.)
 fn dumpGlomeratorCounters(allocator: std.mem.Allocator, kind: []const u8) !void {
     if (!perf_counters.enabled) return;
     const log_path = std.process.getEnvVarOwned(allocator, "PARTIS_ZIG_PERF_LOG") catch |err| switch (err) {
@@ -50,7 +56,7 @@ fn dumpGlomeratorCounters(allocator: std.mem.Allocator, kind: []const u8) !void 
     const line = try std.fmt.allocPrint(
         allocator,
         "PERFCOUNTER_GLOMERATOR kind={s} glomerator_total_ns={d} cumul_dpHandler_run_ns={d}\n",
-        .{ kind, perf_counters.glomerator_cluster_ns, perf_counters.cumul_dpHandler_run_ns },
+        .{ kind, perf_counters.glomerator_ns, perf_counters.cumul_dpHandler_run_ns },
     );
     defer allocator.free(line);
 
@@ -61,6 +67,18 @@ fn dumpGlomeratorCounters(allocator: std.mem.Allocator, kind: []const u8) !void 
     const file = std.fs.File{ .handle = fd };
     defer file.close();
     try file.writeAll(line);
+}
+
+/// Stderr-only diagnostic for the defer-catch path. We can't surface
+/// errors via `defer` so the best we can do is leave a breadcrumb when
+/// the perf log was requested but unwritable (wrong path, permissions,
+/// disk full). Silent under the env-var-unset path because that case
+/// returns early from `dumpGlomeratorCounters` itself.
+fn reportGlomeratorCountersError(err: anyerror) void {
+    std.debug.print(
+        "warning: failed to write PERFCOUNTER_GLOMERATOR line to $PARTIS_ZIG_PERF_LOG: {s}\n",
+        .{@errorName(err)},
+    );
 }
 
 /// Corresponds to C++ `ham::Glomerator`.
@@ -385,8 +403,8 @@ pub const Glomerator = struct {
         // it sees the addElapsed-updated counter. Reversing these two
         // defers would dump a stale 0.
         const t_glom = perf_counters.tick();
-        defer dumpGlomeratorCounters(self.allocator, "cluster") catch {};
-        defer perf_counters.addElapsed(&perf_counters.glomerator_cluster_ns, t_glom);
+        defer dumpGlomeratorCounters(self.allocator, "cluster") catch |err| reportGlomeratorCountersError(err);
+        defer perf_counters.addElapsed(&perf_counters.glomerator_ns, t_glom);
         if (self.args.logprob_ratio_threshold == -std.math.inf(f64)) {
             return error.LogprobRatioThresholdNotSet;
         }
@@ -444,8 +462,8 @@ pub const Glomerator = struct {
         // order is LIFO — dump registered first runs last, so it sees the
         // updated counter (see cluster() above for the rationale).
         const t_glom = perf_counters.tick();
-        defer dumpGlomeratorCounters(self.allocator, "cacheNaiveSeqs") catch {};
-        defer perf_counters.addElapsed(&perf_counters.glomerator_cluster_ns, t_glom);
+        defer dumpGlomeratorCounters(self.allocator, "cacheNaiveSeqs") catch |err| reportGlomeratorCountersError(err);
+        defer perf_counters.addElapsed(&perf_counters.glomerator_ns, t_glom);
         try std.fs.File.stdout().writeAll("      caching all naive sequences\n");
         // Sort keys to match C++ map<string,...> iteration order
         const sorted_keys = try self.allocator.alloc([]const u8, self.cachefo.count());

--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -15,6 +15,7 @@ const Partition = @import("../cluster_path.zig").Partition;
 const Sequence = @import("../sequences.zig").Sequence;
 const mathutils = @import("../mathutils.zig");
 const ham_text = @import("../text.zig");
+const perf_counters = @import("../perf_counters.zig");
 const bcr = @import("../bcr_utils/root.zig");
 const GermLines = bcr.GermLines;
 const HMMHolder = bcr.HMMHolder;
@@ -30,6 +31,36 @@ fn sortPartition(part: *Partition) void {
             return std.mem.order(u8, a, b) == .lt;
         }
     }.lessThan);
+}
+
+/// Phase-B': emit one `PERFCOUNTER_GLOMERATOR` line to `PARTIS_ZIG_PERF_LOG`
+/// at the end of `cluster()` / `cacheNaiveSeqs()`. Pairs with the per-query
+/// `PERFCOUNTER_TIMING` lines from `DPHandler.run()` to expose Glomerator
+/// driver overhead. `kind` is `"cluster"` or `"cacheNaiveSeqs"` so the
+/// aggregator can keep the two modes separate. No-op when counters off or
+/// when the env var is unset (same gate as `dumpPerfCounters`).
+fn dumpGlomeratorCounters(allocator: std.mem.Allocator, kind: []const u8) !void {
+    if (!perf_counters.enabled) return;
+    const log_path = std.process.getEnvVarOwned(allocator, "PARTIS_ZIG_PERF_LOG") catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => return,
+        else => return err,
+    };
+    defer allocator.free(log_path);
+
+    const line = try std.fmt.allocPrint(
+        allocator,
+        "PERFCOUNTER_GLOMERATOR kind={s} glomerator_total_ns={d} cumul_dpHandler_run_ns={d}\n",
+        .{ kind, perf_counters.glomerator_cluster_ns, perf_counters.cumul_dpHandler_run_ns },
+    );
+    defer allocator.free(line);
+
+    const log_path_z = try allocator.dupeZ(u8, log_path);
+    defer allocator.free(log_path_z);
+    const flags: std.posix.O = .{ .ACCMODE = .WRONLY, .APPEND = true, .CREAT = true };
+    const fd = try std.posix.openZ(log_path_z, flags, 0o644);
+    const file = std.fs.File{ .handle = fd };
+    defer file.close();
+    try file.writeAll(line);
 }
 
 /// Corresponds to C++ `ham::Glomerator`.
@@ -344,6 +375,18 @@ pub const Glomerator = struct {
     /// Run full hierarchical clustering and write output.
     /// Corresponds to C++ `Glomerator::Cluster`.
     pub fn cluster(self: *Glomerator) !void {
+        // Phase-B' outer-most timer: total wall in Glomerator.cluster(),
+        // including the merge loop, writePartitions, writeCacheFile, and
+        // setup. Pairs with `cumul_dpHandler_run_ns` to expose Glomerator
+        // driver overhead (merge decisions, partition I/O) as the
+        // residual. Dumped at end of this function via dumpGlomeratorCounters.
+        //
+        // Defer order is LIFO: the dump (registered first) runs LAST, so
+        // it sees the addElapsed-updated counter. Reversing these two
+        // defers would dump a stale 0.
+        const t_glom = perf_counters.tick();
+        defer dumpGlomeratorCounters(self.allocator, "cluster") catch {};
+        defer perf_counters.addElapsed(&perf_counters.glomerator_cluster_ns, t_glom);
         if (self.args.logprob_ratio_threshold == -std.math.inf(f64)) {
             return error.LogprobRatioThresholdNotSet;
         }
@@ -396,6 +439,13 @@ pub const Glomerator = struct {
     /// Cache all naive sequences.
     /// Corresponds to C++ `Glomerator::CacheNaiveSeqs`.
     pub fn cacheNaiveSeqs(self: *Glomerator) !void {
+        // Phase-B' outer-most timer (same as cluster() above): cover the
+        // whole CacheNaiveSeqs path, including writeCacheFile. Defer
+        // order is LIFO — dump registered first runs last, so it sees the
+        // updated counter (see cluster() above for the rationale).
+        const t_glom = perf_counters.tick();
+        defer dumpGlomeratorCounters(self.allocator, "cacheNaiveSeqs") catch {};
+        defer perf_counters.addElapsed(&perf_counters.glomerator_cluster_ns, t_glom);
         try std.fs.File.stdout().writeAll("      caching all naive sequences\n");
         // Sort keys to match C++ map<string,...> iteration order
         const sorted_keys = try self.allocator.alloc([]const u8, self.cachefo.count());

--- a/packages/zig-core/src/ham/perf_counters.zig
+++ b/packages/zig-core/src/ham/perf_counters.zig
@@ -18,6 +18,35 @@
 ///   - active_state_hist[count]     — `trellis.zig` middleViterbiVals/
 ///                                    middleForwardVals
 ///
+/// Phase-B sub-phase nanosecond accumulators (added 2026-05 after the
+/// lever-5 close — see `/tmp/perf-1.1-results/next-steps-plan.md`). The
+/// Phase-0 counts told us the chunk-cache HIT RATE; they did not tell us
+/// how time is split between the cache-hit path (the `partial_match`
+/// branch in `runKSet`) and the various sub-phases inside `fillTrellis`
+/// on the cache-miss path. The lever-5 close was the proximate motivator:
+/// a 24.63% perf-record symbol bucket turned out to over-attribute work
+/// inside an amortized hot loop, and eliminating ~70% of those calls only
+/// shifted bcrham wall by ~2%. The next-steps plan calls for cycle-
+/// precise per-sub-phase timing before any further lever pull. These
+/// `*_ns` accumulators provide that data:
+///
+///   - fillTrellis_total_ns         — whole `fillTrellis` body
+///   - fillTrellis_chunkScan_ns     — chunk-cache prefix-match for-loop
+///   - fillTrellis_init_ns          — cache-miss path: create+clone+initWithSeqs+append
+///   - fillTrellis_tmpInit_ns       — cache-hit (trellis) path: tmptrell init
+///   - fillTrellis_viterbi_ns       — `trell_ptr.viterbi()` call
+///   - fillTrellis_forward_ns       — `trell_ptr.forward()` call
+///   - fillTrellis_traceback_ns     — `trell_ptr.traceback(...)` call
+///   - fillTrellis_put_ns           — `gc.paths.put` + `gc.scores.put`
+///   - cachedPath_ns                — `runKSet`'s `partial_match` cache-hit
+///                                    branch (does NOT enter `fillTrellis`)
+///
+/// All timers use `std.time.Instant` (CLOCK_MONOTONIC). They compile to
+/// nothing when `-Dperf-counters=false` (the `Tick` type is `void`, and
+/// `tick`/`addElapsed` early-return). The corresponding output line is
+/// `PERFCOUNTER_TIMING` (separate from `PERFCOUNTER` so the existing
+/// aggregator keeps parsing the original line unchanged).
+///
 /// The `_calls` vs `_log_exp_calls` split for `addInLogSpace` matters for
 /// item-3.2 costing: at function entry the call may still hit a cheap
 /// `NEG_INF` short-circuit and do zero transcendental work. The first
@@ -55,6 +84,64 @@ pub var chunk_cache_lookups: u64 = 0;
 pub var chunk_cache_hits: u64 = 0;
 pub var active_state_hist: [HIST_LEN]u64 = [_]u64{0} ** HIST_LEN;
 
+// Phase-B sub-phase ns accumulators. Wrap-around (`+%=`) is fine: a u64
+// of nanoseconds is ~584 years.
+pub var fillTrellis_total_ns: u64 = 0;
+pub var fillTrellis_chunkScan_ns: u64 = 0;
+pub var fillTrellis_init_ns: u64 = 0;
+pub var fillTrellis_tmpInit_ns: u64 = 0;
+pub var fillTrellis_viterbi_ns: u64 = 0;
+pub var fillTrellis_forward_ns: u64 = 0;
+pub var fillTrellis_traceback_ns: u64 = 0;
+pub var fillTrellis_put_ns: u64 = 0;
+pub var cachedPath_ns: u64 = 0;
+
+// Phase-B outer-perimeter accumulators. These pair with the inner ones
+// above to bound the un-timed gap inside one `DPHandler.run()`:
+//   runKSet_overhead       = runKSet_total       − (fillTrellis_total + cachedPath)
+//   dpHandler_run_overhead = dpHandler_run_total − Σ runKSet_total
+// The latter covers the run()-body pre/post work: Sequences build, the
+// only_genes map, `hmms.rescaleOverallMuteFreqs`, `fillRecoEvent` for
+// viterbi, `Result.finalize`, debug logging, etc. Phase B saw the
+// inner perimeter (fillTrellis+cachedPath) is ~95% DP; these outer
+// accumulators let us check whether the remaining bcrham wall really
+// is Glomerator+driver, or whether there's an addressable bucket
+// hiding in run() pre/post or runKSet plumbing.
+pub var runKSet_total_ns: u64 = 0;
+pub var dpHandler_run_total_ns: u64 = 0;
+
+// Phase-B'' deeper-DP timers: split `viterbi()` and `forward()` (in
+// `trellis.zig`) into init / position-loop / ending sub-phases. The
+// position-loop body is derived in the aggregator as the residual:
+//   viterbi_positionLoop_ns ≈ fillTrellis_viterbi_ns − init − ending
+//   forward_positionLoop_ns ≈ fillTrellis_forward_ns − init − ending
+// Expected outcome: init + ending sum to <5%, so the position loop
+// — i.e. `middleViterbiVals`/`middleForwardVals` + `swapColumnsActive`
+// — accounts for ~95%+ of the DP time. That confirms the only
+// remaining lever surface is the inner DP body, which is not localized
+// (it's the algorithm itself).
+pub var viterbi_init_ns: u64 = 0;
+pub var viterbi_ending_ns: u64 = 0;
+pub var forward_init_ns: u64 = 0;
+pub var forward_ending_ns: u64 = 0;
+
+// Process-lifetime accumulator: total wall in `Glomerator.cluster()`.
+// Distinct from the per-DPHandler.run() counters above — this one
+// survives the per-query `reset()` so it accumulates across all the
+// nested DPHandler.run() invocations inside one `cluster()` call.
+// Bcrham emits one `PERFCOUNTER_GLOMERATOR` line at the end of
+// `cluster()` reporting this value plus the cumulative DPHandler.run
+// time across all calls inside it (the latter via a paired
+// `cumul_dpHandler_run_ns` accumulator that ALSO survives reset()).
+// Together with the `bcrham time:` line printed by partis, the gap
+//   bcrham_CPU − cumul_dpHandler_run_ns × n_procs
+// tells us whether the remaining bcrham CPU is in Glomerator driver
+// code (merge decisions, partition writes) or in bcrham startup /
+// model loading. Phase B' shows ~28% of bcrham CPU lives outside
+// DPHandler.run(); this counter lets us split it.
+pub var glomerator_cluster_ns: u64 = 0;
+pub var cumul_dpHandler_run_ns: u64 = 0;
+
 pub fn reset() void {
     if (!enabled) return;
     addInLogSpace_calls = 0;
@@ -63,6 +150,21 @@ pub fn reset() void {
     n_ksets = 0;
     chunk_cache_lookups = 0;
     chunk_cache_hits = 0;
+    fillTrellis_total_ns = 0;
+    fillTrellis_chunkScan_ns = 0;
+    fillTrellis_init_ns = 0;
+    fillTrellis_tmpInit_ns = 0;
+    fillTrellis_viterbi_ns = 0;
+    fillTrellis_forward_ns = 0;
+    fillTrellis_traceback_ns = 0;
+    fillTrellis_put_ns = 0;
+    cachedPath_ns = 0;
+    runKSet_total_ns = 0;
+    dpHandler_run_total_ns = 0;
+    viterbi_init_ns = 0;
+    viterbi_ending_ns = 0;
+    forward_init_ns = 0;
+    forward_ending_ns = 0;
     // NB: explicit loop instead of `@memset(&active_state_hist, 0)` —
     // Zig 0.15.2 hits an x86_64 codegen bug ("no encoding found for:
     // none mov m64 m64 none none") on a Debug @memset over a fixed-size
@@ -70,6 +172,30 @@ pub fn reset() void {
     // will turn it back into a memset under ReleaseFast/ReleaseSafe.
     var i: usize = 0;
     while (i < HIST_LEN) : (i += 1) active_state_hist[i] = 0;
+}
+
+/// Cycle-precise sub-phase timer pair, gated on the `-Dperf-counters`
+/// build option. When disabled, `Tick` is `void`, both helpers early-
+/// return, and the call site reduces to nothing under the optimizer —
+/// preserving the default-build bit-equality contract.
+///
+/// Usage:
+///   const t = perf_counters.tick();
+///   // ... work to time ...
+///   perf_counters.addElapsed(&perf_counters.fillTrellis_chunkScan_ns, t);
+pub const Tick = if (enabled) std.time.Instant else void;
+
+pub inline fn tick() Tick {
+    if (!enabled) return {};
+    // `Instant.now()` only returns `error.Unsupported` on platforms
+    // without a monotonic clock. Linux/macOS/Windows all provide one.
+    return std.time.Instant.now() catch unreachable;
+}
+
+pub inline fn addElapsed(accum: *u64, start: Tick) void {
+    if (!enabled) return;
+    const now_inst = std.time.Instant.now() catch unreachable;
+    accum.* +%= now_inst.since(start);
 }
 
 pub inline fn bumpAddInLogSpace() void {
@@ -160,6 +286,48 @@ pub fn formatPerfCounters(
             stats.p95,
             stats.max,
             stats.total,
+        },
+    );
+}
+
+/// Format the per-query sub-phase ns accumulators as a separate
+/// `PERFCOUNTER_TIMING` line. Kept distinct from `PERFCOUNTER` so the
+/// existing aggregator parses unchanged; the timing aggregator reads only
+/// these lines.
+///
+///   PERFCOUNTER_TIMING alg=... q=... n_seqs=... \
+///       fillTrellis_total_ns=T chunkScan_ns=... init_ns=... \
+///       tmpInit_ns=... viterbi_ns=... forward_ns=... traceback_ns=... \
+///       put_ns=... cachedPath_ns=...
+pub fn formatPerfCountersTiming(
+    allocator: std.mem.Allocator,
+    algorithm: []const u8,
+    query_name: []const u8,
+    n_seqs: usize,
+) !?[]u8 {
+    if (!enabled) return null;
+    return try std.fmt.allocPrint(
+        allocator,
+        "PERFCOUNTER_TIMING alg={s} q={s} n_seqs={d} dpHandler_run_total_ns={d} runKSet_total_ns={d} fillTrellis_total_ns={d} chunkScan_ns={d} init_ns={d} tmpInit_ns={d} viterbi_ns={d} forward_ns={d} traceback_ns={d} put_ns={d} cachedPath_ns={d} viterbi_init_ns={d} viterbi_ending_ns={d} forward_init_ns={d} forward_ending_ns={d}\n",
+        .{
+            algorithm,
+            query_name,
+            n_seqs,
+            dpHandler_run_total_ns,
+            runKSet_total_ns,
+            fillTrellis_total_ns,
+            fillTrellis_chunkScan_ns,
+            fillTrellis_init_ns,
+            fillTrellis_tmpInit_ns,
+            fillTrellis_viterbi_ns,
+            fillTrellis_forward_ns,
+            fillTrellis_traceback_ns,
+            fillTrellis_put_ns,
+            cachedPath_ns,
+            viterbi_init_ns,
+            viterbi_ending_ns,
+            forward_init_ns,
+            forward_ending_ns,
         },
     );
 }

--- a/packages/zig-core/src/ham/perf_counters.zig
+++ b/packages/zig-core/src/ham/perf_counters.zig
@@ -125,21 +125,24 @@ pub var viterbi_ending_ns: u64 = 0;
 pub var forward_init_ns: u64 = 0;
 pub var forward_ending_ns: u64 = 0;
 
-// Process-lifetime accumulator: total wall in `Glomerator.cluster()`.
-// Distinct from the per-DPHandler.run() counters above — this one
-// survives the per-query `reset()` so it accumulates across all the
-// nested DPHandler.run() invocations inside one `cluster()` call.
-// Bcrham emits one `PERFCOUNTER_GLOMERATOR` line at the end of
-// `cluster()` reporting this value plus the cumulative DPHandler.run
-// time across all calls inside it (the latter via a paired
-// `cumul_dpHandler_run_ns` accumulator that ALSO survives reset()).
+// Process-lifetime accumulator: total wall in `Glomerator.cluster()` OR
+// `Glomerator.cacheNaiveSeqs()`. The dumped `PERFCOUNTER_GLOMERATOR`
+// line tags which mode via its `kind=` field. Distinct from the
+// per-DPHandler.run() counters above — this one survives the per-query
+// `reset()` so it accumulates across all the nested DPHandler.run()
+// invocations inside one Glomerator entry-point call. Bcrham emits one
+// `PERFCOUNTER_GLOMERATOR` line at the end of each call reporting
+// this value plus the cumulative DPHandler.run time across all calls
+// inside it (the latter via a paired `cumul_dpHandler_run_ns`
+// accumulator that ALSO survives reset()).
+//
 // Together with the `bcrham time:` line printed by partis, the gap
 //   bcrham_CPU − cumul_dpHandler_run_ns × n_procs
 // tells us whether the remaining bcrham CPU is in Glomerator driver
 // code (merge decisions, partition writes) or in bcrham startup /
 // model loading. Phase B' shows ~28% of bcrham CPU lives outside
 // DPHandler.run(); this counter lets us split it.
-pub var glomerator_cluster_ns: u64 = 0;
+pub var glomerator_ns: u64 = 0;
 pub var cumul_dpHandler_run_ns: u64 = 0;
 
 pub fn reset() void {

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -192,6 +192,9 @@ pub const Trellis = struct {
         defer prev_current_states.deinit(allocator);
 
         // Position 0: transitions from init state
+        // Phase-B'' timer: capture the init-position cost so the main
+        // position-loop body is derivable as fillTrellis_viterbi_ns − init − ending.
+        const t_init = perf_counters.tick();
         const init_st = self.hmm.initial orelse return error.NoInitState;
         // Reset next_seen before populating position 0
         self.next_seen = state_mod.StateBitset.initEmpty();
@@ -219,6 +222,7 @@ pub const Trellis = struct {
                 }
             }
         }
+        perf_counters.addElapsed(&perf_counters.viterbi_init_ns, t_init);
 
         // Positions 1..seq_len-1
         var position: usize = 1;
@@ -229,6 +233,7 @@ pub const Trellis = struct {
         self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
 
         // Compute ending probability
+        const t_ending = perf_counters.tick();
         self.ending_viterbi_pointer = -1;
         self.ending_viterbi_log_prob = mathutils.NEG_INF;
         for (0..n_states) |st_prev| {
@@ -239,6 +244,7 @@ pub const Trellis = struct {
                 self.ending_viterbi_pointer = @intCast(st_prev);
             }
         }
+        perf_counters.addElapsed(&perf_counters.viterbi_ending_ns, t_ending);
     }
 
     /// Run the Forward algorithm.
@@ -274,6 +280,8 @@ pub const Trellis = struct {
         defer prev_current_states.deinit(allocator);
 
         // Position 0: transitions from init state
+        // Phase-B'' timer: capture the init-position cost (see viterbi() above).
+        const t_init = perf_counters.tick();
         const init_st = self.hmm.initial orelse return error.NoInitState;
         // Reset next_seen before populating position 0
         self.next_seen = state_mod.StateBitset.initEmpty();
@@ -295,6 +303,7 @@ pub const Trellis = struct {
             }
             self.cacheForwardVals(0, dpval, i_st);
         }
+        perf_counters.addElapsed(&perf_counters.forward_init_ns, t_init);
 
         // Positions 1..seq_len-1
         var position: usize = 1;
@@ -305,6 +314,7 @@ pub const Trellis = struct {
         self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
 
         // Compute ending probability
+        const t_ending = perf_counters.tick();
         self.ending_forward_log_prob = mathutils.NEG_INF;
         for (0..n_states) |st_prev| {
             if (std.math.isNegativeInf(self.scoring_previous[st_prev])) continue;
@@ -312,6 +322,7 @@ pub const Trellis = struct {
             if (std.math.isNegativeInf(dpval)) continue;
             self.ending_forward_log_prob = mathutils.addInLogSpace(self.ending_forward_log_prob, dpval);
         }
+        perf_counters.addElapsed(&perf_counters.forward_ending_ns, t_ending);
     }
 
     /// Traceback to produce a path.

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -153,6 +153,16 @@ pub const Trellis = struct {
             return;
         }
 
+        // Phase-B'' timer: capture all pre-position-loop work — log_probs/indices
+        // resize, traceback_table allocate, 4× @memset on log_probs/indices/
+        // traceback_table/scoring_current/scoring_previous, plus the position-0
+        // init transitions below. The main position-loop body is derivable as
+        // fillTrellis_viterbi_ns − init − ending. Skeptic flag (#383 review,
+        // 2026-05-12): t_init was originally placed AFTER the resize/memset
+        // block, so the O(seq_len × n_states) memsets leaked into the
+        // positionLoop residual. Moving the tick up makes init_ns honest.
+        const t_init = perf_counters.tick();
+
         // Initialize storage
         try self.viterbi_log_probs.resize(allocator, seq_len);
         try self.viterbi_indices.resize(allocator, seq_len);
@@ -192,9 +202,6 @@ pub const Trellis = struct {
         defer prev_current_states.deinit(allocator);
 
         // Position 0: transitions from init state
-        // Phase-B'' timer: capture the init-position cost so the main
-        // position-loop body is derivable as fillTrellis_viterbi_ns − init − ending.
-        const t_init = perf_counters.tick();
         const init_st = self.hmm.initial orelse return error.NoInitState;
         // Reset next_seen before populating position 0
         self.next_seen = state_mod.StateBitset.initEmpty();
@@ -262,6 +269,12 @@ pub const Trellis = struct {
             return;
         }
 
+        // Phase-B'' timer: capture all pre-position-loop work — log_probs
+        // resize, 3× @memset on log_probs/scoring_current/scoring_previous, plus
+        // the position-0 init transitions below. See viterbi() above for the
+        // skeptic-flagged correction (#383 review, 2026-05-12).
+        const t_init = perf_counters.tick();
+
         // Initialize storage
         try self.forward_log_probs.resize(allocator, seq_len);
         @memset(self.forward_log_probs.items, mathutils.NEG_INF);
@@ -280,8 +293,6 @@ pub const Trellis = struct {
         defer prev_current_states.deinit(allocator);
 
         // Position 0: transitions from init state
-        // Phase-B'' timer: capture the init-position cost (see viterbi() above).
-        const t_init = perf_counters.tick();
         const init_st = self.hmm.initial orelse return error.NoInitState;
         // Reset next_seen before populating position 0
         self.next_seen = state_mod.StateBitset.initEmpty();


### PR DESCRIPTION
## Summary

Adds three concentric layers of `std.time.Instant`-based timers under `-Dperf-counters=true`, plus a `PERFCOUNTER_TIMING` line per query and a `PERFCOUNTER_GLOMERATOR` line per bcrham invocation. Default ReleaseFast build remains bit-equal — verified by 30k paired-partition diff vs `/tmp/parity-30k-377-zig` (md5 match on 21563 events), 1k diff, and `partis-test --quick --zig` / `--paired --zig`.

This is an **instrumentation-only** change. No wall claim — the contribution is the timing data + the tooling to keep generating it.

## Why

Closes the open-question column from the lever-5 close ([#382](https://github.com/psathyrella/partis/pull/382)). A 24.63% perf-record symbol bucket turned out to over-attribute work inside an amortized hot loop, and the wall-bench result for the lever came in at +1.89% with CI straddling zero. We needed cycle-precise per-sub-phase timing before pulling another lever — the new perimeters answer the questions Phase 0 + Phase A left open.

## What it surfaces

Three concentric perimeters:

- **Inner** — `fillTrellis` sub-phases: `chunkScan` / `init` / `tmpInit` / `viterbi` / `forward` / `traceback` / `put` / `cachedPath`.
- **Outer (Phase B')** — `runKSet` body + `DPHandler.run` body. Surfaces runKSet plumbing and run()-body pre/post overhead.
- **Outermost (Phase B')** — `Glomerator.cluster()` / `cacheNaiveSeqs()` total + `cumul_dpHandler_run`, dumped once per bcrham invocation.
- **Deeper-DP (Phase B'')** — `viterbi` / `forward` split into init / position-loop / ending. Position loop derived as the residual.

## Headline 2k paired-partition findings

```
                                     viterbi    forward
dpHandler_run_total                  35.484 s   143.593 s
  fillTrellis body                   29.719     136.511
    DP body (viterbi/forward)        27.928 (79.8%)   132.713 (92.8%)
      init                            0.237 ( 0.7%)     0.882 ( 0.6%)
      positionLoop (derived)         27.657 (79.0%)   131.609 (92.1%)
      ending                          0.034 ( 0.1%)     0.221 ( 0.2%)
    chunkScan / init / tmpInit / traceback / put   each <1%
  cachedPath (kset-level cache hit)   0.158 ( 0.4%)     0.227 ( 0.2%)
  runKSet plumbing                    1.234 ( 3.5%)     4.334 ( 3.0%)
  run() pre/post-runKSet              4.420 (12.6%)     2.520 ( 1.8%)

Glomerator.cluster (55 bcrham procs):  152.117 s, driver_overhead=6.008s (3.9%)
Glomerator.cacheNaiveSeqs (8 procs):     8.128 s, driver_overhead=0.077s (1.0%)
```

Key takeaways:

- **99% of the DP body is in the position loop.** init+ending are <1%. The only remaining lever surface is inside `middleViterbiVals` / `middleForwardVals` / `swapColumnsActive` — the inner DP code, not a localized change.
- **cachedPath is 0.2–0.5% of timed work.** Phase 0 said the kset-level cache hits 78–86% of ksets by count; Phase B says those hits save 0.2–0.5% of time. The count-vs-time ratio overstated by ~150×. Lever 5's +1.89% wall observation is consistent with this bound.
- **Glomerator driver overhead is 3.8% of cluster() wall.** Phase A's perf-record put Glomerator at ~10% via inlining attribution from bcrham calls inside its call stack — same misleading mode as lever 5. Not a localized lever.
- **~25% of bcrham CPU lives outside every Phase-B' perimeter.** With ~63 bcrham subprocess invocations per 2k run, that maps to ~1s per process for HMM model loading + parameter file parsing. Partis-level concern, out of #366 scope.

## Decision criteria

The plan's stop criterion was: "no single bucket above ~10% of bcrham wall, addressable by a localized change." Fires. The only ≥10% non-DP bucket is the viterbi run()-body pre/post (12.6% of viterbi run_total, mostly `fillRecoEvent`+`finalize`), which is ~1% of total bcrham CPU on a forward-dominated partition workload.

Future work that touches the Zig perf surface should use these timers to size its wall claim against bcrham *before* pulling.

## Verification

- Default ReleaseFast build is bit-equal to lever-1 head `b88e4d3ba`:
  - 1k paired-partition yaml diff: identical
  - 30k paired-partition yaml diff vs `/tmp/parity-30k-377-zig` (10750 igh + 10813 igk events): identical (md5sums match)
- `partis-test --quick --zig`: ok
- `partis-test --paired --zig`: 0 red diffs. (One step crashed with `command 'R' not found` — pre-existing environment issue on this machine; `which R` returns exit 1.)
- `-Dperf-counters=true` build compiles clean (ReleaseFast).

## Files

| file | what changes |
|---|---|
| `packages/zig-core/src/ham/perf_counters.zig` | 15 ns accumulators, `Tick`/`tick`/`addElapsed` helpers, `formatPerfCountersTiming`. Process-lifetime `glomerator_cluster_ns` / `cumul_dpHandler_run_ns` survive `reset()`. |
| `packages/zig-core/src/ham/dp_handler.zig` | 8 `fillTrellis` timer pairs, 1 `cachedPath` pair, `runKSet` body timer (defer), `DPHandler.run` body timer with cumul mirror; emit `PERFCOUNTER_TIMING` alongside `PERFCOUNTER` / `_CACHE`. |
| `packages/zig-core/src/ham/glomerator/glomerator.zig` | `cluster()` and `cacheNaiveSeqs()` body timers; `dumpGlomeratorCounters` emits one `PERFCOUNTER_GLOMERATOR` line per bcrham invocation. |
| `packages/zig-core/src/ham/trellis.zig` | Phase-B'' timer pairs around the position-0 init block and ending-prob block in `viterbi()` and `forward()`; position loop time derived as the residual. |
| `bin/zig-perf-counters-aggregate.py` | Parse `PERFCOUNTER_TIMING` and `PERFCOUNTER_GLOMERATOR`, compute concentric-perimeter time table. |

Full memo: `/tmp/perf-1.1-results/phase-B-results.md`.

## Test plan

- [x] Default ReleaseFast build compiles clean
- [x] `-Dperf-counters=true` build compiles clean
- [x] 1k paired-partition yaml diff vs lever-1 head identical
- [x] 30k paired-partition yaml diff vs `/tmp/parity-30k-377-zig` identical (md5sums match on 21563 events)
- [x] `partis-test --quick --zig` ok
- [x] `partis-test --paired --zig` 0 red diffs (R-not-installed environment issue is pre-existing)
- [x] `PERFCOUNTER_TIMING` and `PERFCOUNTER_GLOMERATOR` lines emitted under `-Dperf-counters=true` + `PARTIS_ZIG_PERF_LOG=...`
- [x] Aggregator reports concentric-perimeter time table

🤖 Generated with [Claude Code](https://claude.com/claude-code)