### PR TITLE
zig perf round 2 + Zig↔C++ 30k parity fix (#366, #375, #377)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ packages/RPANDA/lib/
 /packages/zig-core/.zig-cache/
 /packages/zig-core/zig-cache/
 /packages/zig-core/.zig-install/
+/.claude/

--- a/bin/partis
+++ b/bin/partis
@@ -1849,4 +1849,10 @@ random.seed(args.random_seed)
 numpy.random.seed(args.random_seed)
 start = time.time()
 args.func(args)
-print('      total time: %.1f' % (time.time()-start))
+total_time = time.time() - start
+print('      total time: %.1f' % total_time)
+from partis import partitiondriver
+bcrham_t, bcrham_n = partitiondriver.get_bcrham_summary()
+if bcrham_n > 0:
+    pct = 100.0 * bcrham_t / total_time if total_time > 0 else 0.0
+    print('      bcrham time: %.1f (%.1f%% of total, %d calls)' % (bcrham_t, pct, bcrham_n))

--- a/bin/partis
+++ b/bin/partis
@@ -34,6 +34,7 @@ import partis.glutils as glutils
 import partis.treeutils as treeutils
 import partis.processargs as processargs
 import partis.seqfileopener as seqfileopener
+from partis import partitiondriver
 from partis.partitiondriver import PartitionDriver
 from partis.clusterpath import ClusterPath
 import partis.paircluster as paircluster
@@ -1851,7 +1852,6 @@ start = time.time()
 args.func(args)
 total_time = time.time() - start
 print('      total time: %.1f' % total_time)
-from partis import partitiondriver
 bcrham_t, bcrham_n = partitiondriver.get_bcrham_summary()
 if bcrham_n > 0:
     pct = 100.0 * bcrham_t / total_time if total_time > 0 else 0.0

--- a/bin/partis-30k-parity-test.sh
+++ b/bin/partis-30k-parity-test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# 30k Zig-vs-C++ partition parity gate (issue #375).
+#
+# Runs an unbounded paired-loci partition with the Zig and C++ backends on the
+# same 30k input, then compares cluster membership and per-event annotation
+# fields. Exits 0 if identical, 1 otherwise. The 5k partis-test.py rung doesn't
+# exercise enough cache round-trips to surface tiebreak-density-dependent
+# divergences (#375 was latent until 30k).
+#
+# Usage:
+#   bin/partis-30k-parity-test.sh [INFILE [OUTBASE [N]]]
+#
+# Defaults:
+#   INFILE = /tmp/paired-paper-all-seqs.fa
+#   OUTBASE = /tmp/parity-30k-test
+#   N = 30000
+#
+# Wall budget on pax (32-core Zen 5):
+#   ~50 min Zig + ~100 min C++ + a few min compare = ~2.5 h total when sequential.
+#   Backends run sequentially to keep the host responsive; bump --n-procs in
+#   this script to parallelize within a backend.
+
+set -euo pipefail
+
+INFILE="${1:-/tmp/paired-paper-all-seqs.fa}"
+OUTBASE="${2:-/tmp/parity-30k-test}"
+N="${3:-30000}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPARE="${REPO_ROOT}/bin/zig-compare.py"
+if [[ ! -x "${COMPARE}" ]]; then
+  echo "ERROR: cannot find zig-compare.py at ${COMPARE}" >&2
+  exit 2
+fi
+
+if [[ ! -f "${INFILE}" ]]; then
+  echo "ERROR: input file ${INFILE} does not exist" >&2
+  exit 2
+fi
+
+CPP_DIR="${OUTBASE}-cpp"
+ZIG_DIR="${OUTBASE}-zig"
+
+run_backend() {
+  local backend="$1" outdir="$2"
+  shift 2
+  rm -rf "${outdir}"
+  echo ">> running ${backend} backend → ${outdir}"
+  PYTHONHASHSEED=0 python3 "${REPO_ROOT}/bin/partis" partition --paired-loci \
+    --paired-outdir "${outdir}" \
+    --infname "${INFILE}" --n-max-queries "${N}" \
+    --random-seed 1 --n-procs 10 --no-time-based-n-proc-reduction \
+    --dont-write-git-info "$@"
+}
+
+# C++ first (slower), then Zig — sequential keeps the host responsive at the
+# usual 10 procs. Either order works; the partition is deterministic.
+run_backend "C++"  "${CPP_DIR}"
+run_backend "Zig"  "${ZIG_DIR}"  --zig
+
+echo ">> comparing"
+"${COMPARE}" "${CPP_DIR}" "${ZIG_DIR}"

--- a/bin/partis-30k-parity-test.sh
+++ b/bin/partis-30k-parity-test.sh
@@ -27,6 +27,13 @@ OUTBASE="${2:-/tmp/parity-30k-test}"
 N="${3:-30000}"
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Match bin/zig-perf-counters-run.sh: per project CLAUDE.md, activate the venv
+# before invoking partis so an unactivated shell doesn't fall back to system
+# python and fail with an import error.
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/.venv/bin/activate"
+
 COMPARE="${REPO_ROOT}/bin/zig-compare.py"
 if [[ ! -x "${COMPARE}" ]]; then
   echo "ERROR: cannot find zig-compare.py at ${COMPARE}" >&2

--- a/bin/zig-compare.py
+++ b/bin/zig-compare.py
@@ -7,11 +7,11 @@ Companion to bin/partis-30k-parity-test.sh (issue #375 cpp-mirror gate).
 Exit 0 if identical, 1 otherwise.
 """
 import hashlib
-import json
 import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+from partis import utils
 from partis.clusterpath import ClusterPath
 
 
@@ -25,20 +25,29 @@ FIELDS = ('naive_seq', 'v_gene', 'd_gene', 'j_gene',
           'v_3p_del', 'd_5p_del', 'd_3p_del', 'j_5p_del',
           'vd_insertion', 'dj_insertion', 'cdr3_length')
 
+_MD5_CHUNK_BYTES = 1 << 20
 
-# All partition-{locus}.yaml files paired-loci output writes. Originally the
+
+# All partition-{locus}.yaml files paired-loci output writes. Subdirs and loci
+# are derived from utils.locus_pairs (plus top-level + single-chain/) so a
+# future paired-loci pair addition picks up automatically. Originally the
 # gate only walked igh+igk/ (or igh+igl/ as fallback) and missed single-chain
 # divergence at 50k — see #386.
-PARTITION_RELPATHS = []
-for _sub in ('', 'igh+igk', 'igh+igl', 'single-chain'):
-    for _loc in ('igh', 'igk', 'igl'):
-        PARTITION_RELPATHS.append((_sub, _loc, f'{_sub}/partition-{_loc}.yaml' if _sub else f'partition-{_loc}.yaml'))
+def _partition_relpaths():
+    pairs = utils.locus_pairs['ig']
+    loci = sorted({l for lp in pairs for l in lp})
+    subs = [''] + ['+'.join(lp) for lp in pairs] + ['single-chain']
+    return [(sub, loc, f'{sub}/partition-{loc}.yaml' if sub else f'partition-{loc}.yaml')
+            for sub in subs for loc in loci]
+
+
+PARTITION_RELPATHS = _partition_relpaths()
 
 
 def md5(path):
     h = hashlib.md5()
     with open(path, 'rb') as fh:
-        for chunk in iter(lambda: fh.read(1 << 20), b''):
+        for chunk in iter(lambda: fh.read(_MD5_CHUNK_BYTES), b''):
             h.update(chunk)
     return h.hexdigest()
 
@@ -61,10 +70,8 @@ def diff_one(label, bp, np_):
     if bpart != npart:
         print(f'{label}: PARTITION DIFF ({len(bpart)} vs {len(npart)} clusters)')
         return 1
-    with open(bp) as fh:
-        bd = json.load(fh)
-    with open(np_) as fh:
-        nd = json.load(fh)
+    bd = utils.read_json_yaml(bp)
+    nd = utils.read_json_yaml(np_)
     bk = {tuple(sorted(e['unique_ids'])): e for e in bd['events']}
     nk = {tuple(sorted(e['unique_ids'])): e for e in nd['events']}
     if set(bk) != set(nk):
@@ -78,7 +85,7 @@ def diff_one(label, bp, np_):
             if bk[k].get(f) != nk[k].get(f):
                 field_diffs += 1
                 if field_diffs <= 3:
-                    print(f'{label} {k[:1]}...: {f} diff: {bk[k].get(f)} vs {nk[k].get(f)}')
+                    print(f'{label} {k[0]}...: {f} diff: {bk[k].get(f)} vs {nk[k].get(f)}')
     if field_diffs:
         print(f'{label}: {field_diffs} FIELD DIFFS across {len(bk)} events')
         return 1

--- a/bin/zig-compare.py
+++ b/bin/zig-compare.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Diff two partis paired-loci output dirs for byte-equality on partition + annotations.
+
+Usage: zig-compare.py <baseline_dir> <new_dir>
+
+Companion to bin/partis-30k-parity-test.sh (issue #375 cpp-mirror gate).
+Exit 0 if identical, 1 otherwise.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+from partis.clusterpath import ClusterPath
+
+
+def best_partition(path):
+    cpath = ClusterPath()
+    cpath.readfile(path)
+    return sorted(tuple(sorted(c)) for c in cpath.partitions[cpath.i_best])
+
+
+FIELDS = ('naive_seq', 'v_gene', 'd_gene', 'j_gene',
+          'v_3p_del', 'd_5p_del', 'd_3p_del', 'j_5p_del',
+          'vd_insertion', 'dj_insertion', 'cdr3_length')
+
+
+def diff_pair(base, new):
+    n_diffs = 0
+    for locus in ('igh', 'igk', 'igl'):
+        bp = f'{base}/igh+igk/partition-{locus}.yaml'
+        np_ = f'{new}/igh+igk/partition-{locus}.yaml'
+        if not os.path.exists(bp):
+            bp = f'{base}/igh+igl/partition-{locus}.yaml'
+            np_ = f'{new}/igh+igl/partition-{locus}.yaml'
+        if not os.path.exists(bp):
+            print(f'{locus}: no baseline file (skipping)')
+            continue
+        if not os.path.exists(np_):
+            print(f'{locus}: MISSING in new ({np_})')
+            n_diffs += 1
+            continue
+        bpart = best_partition(bp)
+        npart = best_partition(np_)
+        if bpart != npart:
+            print(f'{locus}: PARTITION DIFF ({len(bpart)} vs {len(npart)} clusters)')
+            n_diffs += 1
+            continue
+        with open(bp) as f:
+            bd = json.load(f)
+        with open(np_) as f:
+            nd = json.load(f)
+        bk = {tuple(sorted(e['unique_ids'])): e for e in bd['events']}
+        nk = {tuple(sorted(e['unique_ids'])): e for e in nd['events']}
+        if set(bk) != set(nk):
+            only_b = set(bk) - set(nk)
+            only_n = set(nk) - set(bk)
+            print(f'{locus}: EVENT-KEY DIFF (only in base: {len(only_b)}, only in new: {len(only_n)})')
+            n_diffs += 1
+            continue
+        field_diffs = 0
+        for k in bk:
+            for f in FIELDS:
+                if bk[k].get(f) != nk[k].get(f):
+                    field_diffs += 1
+                    if field_diffs <= 3:
+                        print(f'{locus} {k[:1]}...: {f} diff: {bk[k].get(f)} vs {nk[k].get(f)}')
+        if field_diffs:
+            print(f'{locus}: {field_diffs} FIELD DIFFS across {len(bk)} events')
+            n_diffs += 1
+        else:
+            print(f'{locus}: {len(bk)} events identical')
+    return n_diffs
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit(__doc__)
+    base, new = sys.argv[1], sys.argv[2]
+    n = diff_pair(base, new)
+    if n:
+        print(f'\nFAILED: {n} loci differ')
+        sys.exit(1)
+    print('\nOK: identical')
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/zig-compare.py
+++ b/bin/zig-compare.py
@@ -6,6 +6,7 @@ Usage: zig-compare.py <baseline_dir> <new_dir>
 Companion to bin/partis-30k-parity-test.sh (issue #375 cpp-mirror gate).
 Exit 0 if identical, 1 otherwise.
 """
+import hashlib
 import json
 import os
 import sys
@@ -25,51 +26,85 @@ FIELDS = ('naive_seq', 'v_gene', 'd_gene', 'j_gene',
           'vd_insertion', 'dj_insertion', 'cdr3_length')
 
 
+# All partition-{locus}.yaml files paired-loci output writes. Originally the
+# gate only walked igh+igk/ (or igh+igl/ as fallback) and missed single-chain
+# divergence at 50k — see #386.
+PARTITION_RELPATHS = []
+for _sub in ('', 'igh+igk', 'igh+igl', 'single-chain'):
+    for _loc in ('igh', 'igk', 'igl'):
+        PARTITION_RELPATHS.append((_sub, _loc, f'{_sub}/partition-{_loc}.yaml' if _sub else f'partition-{_loc}.yaml'))
+
+
+def md5(path):
+    h = hashlib.md5()
+    with open(path, 'rb') as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def diff_one(label, bp, np_):
+    """Compare a single base/new partition-*.yaml pair. Returns 1 on diff, 0 on match, None on skip."""
+    if not os.path.exists(bp) and not os.path.exists(np_):
+        return None  # neither side has this file — not produced by this run
+    if not os.path.exists(bp):
+        print(f'{label}: MISSING in base ({bp})')
+        return 1
+    if not os.path.exists(np_):
+        print(f'{label}: MISSING in new ({np_})')
+        return 1
+    if md5(bp) == md5(np_):
+        print(f'{label}: byte-identical')
+        return 0
+    bpart = best_partition(bp)
+    npart = best_partition(np_)
+    if bpart != npart:
+        print(f'{label}: PARTITION DIFF ({len(bpart)} vs {len(npart)} clusters)')
+        return 1
+    with open(bp) as fh:
+        bd = json.load(fh)
+    with open(np_) as fh:
+        nd = json.load(fh)
+    bk = {tuple(sorted(e['unique_ids'])): e for e in bd['events']}
+    nk = {tuple(sorted(e['unique_ids'])): e for e in nd['events']}
+    if set(bk) != set(nk):
+        only_b = set(bk) - set(nk)
+        only_n = set(nk) - set(bk)
+        print(f'{label}: EVENT-KEY DIFF (only in base: {len(only_b)}, only in new: {len(only_n)})')
+        return 1
+    field_diffs = 0
+    for k in bk:
+        for f in FIELDS:
+            if bk[k].get(f) != nk[k].get(f):
+                field_diffs += 1
+                if field_diffs <= 3:
+                    print(f'{label} {k[:1]}...: {f} diff: {bk[k].get(f)} vs {nk[k].get(f)}')
+    if field_diffs:
+        print(f'{label}: {field_diffs} FIELD DIFFS across {len(bk)} events')
+        return 1
+    # Bytes differ but every event keyed by unique_ids has bit-identical content
+    # and partitions match — the diff is event-list ordering only (#386).
+    cpp_order = [tuple(sorted(e['unique_ids'])) for e in bd['events']]
+    zig_order = [tuple(sorted(e['unique_ids'])) for e in nd['events']]
+    n_pos_diff = sum(1 for a, b in zip(cpp_order, zig_order) if a != b)
+    print(f'{label}: BYTE DIFF (md5 mismatch) but events bit-identical by uid; '
+          f'event-list order differs at {n_pos_diff}/{len(bk)} positions')
+    return 1
+
+
 def diff_pair(base, new):
     n_diffs = 0
-    for locus in ('igh', 'igk', 'igl'):
-        bp = f'{base}/igh+igk/partition-{locus}.yaml'
-        np_ = f'{new}/igh+igk/partition-{locus}.yaml'
-        if not os.path.exists(bp):
-            bp = f'{base}/igh+igl/partition-{locus}.yaml'
-            np_ = f'{new}/igh+igl/partition-{locus}.yaml'
-        if not os.path.exists(bp):
-            print(f'{locus}: no baseline file (skipping)')
+    n_compared = 0
+    for sub, locus, rel in PARTITION_RELPATHS:
+        label = f'{sub or "(top)"}/{locus}'
+        res = diff_one(label, f'{base}/{rel}', f'{new}/{rel}')
+        if res is None:
             continue
-        if not os.path.exists(np_):
-            print(f'{locus}: MISSING in new ({np_})')
-            n_diffs += 1
-            continue
-        bpart = best_partition(bp)
-        npart = best_partition(np_)
-        if bpart != npart:
-            print(f'{locus}: PARTITION DIFF ({len(bpart)} vs {len(npart)} clusters)')
-            n_diffs += 1
-            continue
-        with open(bp) as f:
-            bd = json.load(f)
-        with open(np_) as f:
-            nd = json.load(f)
-        bk = {tuple(sorted(e['unique_ids'])): e for e in bd['events']}
-        nk = {tuple(sorted(e['unique_ids'])): e for e in nd['events']}
-        if set(bk) != set(nk):
-            only_b = set(bk) - set(nk)
-            only_n = set(nk) - set(bk)
-            print(f'{locus}: EVENT-KEY DIFF (only in base: {len(only_b)}, only in new: {len(only_n)})')
-            n_diffs += 1
-            continue
-        field_diffs = 0
-        for k in bk:
-            for f in FIELDS:
-                if bk[k].get(f) != nk[k].get(f):
-                    field_diffs += 1
-                    if field_diffs <= 3:
-                        print(f'{locus} {k[:1]}...: {f} diff: {bk[k].get(f)} vs {nk[k].get(f)}')
-        if field_diffs:
-            print(f'{locus}: {field_diffs} FIELD DIFFS across {len(bk)} events')
-            n_diffs += 1
-        else:
-            print(f'{locus}: {len(bk)} events identical')
+        n_compared += 1
+        n_diffs += res
+    if n_compared == 0:
+        print('no partition files found in either dir')
+        return 1
     return n_diffs
 
 

--- a/bin/zig-perf-counters-aggregate.py
+++ b/bin/zig-perf-counters-aggregate.py
@@ -27,9 +27,16 @@ PR #368.
 
 Usage: zig-perf-counters-aggregate.py <log-file>
 """
+import argparse
 import re
 import sys
 from collections import defaultdict
+
+
+# Histogram bucket labels for the chunk-cache prefix-list-length report,
+# in display order.
+CACHE_BUCKET_ORDER = ("0", "1", "2", "3", "4", "5",
+                      "6_9", "10_19", "20_49", "50_99", "100_199", "200p")
 
 
 def parse_kv(line):
@@ -62,6 +69,11 @@ TIMING_SUBPHASES = (
 )
 
 
+def trow(name, ns, denom):
+    pct = (100 * ns / denom) if denom else 0
+    print(f"    {name:<32}  {ns / 1e9:>9.3f}s  ({pct:>5.1f}% of timed)")
+
+
 def main(path):
     by_alg = defaultdict(lambda: {
         "ksets": [], "fillTrellis": [], "addInLogSpace": [],
@@ -83,63 +95,64 @@ def main(path):
         fh = open(path)
     except (IOError, OSError) as e:
         sys.exit(f"error: cannot open {path}: {e}")
-    for line in fh:
-        line = line.strip()
-        if not line:
-            continue
-        if line.startswith("PERFCOUNTER_GLOMERATOR"):
-            n_glom_lines += 1
-            kv = parse_kv(line[len("PERFCOUNTER_GLOMERATOR "):])
-            kind = kv.get("kind", "?")
-            glomerator[kind].append({
-                "glomerator_total_ns": int(kv["glomerator_total_ns"]),
-                "cumul_dpHandler_run_ns": int(kv["cumul_dpHandler_run_ns"]),
-            })
-            continue
-        if line.startswith("PERFCOUNTER_CACHE"):
-            n_cache_lines += 1
-            kv = parse_kv(line[len("PERFCOUNTER_CACHE "):])
+    with fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("PERFCOUNTER_GLOMERATOR"):
+                n_glom_lines += 1
+                kv = parse_kv(line[len("PERFCOUNTER_GLOMERATOR "):])
+                kind = kv.get("kind", "?")
+                glomerator[kind].append({
+                    "glomerator_total_ns": int(kv["glomerator_total_ns"]),
+                    "cumul_dpHandler_run_ns": int(kv["cumul_dpHandler_run_ns"]),
+                })
+                continue
+            if line.startswith("PERFCOUNTER_CACHE"):
+                n_cache_lines += 1
+                kv = parse_kv(line[len("PERFCOUNTER_CACHE "):])
+                alg = kv.get("alg", "?")
+                for k, v in kv.items():
+                    if k in ("alg", "q"):
+                        continue
+                    cache_buckets[alg][k] += int(v)
+                continue
+            if line.startswith("PERFCOUNTER_TIMING"):
+                n_timing_lines += 1
+                kv = parse_kv(line[len("PERFCOUNTER_TIMING "):])
+                alg = kv.get("alg", "?")
+                t = timing[alg]
+                t["fillTrellis_total_ns"].append(int(kv["fillTrellis_total_ns"]))
+                t["cachedPath_ns"].append(int(kv["cachedPath_ns"]))
+                for k in TIMING_SUBPHASES:
+                    t[k].append(int(kv[k]))
+                # Outer-perimeter accumulators (older logs omit these; default 0).
+                t["runKSet_total_ns"].append(int(kv.get("runKSet_total_ns", "0")))
+                t["dpHandler_run_total_ns"].append(int(kv.get("dpHandler_run_total_ns", "0")))
+                # Phase-B'' deeper-DP timers (older logs omit; default 0).
+                for k in ("viterbi_init_ns", "viterbi_ending_ns",
+                          "forward_init_ns", "forward_ending_ns"):
+                    t[k].append(int(kv.get(k, "0")))
+                continue
+            if not line.startswith("PERFCOUNTER"):
+                continue
+            n_lines += 1
+            kv = parse_kv(line[len("PERFCOUNTER "):])
             alg = kv.get("alg", "?")
-            for k, v in kv.items():
-                if k in ("alg", "q"):
-                    continue
-                cache_buckets[alg][k] += int(v)
-            continue
-        if line.startswith("PERFCOUNTER_TIMING"):
-            n_timing_lines += 1
-            kv = parse_kv(line[len("PERFCOUNTER_TIMING "):])
-            alg = kv.get("alg", "?")
-            t = timing[alg]
-            t["fillTrellis_total_ns"].append(int(kv["fillTrellis_total_ns"]))
-            t["cachedPath_ns"].append(int(kv["cachedPath_ns"]))
-            for k in TIMING_SUBPHASES:
-                t[k].append(int(kv[k]))
-            # Outer-perimeter accumulators (older logs omit these; default 0).
-            t["runKSet_total_ns"].append(int(kv.get("runKSet_total_ns", "0")))
-            t["dpHandler_run_total_ns"].append(int(kv.get("dpHandler_run_total_ns", "0")))
-            # Phase-B'' deeper-DP timers (older logs omit; default 0).
-            for k in ("viterbi_init_ns", "viterbi_ending_ns",
-                      "forward_init_ns", "forward_ending_ns"):
-                t[k].append(int(kv.get(k, "0")))
-            continue
-        if not line.startswith("PERFCOUNTER"):
-            continue
-        n_lines += 1
-        kv = parse_kv(line[len("PERFCOUNTER "):])
-        alg = kv.get("alg", "?")
-        d = by_alg[alg]
-        d["n_seqs"].append(int(kv["n_seqs"]))
-        d["ksets"].append(int(kv["ksets"]))
-        d["fillTrellis"].append(int(kv["fillTrellis"]))
-        d["addInLogSpace"].append(int(kv["addInLogSpace"]))
-        d["addInLogSpace_log_exp"].append(int(kv["addInLogSpace_log_exp"]))
-        h, l = kv["chunk_hits"].split("/")
-        d["chunk_hits"].append(int(h))
-        d["chunk_lookups"].append(int(l))
-        d["active_med"].append(int(kv["active_states_med"]))
-        d["active_p95"].append(int(kv["active_states_p95"]))
-        d["active_max"].append(int(kv["active_states_max"]))
-        d["active_positions"].append(int(kv["active_states_positions"]))
+            d = by_alg[alg]
+            d["n_seqs"].append(int(kv["n_seqs"]))
+            d["ksets"].append(int(kv["ksets"]))
+            d["fillTrellis"].append(int(kv["fillTrellis"]))
+            d["addInLogSpace"].append(int(kv["addInLogSpace"]))
+            d["addInLogSpace_log_exp"].append(int(kv["addInLogSpace_log_exp"]))
+            h, l = kv["chunk_hits"].split("/")
+            d["chunk_hits"].append(int(h))
+            d["chunk_lookups"].append(int(l))
+            d["active_med"].append(int(kv["active_states_med"]))
+            d["active_p95"].append(int(kv["active_states_p95"]))
+            d["active_max"].append(int(kv["active_states_max"]))
+            d["active_positions"].append(int(kv["active_states_positions"]))
 
     print(f"# parsed {n_lines} PERFCOUNTER + {n_cache_lines} PERFCOUNTER_CACHE + {n_timing_lines} PERFCOUNTER_TIMING + {n_glom_lines} PERFCOUNTER_GLOMERATOR lines from {path}")
     for alg, d in by_alg.items():
@@ -174,9 +187,8 @@ def main(path):
         print("\n## chunk-cache prefix-list-length histogram (across all queries)")
         for alg, buckets in cache_buckets.items():
             print(f"  alg={alg}")
-            order = ["0", "1", "2", "3", "4", "5", "6_9", "10_19", "20_49", "50_99", "100_199", "200p"]
             total = sum(buckets.values())
-            for k in order:
+            for k in CACHE_BUCKET_ORDER:
                 v = buckets.get(k, 0)
                 pct = 100 * v / total if total else 0
                 print(f"    {k:>8}: {v:>10,d}  ({pct:>5.1f}%)")
@@ -210,10 +222,6 @@ def main(path):
                   f"dpHandler_run_total={tot_run / 1e9:.3f}s "
                   f"(runKSet={tot_rks / 1e9:.3f}s, "
                   f"fillTrellis+cachedPath={inner_timed / 1e9:.3f}s)")
-
-            def trow(name, ns, denom):
-                pct = (100 * ns / denom) if denom else 0
-                print(f"    {name:<32}  {ns / 1e9:>9.3f}s  ({pct:>5.1f}% of timed)")
 
             if tot_run > 0:
                 trow("dpHandler_run_total (outer)", tot_run, denom)
@@ -282,6 +290,7 @@ def main(path):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        sys.exit(__doc__)
-    main(sys.argv[1])
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("log_file", help="PERFCOUNTER log produced by partis-zig-core")
+    main(parser.parse_args().log_file)

--- a/bin/zig-perf-counters-aggregate.py
+++ b/bin/zig-perf-counters-aggregate.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python3
-"""Aggregate PERFCOUNTER + PERFCOUNTER_CACHE lines from a perf log file.
+"""Aggregate PERFCOUNTER / PERFCOUNTER_CACHE / PERFCOUNTER_TIMING lines.
 
 Per-query summary: median/p95/max of ksets, fillTrellis calls, addInLogSpace
 calls, addInLogSpace+log_exp work calls, active-state distribution stats, and
 chunk-cache hit rate. Plus a chunk-cache prefix-list-length histogram across
 all queries.
+
+For Phase-B (added after the issue #366 lever-5 close, PR
+https://github.com/psathyrella/partis/pull/383), also aggregates
+PERFCOUNTER_TIMING lines: cycle-precise nanosecond accumulators for
+fillTrellis sub-phases (chunkScan / init / tmpInit / viterbi / forward /
+traceback / put) and the runKSet cache-hit branch (cachedPath). The
+timing report is what we should have had before pulling lever 5: it
+divides time spent between cache-hit and cache-miss paths, and within
+the cache-miss path between trellis init, the DP itself, and traceback.
 
 The log file is produced by partis-zig-core when built with
 -Dperf-counters=true and run with PARTIS_ZIG_PERF_LOG=<path> in the env. See
@@ -43,6 +52,16 @@ def stats(xs):
     }
 
 
+# Fields on PERFCOUNTER_TIMING line that hold per-query ns accumulators.
+# fillTrellis_total is the parent (sub-phases sum into it modulo work
+# outside the sub-timers, like the model load); cachedPath is a sibling
+# (the runKSet branch that bypasses fillTrellis entirely).
+TIMING_SUBPHASES = (
+    "chunkScan_ns", "init_ns", "tmpInit_ns",
+    "viterbi_ns", "forward_ns", "traceback_ns", "put_ns",
+)
+
+
 def main(path):
     by_alg = defaultdict(lambda: {
         "ksets": [], "fillTrellis": [], "addInLogSpace": [],
@@ -51,12 +70,27 @@ def main(path):
         "n_seqs": [],
     })
     cache_buckets = defaultdict(lambda: defaultdict(int))
+    # timing[alg][field] = list of per-query ns values
+    timing = defaultdict(lambda: defaultdict(list))
+    # glomerator[kind] = list of {glomerator_total_ns, cumul_dpHandler_run_ns}
+    glomerator = defaultdict(list)
     n_lines = 0
     n_cache_lines = 0
+    n_timing_lines = 0
+    n_glom_lines = 0
 
     for line in open(path):
         line = line.strip()
         if not line:
+            continue
+        if line.startswith("PERFCOUNTER_GLOMERATOR"):
+            n_glom_lines += 1
+            kv = parse_kv(line[len("PERFCOUNTER_GLOMERATOR "):])
+            kind = kv.get("kind", "?")
+            glomerator[kind].append({
+                "glomerator_total_ns": int(kv["glomerator_total_ns"]),
+                "cumul_dpHandler_run_ns": int(kv["cumul_dpHandler_run_ns"]),
+            })
             continue
         if line.startswith("PERFCOUNTER_CACHE"):
             n_cache_lines += 1
@@ -66,6 +100,23 @@ def main(path):
                 if k in ("alg", "q"):
                     continue
                 cache_buckets[alg][k] += int(v)
+            continue
+        if line.startswith("PERFCOUNTER_TIMING"):
+            n_timing_lines += 1
+            kv = parse_kv(line[len("PERFCOUNTER_TIMING "):])
+            alg = kv.get("alg", "?")
+            t = timing[alg]
+            t["fillTrellis_total_ns"].append(int(kv["fillTrellis_total_ns"]))
+            t["cachedPath_ns"].append(int(kv["cachedPath_ns"]))
+            for k in TIMING_SUBPHASES:
+                t[k].append(int(kv[k]))
+            # Outer-perimeter accumulators (older logs omit these; default 0).
+            t["runKSet_total_ns"].append(int(kv.get("runKSet_total_ns", "0")))
+            t["dpHandler_run_total_ns"].append(int(kv.get("dpHandler_run_total_ns", "0")))
+            # Phase-B'' deeper-DP timers (older logs omit; default 0).
+            for k in ("viterbi_init_ns", "viterbi_ending_ns",
+                      "forward_init_ns", "forward_ending_ns"):
+                t[k].append(int(kv.get(k, "0")))
             continue
         if not line.startswith("PERFCOUNTER"):
             continue
@@ -86,7 +137,7 @@ def main(path):
         d["active_max"].append(int(kv["active_states_max"]))
         d["active_positions"].append(int(kv["active_states_positions"]))
 
-    print(f"# parsed {n_lines} PERFCOUNTER + {n_cache_lines} PERFCOUNTER_CACHE lines from {path}")
+    print(f"# parsed {n_lines} PERFCOUNTER + {n_cache_lines} PERFCOUNTER_CACHE + {n_timing_lines} PERFCOUNTER_TIMING + {n_glom_lines} PERFCOUNTER_GLOMERATOR lines from {path}")
     for alg, d in by_alg.items():
         nq = len(d["ksets"])
         print(f"\n## algorithm={alg}, n_queries={nq}")
@@ -126,6 +177,104 @@ def main(path):
                 pct = 100 * v / total if total else 0
                 print(f"    {k:>8}: {v:>10,d}  ({pct:>5.1f}%)")
             print(f"    {'total':>8}: {total:>10,d}")
+
+    # Phase-B timing report: where is bcrham wall actually going inside
+    # the Zig core? Sub-phases sum into fillTrellis_total; cachedPath is
+    # the sibling runKSet branch that bypasses fillTrellis entirely. The
+    # denominator we want for "%" is "all time the Zig core spent doing
+    # DP-ish work for this query," which is fillTrellis_total + cachedPath.
+    # Anything not in that sum is runKSet glue, findPartialCacheMatch,
+    # sorted-gene plumbing, etc. — out of the timed perimeter.
+    if timing:
+        print("\n## sub-phase timing (Phase-B, PERFCOUNTER_TIMING)")
+        # Three concentric perimeters, biggest first:
+        #   dpHandler_run_total ⊇ Σ runKSet_total ⊇ Σ fillTrellis_total + Σ cachedPath
+        # Each "_overhead" row is the residual between a perimeter and the
+        # sum of its inner pieces — i.e. work in the outer that isn't in
+        # any inner sub-bucket. Denominator is dpHandler_run_total when
+        # present (so % adds up over all reported rows); falls back to
+        # fillTrellis_total + cachedPath for older logs without outer
+        # timers.
+        for alg, t in timing.items():
+            tot_run = sum(t.get("dpHandler_run_total_ns", []))
+            tot_rks = sum(t.get("runKSet_total_ns", []))
+            tot_fill = sum(t["fillTrellis_total_ns"])
+            tot_cached = sum(t["cachedPath_ns"])
+            inner_timed = tot_fill + tot_cached
+            denom = tot_run if tot_run > 0 else inner_timed
+            print(f"  alg={alg}, n_queries={len(t['fillTrellis_total_ns'])}, "
+                  f"dpHandler_run_total={tot_run / 1e9:.3f}s "
+                  f"(runKSet={tot_rks / 1e9:.3f}s, "
+                  f"fillTrellis+cachedPath={inner_timed / 1e9:.3f}s)")
+
+            def trow(name, ns, denom):
+                pct = (100 * ns / denom) if denom else 0
+                print(f"    {name:<32}  {ns / 1e9:>9.3f}s  ({pct:>5.1f}% of timed)")
+
+            if tot_run > 0:
+                trow("dpHandler_run_total (outer)", tot_run, denom)
+                # Pre/post-runKSet work inside run(): Sequences build,
+                # only_genes map, rescaleOverallMuteFreqs, fillRecoEvent,
+                # Result.finalize, debug summary.
+                trow("  (run()-body pre/post-runKSet)", tot_run - tot_rks, denom)
+                trow("runKSet_total (Σ ksets)", tot_rks, denom)
+            trow("  fillTrellis_total (Σ misses+chunks)", tot_fill, denom)
+            for k in TIMING_SUBPHASES:
+                trow(f"    {k}", sum(t[k]), denom)
+                # Phase-B'' DP-body sub-split (init + ending → position
+                # loop derived as residual). Only meaningful for the
+                # viterbi/forward rows.
+                if k == "viterbi_ns":
+                    vi = sum(t.get("viterbi_init_ns", [0]))
+                    ve = sum(t.get("viterbi_ending_ns", [0]))
+                    vp = sum(t[k]) - vi - ve
+                    trow("      viterbi_init_ns", vi, denom)
+                    trow("      viterbi_positionLoop_ns (derived)", vp, denom)
+                    trow("      viterbi_ending_ns", ve, denom)
+                elif k == "forward_ns":
+                    fi = sum(t.get("forward_init_ns", [0]))
+                    fe = sum(t.get("forward_ending_ns", [0]))
+                    fp = sum(t[k]) - fi - fe
+                    trow("      forward_init_ns", fi, denom)
+                    trow("      forward_positionLoop_ns (derived)", fp, denom)
+                    trow("      forward_ending_ns", fe, denom)
+            sub_sum = sum(sum(t[k]) for k in TIMING_SUBPHASES)
+            unaccounted_fill = tot_fill - sub_sum
+            # The model load (`self.hmms.get(gene)`) sits between the
+            # chunk scan and the init/tmpInit; it's not timed. So
+            # fillTrellis_total − Σ sub-phases is the un-timed remainder,
+            # mostly that lookup plus the addWithMinusInfinities math.
+            trow("    (fillTrellis untimed)", unaccounted_fill, denom)
+            trow("  cachedPath (sibling, Σ hits)", tot_cached, denom)
+            if tot_rks > 0:
+                # runKSet plumbing: sorted_genes alloc/sort, regions loop,
+                # findPartialCacheMatch, regional_total/best updates, the
+                # debug-output and fillRecoEvent assembly. Anything inside
+                # runKSet body but outside fillTrellis() and cachedPath_ns.
+                trow("  (runKSet body, excl. fillTrellis+cachedPath)",
+                     tot_rks - inner_timed, denom)
+
+    # Phase-B' outermost perimeter: one PERFCOUNTER_GLOMERATOR per bcrham
+    # invocation that ran Glomerator.cluster() or cacheNaiveSeqs(). The
+    # `cumul_dpHandler_run_ns` is the sum of every DPHandler.run() body
+    # time during that bcrham process; the residual is Glomerator driver
+    # overhead — merge decisions, partition I/O, hfrac calculations.
+    if glomerator:
+        print("\n## Glomerator wrapper (Phase-B', PERFCOUNTER_GLOMERATOR)")
+        for kind, rows in glomerator.items():
+            tot_glom = sum(r["glomerator_total_ns"] for r in rows)
+            tot_dp = sum(r["cumul_dpHandler_run_ns"] for r in rows)
+            n_proc = len(rows)
+            # `glomerator_total` is summed across bcrham procs, not elapsed
+            # wall — without the mean-per-proc column readers can mis-read
+            # a 152s sum as a single-process wall claim. Both reported.
+            mean_glom = tot_glom / n_proc if n_proc else 0
+            print(f"  kind={kind}, n_bcrham_procs={n_proc}, "
+                  f"mean_glom_per_proc={mean_glom / 1e9:.3f}s, "
+                  f"sum_glomerator_total={tot_glom / 1e9:.3f}s "
+                  f"(cumul_dpHandler_run={tot_dp / 1e9:.3f}s, "
+                  f"driver_overhead={(tot_glom - tot_dp) / 1e9:.3f}s, "
+                  f"driver_overhead_pct={100 * (tot_glom - tot_dp) / tot_glom if tot_glom else 0:.1f}%)")
 
 
 if __name__ == "__main__":

--- a/bin/zig-perf-counters-aggregate.py
+++ b/bin/zig-perf-counters-aggregate.py
@@ -8,8 +8,13 @@ all queries.
 
 The log file is produced by partis-zig-core when built with
 -Dperf-counters=true and run with PARTIS_ZIG_PERF_LOG=<path> in the env. See
-packages/zig-core/src/ham/perf_counters.zig for the metric definitions and
-PERF-NEXT.md Phase 0.1 / 0.2 for the priors this is meant to test against.
+packages/zig-core/src/ham/perf_counters.zig for the metric definitions.
+
+These counters pin denominators (active-state distribution, n_ksets,
+fillTrellis call counts, addInLogSpace call counts, chunk-cache hit rate)
+for the perf-work cost claims tracked in issue #366
+(https://github.com/psathyrella/partis/issues/366). Originally landed in
+PR #368.
 
 Usage: zig-perf-counters-aggregate.py <log-file>
 """

--- a/bin/zig-perf-counters-aggregate.py
+++ b/bin/zig-perf-counters-aggregate.py
@@ -79,7 +79,11 @@ def main(path):
     n_timing_lines = 0
     n_glom_lines = 0
 
-    for line in open(path):
+    try:
+        fh = open(path)
+    except (IOError, OSError) as e:
+        sys.exit(f"error: cannot open {path}: {e}")
+    for line in fh:
         line = line.strip()
         if not line:
             continue
@@ -278,4 +282,6 @@ def main(path):
 
 
 if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit(__doc__)
     main(sys.argv[1])

--- a/bin/zig-perf-counters-aggregate.py
+++ b/bin/zig-perf-counters-aggregate.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Aggregate PERFCOUNTER + PERFCOUNTER_CACHE lines from a perf log file.
+
+Per-query summary: median/p95/max of ksets, fillTrellis calls, addInLogSpace
+calls, addInLogSpace+log_exp work calls, active-state distribution stats, and
+chunk-cache hit rate. Plus a chunk-cache prefix-list-length histogram across
+all queries.
+
+The log file is produced by partis-zig-core when built with
+-Dperf-counters=true and run with PARTIS_ZIG_PERF_LOG=<path> in the env. See
+packages/zig-core/src/ham/perf_counters.zig for the metric definitions and
+PERF-NEXT.md Phase 0.1 / 0.2 for the priors this is meant to test against.
+
+Usage: zig-perf-counters-aggregate.py <log-file>
+"""
+import re
+import sys
+from collections import defaultdict
+
+
+def parse_kv(line):
+    return {m.group(1): m.group(2) for m in re.finditer(r"(\w+)=(\S+)", line)}
+
+
+def stats(xs):
+    if not xs:
+        return None
+    xs = sorted(xs)
+    n = len(xs)
+    return {
+        "n": n,
+        "min": xs[0],
+        "median": xs[n // 2],
+        "p95": xs[int(n * 0.95)] if n > 1 else xs[0],
+        "max": xs[-1],
+        "mean": sum(xs) / n,
+        "total": sum(xs),
+    }
+
+
+def main(path):
+    by_alg = defaultdict(lambda: {
+        "ksets": [], "fillTrellis": [], "addInLogSpace": [],
+        "addInLogSpace_log_exp": [], "chunk_hits": [], "chunk_lookups": [],
+        "active_med": [], "active_p95": [], "active_max": [], "active_positions": [],
+        "n_seqs": [],
+    })
+    cache_buckets = defaultdict(lambda: defaultdict(int))
+    n_lines = 0
+    n_cache_lines = 0
+
+    for line in open(path):
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("PERFCOUNTER_CACHE"):
+            n_cache_lines += 1
+            kv = parse_kv(line[len("PERFCOUNTER_CACHE "):])
+            alg = kv.get("alg", "?")
+            for k, v in kv.items():
+                if k in ("alg", "q"):
+                    continue
+                cache_buckets[alg][k] += int(v)
+            continue
+        if not line.startswith("PERFCOUNTER"):
+            continue
+        n_lines += 1
+        kv = parse_kv(line[len("PERFCOUNTER "):])
+        alg = kv.get("alg", "?")
+        d = by_alg[alg]
+        d["n_seqs"].append(int(kv["n_seqs"]))
+        d["ksets"].append(int(kv["ksets"]))
+        d["fillTrellis"].append(int(kv["fillTrellis"]))
+        d["addInLogSpace"].append(int(kv["addInLogSpace"]))
+        d["addInLogSpace_log_exp"].append(int(kv["addInLogSpace_log_exp"]))
+        h, l = kv["chunk_hits"].split("/")
+        d["chunk_hits"].append(int(h))
+        d["chunk_lookups"].append(int(l))
+        d["active_med"].append(int(kv["active_states_med"]))
+        d["active_p95"].append(int(kv["active_states_p95"]))
+        d["active_max"].append(int(kv["active_states_max"]))
+        d["active_positions"].append(int(kv["active_states_positions"]))
+
+    print(f"# parsed {n_lines} PERFCOUNTER + {n_cache_lines} PERFCOUNTER_CACHE lines from {path}")
+    for alg, d in by_alg.items():
+        nq = len(d["ksets"])
+        print(f"\n## algorithm={alg}, n_queries={nq}")
+
+        def row(name, xs, fmt="{:>12,d}"):
+            s = stats(xs)
+            if s is None:
+                return
+            print(f"  {name:<32}  median={fmt.format(s['median'])}  p95={fmt.format(s['p95'])}  max={fmt.format(s['max'])}  mean={s['mean']:>12,.1f}  total={s['total']:>14,d}")
+
+        row("n_seqs (per query)", d["n_seqs"])
+        row("ksets (per query)", d["ksets"])
+        row("fillTrellis calls (per query)", d["fillTrellis"])
+        row("addInLogSpace calls (per query)", d["addInLogSpace"])
+        row("addInLogSpace+log_exp (per query)", d["addInLogSpace_log_exp"])
+
+        # active states are already per-query medians/p95/maxes; aggregate across queries
+        row("active_states median-of-medians", d["active_med"])
+        row("active_states median-of-p95s", d["active_p95"])
+        row("active_states median-of-maxes", d["active_max"])
+        row("active_positions (per query)", d["active_positions"])
+
+        # chunk-cache rate
+        total_hits = sum(d["chunk_hits"])
+        total_lookups = sum(d["chunk_lookups"])
+        if total_lookups:
+            print(f"  {'chunk_cache_rate':<32}  hits/lookups = {total_hits:,} / {total_lookups:,} = {100*total_hits/total_lookups:.1f}%")
+
+    if cache_buckets:
+        print("\n## chunk-cache prefix-list-length histogram (across all queries)")
+        for alg, buckets in cache_buckets.items():
+            print(f"  alg={alg}")
+            order = ["0", "1", "2", "3", "4", "5", "6_9", "10_19", "20_49", "50_99", "100_199", "200p"]
+            total = sum(buckets.values())
+            for k in order:
+                v = buckets.get(k, 0)
+                pct = 100 * v / total if total else 0
+                print(f"    {k:>8}: {v:>10,d}  ({pct:>5.1f}%)")
+            print(f"    {'total':>8}: {total:>10,d}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/bin/zig-perf-counters-run.sh
+++ b/bin/zig-perf-counters-run.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Build partis-zig-core with -Dperf-counters=true and run a partition workload
+# with PARTIS_ZIG_PERF_LOG set, so each query emits one PERFCOUNTER line plus
+# one PERFCOUNTER_CACHE line (chunk-cache prefix-list-length histogram) into
+# the log. See packages/zig-core/src/ham/perf_counters.zig for the metric set
+# and packages/zig-core/PERF-NEXT.md Phase 0.1/0.2 for what these are for.
+#
+# Pair with bin/zig-perf-counters-aggregate.py to compute median/p95/max
+# distributions and chunk-cache hit rate from the resulting log.
+#
+# Usage:
+#   bin/zig-perf-counters-run.sh [INFILE [OUTBASE [N [N_PROCS]]]]
+#
+# Defaults:
+#   INFILE  = /tmp/paired-paper-all-seqs.fa
+#   OUTBASE = /tmp/perf-counters-test
+#   N       = 1000
+#   N_PROCS = 1   (PERF-NEXT.md 0.1 specifies n-procs 1 for clean wall-time
+#                 numbers; for distribution stats only, n_procs > 1 is fine)
+#
+# After the run, the perf log path is:
+#   $OUTBASE/zig-perf.log
+# and the aggregated summary path is:
+#   $OUTBASE/aggregate.txt
+#
+# The script restores the un-instrumented ReleaseFast build at the end so the
+# working tree's binary is back to bit-equality-baseline state.
+
+set -euo pipefail
+
+INFILE="${1:-/tmp/paired-paper-all-seqs.fa}"
+OUTBASE="${2:-/tmp/perf-counters-test}"
+N="${3:-1000}"
+N_PROCS="${4:-1}"
+
+PARTIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ZIG_CORE_DIR="$PARTIS_DIR/packages/zig-core"
+PERF_LOG="$OUTBASE/zig-perf.log"
+AGG_OUT="$OUTBASE/aggregate.txt"
+
+mkdir -p "$OUTBASE"
+rm -f "$PERF_LOG" "$AGG_OUT"
+
+# ── 1. Build with perf counters enabled ─────────────────────────────────────
+echo "==> building partis-zig-core with -Dperf-counters=true"
+(cd "$ZIG_CORE_DIR" && zig build -Doptimize=ReleaseFast -Dperf-counters=true)
+
+# ── 2. Run partition with the perf log set ──────────────────────────────────
+RUN_OUTBASE="$OUTBASE/run-output"
+rm -rf "$RUN_OUTBASE"
+mkdir -p "$RUN_OUTBASE"
+
+echo "==> running partition: N=$N, n_procs=$N_PROCS, infile=$INFILE"
+echo "==> perf log: $PERF_LOG"
+
+# shellcheck disable=SC1091
+source "$PARTIS_DIR/.venv/bin/activate"
+
+PARTIS_ZIG_PERF_LOG="$PERF_LOG" PYTHONHASHSEED=0 python3 "$PARTIS_DIR/bin/partis" \
+    partition --paired-loci \
+    --paired-outdir "$RUN_OUTBASE" \
+    --infname "$INFILE" \
+    --n-max-queries "$N" \
+    --random-seed 1 \
+    --n-procs "$N_PROCS" \
+    --no-time-based-n-proc-reduction \
+    --dont-write-git-info \
+    --zig
+
+# ── 3. Aggregate ────────────────────────────────────────────────────────────
+echo "==> aggregating $PERF_LOG → $AGG_OUT"
+python3 "$PARTIS_DIR/bin/zig-perf-counters-aggregate.py" "$PERF_LOG" | tee "$AGG_OUT"
+
+# ── 4. Restore un-instrumented build ────────────────────────────────────────
+echo "==> restoring un-instrumented partis-zig-core (ReleaseFast, no perf counters)"
+(cd "$ZIG_CORE_DIR" && zig build -Doptimize=ReleaseFast)
+
+echo "==> done. raw log: $PERF_LOG    summary: $AGG_OUT"

--- a/bin/zig-perf-counters-run.sh
+++ b/bin/zig-perf-counters-run.sh
@@ -2,8 +2,14 @@
 # Build partis-zig-core with -Dperf-counters=true and run a partition workload
 # with PARTIS_ZIG_PERF_LOG set, so each query emits one PERFCOUNTER line plus
 # one PERFCOUNTER_CACHE line (chunk-cache prefix-list-length histogram) into
-# the log. See packages/zig-core/src/ham/perf_counters.zig for the metric set
-# and packages/zig-core/PERF-NEXT.md Phase 0.1/0.2 for what these are for.
+# the log. See packages/zig-core/src/ham/perf_counters.zig for the metric set.
+#
+# These counters pin denominators for the perf-work cost claims tracked in
+# issue #366 (https://github.com/psathyrella/partis/issues/366) — the
+# distributions every later perf-item's wall claim depends on:
+# per-query active-state median/p95/max, n_ksets, fillTrellis call counts,
+# addInLogSpace call counts, and chunk-cache hit rate. Originally landed in
+# PR #368.
 #
 # Pair with bin/zig-perf-counters-aggregate.py to compute median/p95/max
 # distributions and chunk-cache hit rate from the resulting log.
@@ -15,8 +21,10 @@
 #   INFILE  = /tmp/paired-paper-all-seqs.fa
 #   OUTBASE = /tmp/perf-counters-test
 #   N       = 1000
-#   N_PROCS = 1   (PERF-NEXT.md 0.1 specifies n-procs 1 for clean wall-time
-#                 numbers; for distribution stats only, n_procs > 1 is fine)
+#   N_PROCS = 1   (single-proc keeps wall-time numbers clean for cost-claim
+#                 sizing — multi-proc smears the symbol map across child PIDs
+#                 and adds scheduling jitter. For distribution stats only,
+#                 n_procs > 1 is fine.)
 #
 # After the run, the perf log path is:
 #   $OUTBASE/zig-perf.log

--- a/packages/zig-core/build.zig
+++ b/packages/zig-core/build.zig
@@ -96,7 +96,13 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    // Link libc + glibc_math shim so tests that exercise mathutils.log/exp
+    // resolve `glibc_log` / `glibc_exp`. Without these, unit tests linking
+    // anything that uses the math hot path fail with "undefined symbol:
+    // glibc_log". Symmetric with the `exe` setup above.
+    ham_test_mod.linkSystemLibrary("c", .{});
     const unit_tests = b.addTest(.{ .root_module = ham_test_mod });
+    unit_tests.addCSourceFile(.{ .file = b.path("src/ham/glibc_math.c"), .flags = &.{ "-O2", "-fno-builtin" } });
     const run_unit_tests = b.addRunArtifact(unit_tests);
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_unit_tests.step);

--- a/packages/zig-core/build.zig
+++ b/packages/zig-core/build.zig
@@ -4,6 +4,19 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    // -Dperf-counters: gate the issue-#366 phase-0 diagnostics counters in
+    // src/ham/perf_counters.zig. When false (default), every counter site
+    // is `if (enabled) { ... }` with `enabled = false`, so the inner-loop
+    // calls compile to nothing and bit-equal output is preserved.
+    const perf_counters = b.option(
+        bool,
+        "perf-counters",
+        "Enable Phase-0 perf counters (issue #366). Default false; counters compile out when off.",
+    ) orelse false;
+    const perf_opts = b.addOptions();
+    perf_opts.addOption(bool, "perf_counters", perf_counters);
+    const build_options_module = perf_opts.createModule();
+
     // ── partis-zig-core executable: bcrham-compatible CLI ────────────────
     // `zig build` produces this by default. No external library deps.
     const exe = b.addExecutable(.{
@@ -14,6 +27,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    exe.root_module.addImport("build_options", build_options_module);
     // Link libc so release builds can use std.heap.c_allocator (malloc/free),
     // which avoids GPA's per-allocation tracking overhead.
     exe.root_module.linkSystemLibrary("c", .{});
@@ -32,6 +46,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    compare.root_module.addImport("build_options", build_options_module);
     b.installArtifact(compare);
 
     // ── lib: C ABI shared library (requires ig-sw sources from partis) ───
@@ -45,6 +60,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    cabi_mod.addImport("build_options", build_options_module);
     if (igsw_src.len > 0) {
         cabi_mod.addIncludePath(.{ .cwd_relative = igsw_src });
     }
@@ -96,6 +112,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    ham_test_mod.addImport("build_options", build_options_module);
     // Link libc + glibc_math shim so tests that exercise mathutils.log/exp
     // resolve `glibc_log` / `glibc_exp`. Without these, unit tests linking
     // anything that uses the math hot path fail with "undefined symbol:

--- a/packages/zig-core/build.zig
+++ b/packages/zig-core/build.zig
@@ -35,6 +35,11 @@ pub fn build(b: *std.Build) void {
     // to actual glibc (dynamic 'U' symbols) rather than Zig's compiler-rt
     // (local 't' symbols that may differ from glibc on some CPUs).
     exe.addCSourceFile(.{ .file = b.path("src/ham/glibc_math.c"), .flags = &.{ "-O2", "-fno-builtin" } });
+    // fast_math.c — fast_softplus LUT (issue #366 item 3.2). Mirrors
+    // packages/ham/src/fast_math.c on the C++ side; both must stay in sync.
+    // -ffp-contract=off keeps the linear-interp arithmetic bit-deterministic
+    // across compilers (cheap insurance for cross-backend bit equality).
+    exe.addCSourceFile(.{ .file = b.path("src/ham/fast_math.c"), .flags = &.{ "-O3", "-ffp-contract=off", "-fno-builtin" } });
     b.installArtifact(exe);
 
     // ── compare: equivalence harness binary ──────────────────────────────
@@ -120,6 +125,7 @@ pub fn build(b: *std.Build) void {
     ham_test_mod.linkSystemLibrary("c", .{});
     const unit_tests = b.addTest(.{ .root_module = ham_test_mod });
     unit_tests.addCSourceFile(.{ .file = b.path("src/ham/glibc_math.c"), .flags = &.{ "-O2", "-fno-builtin" } });
+    unit_tests.addCSourceFile(.{ .file = b.path("src/ham/fast_math.c"), .flags = &.{ "-O3", "-ffp-contract=off", "-fno-builtin" } });
     const run_unit_tests = b.addRunArtifact(unit_tests);
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_unit_tests.step);

--- a/packages/zig-core/src/ham/args.zig
+++ b/packages/zig-core/src/ham/args.zig
@@ -64,10 +64,10 @@ pub const Args = struct {
     ambig_base: []u8,
     seed_unique_id: []u8,
 
-    hamming_fraction_bound_lo: f32,
-    hamming_fraction_bound_hi: f32,
-    logprob_ratio_threshold: f32,
-    max_logprob_drop: f32,
+    hamming_fraction_bound_lo: f64,
+    hamming_fraction_bound_hi: f64,
+    logprob_ratio_threshold: f64,
+    max_logprob_drop: f64,
 
     debug: i32,
     naive_hamming_cluster: i32,
@@ -108,7 +108,7 @@ pub const Args = struct {
             .seed_unique_id = try allocator.dupe(u8, ""),
             .hamming_fraction_bound_lo = 0.0,
             .hamming_fraction_bound_hi = 1.0,
-            .logprob_ratio_threshold = -std.math.inf(f32),
+            .logprob_ratio_threshold = -std.math.inf(f64),
             .max_logprob_drop = -1.0,
             .debug = 0,
             .naive_hamming_cluster = 0,

--- a/packages/zig-core/src/ham/bcr_utils/hmm_holder.zig
+++ b/packages/zig-core/src/ham/bcr_utils/hmm_holder.zig
@@ -106,7 +106,7 @@ pub const HMMHolder = struct {
             var git = gene_set.iterator();
             while (git.next()) |entry| {
                 const m = try self.get(entry.key_ptr.*);
-                m.unRescaleOverallMuteFreq(self.allocator);
+                m.unRescaleOverallMuteFreq();
             }
         }
     }

--- a/packages/zig-core/src/ham/bcr_utils/reco_event.zig
+++ b/packages/zig-core/src/ham/bcr_utils/reco_event.zig
@@ -16,7 +16,7 @@ pub const RecoEvent = struct {
     /// Insertion sequences: "fv", "vd", "dj", "jf".
     insertions: std.StringHashMapUnmanaged([]u8),
     naive_seq: []u8,
-    score: f32,
+    score: f64,
     cyst_position: i32,
     tryp_position: i32,
     cdr3_length: i32,
@@ -107,7 +107,7 @@ pub const RecoEvent = struct {
     }
 
     pub fn setScore(self: *RecoEvent, s: f64) void {
-        self.score = @floatCast(s);
+        self.score = s;
     }
 
     pub fn clear(self: *RecoEvent, allocator: std.mem.Allocator) void {

--- a/packages/zig-core/src/ham/bcr_utils/result.zig
+++ b/packages/zig-core/src/ham/bcr_utils/result.zig
@@ -70,8 +70,13 @@ pub const Result = struct {
         _ = _gl;
         std.debug.assert(!self.finalized);
 
-        // Sort events descending by score
-        std.mem.sort(RecoEvent, self.events.items, {}, struct {
+        // Sort events descending by score. STABLE sort to make tied scores
+        // resolve to first-pushed (deterministic across runs and backends).
+        // Ties happen at 30k+: f32 score truncation (Result::SetScore @floatCast)
+        // can collapse close f64 viterbi scores, and unstable pdqsort/introsort
+        // would otherwise pick different "best" events between Zig and C++ —
+        // which cascades through naive_seq → hfrac → cluster merges (#375).
+        std.sort.block(RecoEvent, self.events.items, {}, struct {
             fn desc(_: void, a: RecoEvent, b: RecoEvent) bool {
                 return a.score > b.score;
             }

--- a/packages/zig-core/src/ham/bcr_utils/result.zig
+++ b/packages/zig-core/src/ham/bcr_utils/result.zig
@@ -72,10 +72,11 @@ pub const Result = struct {
 
         // Sort events descending by score. STABLE sort to make tied scores
         // resolve to first-pushed (deterministic across runs and backends).
-        // Ties happen at 30k+: f32 score truncation (Result::SetScore @floatCast)
-        // can collapse close f64 viterbi scores, and unstable pdqsort/introsort
-        // would otherwise pick different "best" events between Zig and C++ —
-        // which cascades through naive_seq → hfrac → cluster merges (#375).
+        // With score stored as f64 (#377) the f32-collapse failure mode from
+        // #375 is gone, but two ksets can still produce machine-epsilon-equal
+        // f64 scores; an unstable pdqsort/introsort would otherwise pick
+        // different "best" events between Zig and C++, cascading through
+        // naive_seq → hfrac → cluster merges. Originally added in #375.
         std.sort.block(RecoEvent, self.events.items, {}, struct {
             fn desc(_: void, a: RecoEvent, b: RecoEvent) bool {
                 return a.score > b.score;

--- a/packages/zig-core/src/ham/bcr_utils/utils.zig
+++ b/packages/zig-core/src/ham/bcr_utils/utils.zig
@@ -69,7 +69,7 @@ pub fn streamErrorput(
     writer: anytype,
     algorithm: []const u8,
     allocator: std.mem.Allocator,
-    seqs: []const Sequence,
+    seqs: []const *const Sequence,
     errors: []const u8,
 ) !void {
     const names = try seqNameStr(allocator, seqs, ":");
@@ -90,7 +90,7 @@ pub fn streamViterbiOutput(
     writer: anytype,
     allocator: std.mem.Allocator,
     event: *const RecoEvent,
-    seqs: []const Sequence,
+    seqs: []const *const Sequence,
     errors: []const u8,
 ) !void {
     const names = try seqNameStr(allocator, seqs, ":");
@@ -139,7 +139,7 @@ pub fn streamViterbiOutput(
 pub fn streamForwardOutput(
     writer: anytype,
     allocator: std.mem.Allocator,
-    seqs: []const Sequence,
+    seqs: []const *const Sequence,
     total_score: f64,
     errors: []const u8,
 ) !void {
@@ -156,12 +156,12 @@ pub fn streamForwardOutput(
 /// Corresponds to C++ `ham::SeqStr`.
 pub fn seqStr(
     allocator: std.mem.Allocator,
-    seqs: []const Sequence,
+    seqs: []const *const Sequence,
     delimiter: []const u8,
 ) ![]u8 {
     var buf: std.ArrayListUnmanaged(u8) = .{};
     defer buf.deinit(allocator);
-    for (seqs, 0..) |*seq, i| {
+    for (seqs, 0..) |seq, i| {
         if (i > 0) try buf.appendSlice(allocator, delimiter);
         try buf.appendSlice(allocator, seq.undigitized);
     }
@@ -172,12 +172,12 @@ pub fn seqStr(
 /// Corresponds to C++ `ham::SeqNameStr`.
 pub fn seqNameStr(
     allocator: std.mem.Allocator,
-    seqs: []const Sequence,
+    seqs: []const *const Sequence,
     delimiter: []const u8,
 ) ![]u8 {
     var buf: std.ArrayListUnmanaged(u8) = .{};
     defer buf.deinit(allocator);
-    for (seqs, 0..) |*seq, i| {
+    for (seqs, 0..) |seq, i| {
         if (i > 0) try buf.appendSlice(allocator, delimiter);
         try buf.appendSlice(allocator, seq.name);
     }

--- a/packages/zig-core/src/ham/bcrham.zig
+++ b/packages/zig-core/src/ham/bcrham.zig
@@ -89,18 +89,23 @@ pub fn runAlgorithm(
         defer allocator.free(only_genes);
         for (qrow.only_genes.items, only_genes) |g, *out| out.* = g;
 
+        // Build pointer view into qseqs for the DP and stream calls (item 16).
+        const qseq_ptrs = try allocator.alloc(*const Sequence, qseqs.items.len);
+        defer allocator.free(qseq_ptrs);
+        for (qseqs.items, qseq_ptrs) |*sq, *out| out.* = sq;
+
         var dph = try DPHandler.init(allocator, args.algorithm, args, gl, hmms);
         defer dph.deinit();
 
-        var result = try dph.run(qseqs.items, kbounds, only_genes, @floatCast(qrow.mut_freq), true);
+        var result = try dph.run(qseq_ptrs, kbounds, only_genes, @floatCast(qrow.mut_freq), true);
         defer result.deinit();
 
         if (result.no_path) {
-            try bcr_text.streamErrorput(writer, args.algorithm, allocator, qseqs.items, "no_path");
+            try bcr_text.streamErrorput(writer, args.algorithm, allocator, qseq_ptrs, "no_path");
         } else if (std.mem.eql(u8, args.algorithm, "viterbi")) {
-            try bcr_text.streamViterbiOutput(writer, allocator, &result.best_event.?, qseqs.items, "");
+            try bcr_text.streamViterbiOutput(writer, allocator, &result.best_event.?, qseq_ptrs, "");
         } else if (std.mem.eql(u8, args.algorithm, "forward")) {
-            try bcr_text.streamForwardOutput(writer, allocator, qseqs.items, result.total_score, "");
+            try bcr_text.streamForwardOutput(writer, allocator, qseq_ptrs, result.total_score, "");
         } else {
             return error.UnknownAlgorithm;
         }

--- a/packages/zig-core/src/ham/bcrham.zig
+++ b/packages/zig-core/src/ham/bcrham.zig
@@ -97,7 +97,7 @@ pub fn runAlgorithm(
         var dph = try DPHandler.init(allocator, args.algorithm, args, gl, hmms);
         defer dph.deinit();
 
-        var result = try dph.run(qseq_ptrs, kbounds, only_genes, @floatCast(qrow.mut_freq), true);
+        var result = try dph.run(qseq_ptrs, kbounds, only_genes, qrow.mut_freq, true);
         defer result.deinit();
 
         if (result.no_path) {
@@ -159,7 +159,7 @@ pub fn run(allocator: std.mem.Allocator, argv: []const [*:0]const u8) !void {
             .{ "--random-seed", "random_seed" },
             .{ "--min-largest-cluster-size", "min_largest_cluster_size" },
         };
-        const f32_flags = .{
+        const f64_flags = .{
             .{ "--hamming-fraction-bound-lo", "hamming_fraction_bound_lo" },
             .{ "--hamming-fraction-bound-hi", "hamming_fraction_bound_hi" },
             .{ "--logprob-ratio-threshold", "logprob_ratio_threshold" },
@@ -212,9 +212,9 @@ pub fn run(allocator: std.mem.Allocator, argv: []const [*:0]const u8) !void {
                     matched = true;
                 }
             }
-            inline for (f32_flags) |entry| {
+            inline for (f64_flags) |entry| {
                 if (std.mem.eql(u8, flag, entry[0])) {
-                    @field(args, entry[1]) = try std.fmt.parseFloat(f32, val);
+                    @field(args, entry[1]) = try std.fmt.parseFloat(f64, val);
                     matched = true;
                 }
             }

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -33,9 +33,20 @@ const GeneKSetKey = struct {
     kset: KSet,
 };
 
-/// Cached trellis entry: query strings → Trellis
+/// Cached trellis entry. Owns the Sequences the trellis was built over.
+///
+/// The entry itself is **heap-allocated** and the cache list holds pointers
+/// (`ArrayListUnmanaged(*TrellisEntry)`), so the entry's address is stable
+/// across cache-list reallocations. Inlining `query_seqs` here (rather than
+/// holding it via an extra `*Sequences` indirection) means `Trellis.seqs`
+/// can borrow `&entry.query_seqs` directly with one fewer pointer chase
+/// during prefix-match scans and DP setup.
+///
+/// Prefix-match for chunk-cache hits reads
+/// `entry.query_seqs.seqs.items[i].undigitized` — there is no separate
+/// `query_strs` list.
 const TrellisEntry = struct {
-    query_strs: std.ArrayListUnmanaged([]u8),
+    query_seqs: Sequences,
     trellis: Trellis,
 };
 
@@ -45,13 +56,40 @@ pub const DPHandler = struct {
     args: *Args,
     gl: *GermLines,
     hmms: *HMMHolder,
-    allocator: std.mem.Allocator,
 
-    /// scratch_cachefo_: gene → list of (query-string-vec, Trellis) entries
-    scratch_cachefo: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(TrellisEntry)),
-    /// paths_: gene → (KSet → TracebackPath)
+    /// Caller-supplied allocator. Used **only** for allocations that
+    /// outlive the DPHandler — Result, RecoEvent and any owned strings
+    /// reachable from them (gene names on RecoEvent, naive_seq, deletion
+    /// keys, insertion seqs). See item 4 of issue #342 for the lifetime
+    /// table; any allocation that lands in `parent_allocator` rather than
+    /// `scratchAllocator()` is a deliberate cross-boundary write.
+    parent_allocator: std.mem.Allocator,
+
+    /// Per-query arena, lives for the full DPHandler lifetime. Backs every
+    /// internal scratch allocation: scratch_cachefo, paths, scores,
+    /// per_gene_support, and the run()-local maps (only_genes,
+    /// best_scores, total_scores, best_genes). On `clear()`,
+    /// reset(.retain_capacity) drops every dependent allocation in O(1)
+    /// and reuses the backing pages for the next call. Item 4, #342.
+    query_arena: std.heap.ArenaAllocator,
+
+    /// scratch_cachefo_: gene → list of *TrellisEntry. Entries are
+    /// individually heap-allocated for stable address (the trellis at each
+    /// entry borrows `&entry.query_seqs` and that pointer must stay valid
+    /// across appends to the same gene's list). Address stability is
+    /// preserved under the per-query arena because arenas only grow —
+    /// past allocations are never relocated.
+    ///
+    /// The string keys are NOT owned by this map — they are shared with
+    /// `paths` and `scores`, which are populated by the same `initCache`
+    /// call (item 5 of #342). `scores` owns the duped key bytes; `clear()`
+    /// frees keys only when iterating `scores` to avoid a triple-free.
+    scratch_cachefo: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(*TrellisEntry)),
+    /// paths_: gene → (KSet → TracebackPath). Keys are borrowed (see
+    /// `scratch_cachefo` doc-block); the canonical owner is `scores`.
     paths: std.StringHashMapUnmanaged(std.AutoHashMapUnmanaged(KSet, TracebackPath)),
-    /// scores_: gene → (KSet → f64)
+    /// scores_: gene → (KSet → f64). Owns the gene-name keys shared with
+    /// `scratch_cachefo` and `paths` (item 5 of #342).
     scores: std.StringHashMapUnmanaged(std.AutoHashMapUnmanaged(KSet, f64)),
     /// per_gene_support_: gene → best full-annotation log-prob
     per_gene_support: std.StringHashMapUnmanaged(f64),
@@ -68,7 +106,8 @@ pub const DPHandler = struct {
             .args = args,
             .gl = gl,
             .hmms = hmms,
-            .allocator = allocator,
+            .parent_allocator = allocator,
+            .query_arena = std.heap.ArenaAllocator.init(allocator),
             .scratch_cachefo = .{},
             .paths = .{},
             .scores = .{},
@@ -76,33 +115,53 @@ pub const DPHandler = struct {
         };
     }
 
+    /// Per-query scratch allocator. **Always re-derive at the use site** —
+    /// caching `arena.allocator()` in a struct field would silently break
+    /// after a DPHandler move, since the returned `Allocator.ptr` points
+    /// at the arena's address at call time. (Item 4, #342.)
+    pub inline fn scratchAllocator(self: *DPHandler) std.mem.Allocator {
+        return self.query_arena.allocator();
+    }
+
     pub fn deinit(self: *DPHandler) void {
         self.clear();
+        self.query_arena.deinit();
     }
 
     /// Clear all cached trellis data.
     /// Corresponds to C++ `DPHandler::Clear`.
+    ///
+    /// Under the per-query arena (item 4, #342), every individual `free` /
+    /// `destroy` / `deinit` below is a no-op — the arena reset at the end
+    /// reclaims everything in one shot. The explicit cleanup loops are kept
+    /// as documentation and as a safety belt: they make the ownership
+    /// graph readable, and if a future change ever pulls one of these
+    /// allocations off the arena and back onto a real allocator, the
+    /// existing `free` will keep doing the right thing.
     pub fn clear(self: *DPHandler) void {
-        const allocator = self.allocator;
+        const allocator = self.scratchAllocator();
 
-        // Free scratch_cachefo
+        // Free scratch_cachefo. Each *TrellisEntry is heap-allocated and the
+        // entry's trellis borrows from the inline `query_seqs`. Deinit the
+        // trellis first (it doesn't own seqs but may use seq_len etc.), then
+        // the Sequences, then destroy the entry struct itself.
+        // Keys are shared with `paths` and `scores` (item 5 of #342); freed
+        // once below when iterating `scores`.
         var cit = self.scratch_cachefo.iterator();
         while (cit.next()) |entry| {
-            allocator.free(entry.key_ptr.*);
-            for (entry.value_ptr.items) |*te| {
-                for (te.query_strs.items) |s| allocator.free(s);
-                te.query_strs.deinit(allocator);
+            for (entry.value_ptr.items) |te| {
                 te.trellis.deinit();
+                te.query_seqs.deinit(allocator);
+                allocator.destroy(te);
             }
             entry.value_ptr.deinit(allocator);
         }
         self.scratch_cachefo.deinit(allocator);
         self.scratch_cachefo = .{};
 
-        // Free paths
+        // Free paths. Keys are shared with `scores` (see above).
         var pit = self.paths.iterator();
         while (pit.next()) |entry| {
-            allocator.free(entry.key_ptr.*);
             var inner_it = entry.value_ptr.iterator();
             while (inner_it.next()) |kv| kv.value_ptr.deinit(allocator);
             entry.value_ptr.deinit(allocator);
@@ -110,7 +169,8 @@ pub const DPHandler = struct {
         self.paths.deinit(allocator);
         self.paths = .{};
 
-        // Free scores
+        // Free scores. This is the canonical owner of the gene-name keys
+        // shared with `scratch_cachefo` and `paths`.
         var sit = self.scores.iterator();
         while (sit.next()) |entry| {
             allocator.free(entry.key_ptr.*);
@@ -124,42 +184,72 @@ pub const DPHandler = struct {
         while (pgit.next()) |entry| allocator.free(entry.key_ptr.*);
         self.per_gene_support.deinit(allocator);
         self.per_gene_support = .{};
+
+        // Reset the per-query arena: this is what actually reclaims memory
+        // (the loops above are no-ops on the arena). Retains capacity so
+        // the next run() in handleFishyAnnotations reuses the backing pages.
+        _ = self.query_arena.reset(.retain_capacity);
     }
 
     /// Run the DP for a single Sequence.
     /// Corresponds to C++ `DPHandler::Run(Sequence, ...)`.
+    /// The Sequence's heap buffers (name/header/undigitized/seqq) are borrowed
+    /// for the duration of the call; the caller retains ownership.
     pub fn runSeq(
         self: *DPHandler,
-        seq: Sequence,
+        seq: *const Sequence,
         kbounds: KBounds,
         only_gene_list: []const []const u8,
         overall_mute_freq: f64,
         clear_cache: bool,
     ) !Result {
-        // Clone into a Sequences container (single sequence)
-        var seqvec: std.ArrayListUnmanaged(Sequence) = .{};
-        defer seqvec.deinit(self.allocator);
-        try seqvec.append(self.allocator, try seq.clone(self.allocator));
-        return self.run(seqvec.items, kbounds, only_gene_list, overall_mute_freq, clear_cache);
+        const seqvec = [_]*const Sequence{seq};
+        return self.run(&seqvec, kbounds, only_gene_list, overall_mute_freq, clear_cache);
     }
 
     /// Run the DP over a vector of sequences.
     /// Corresponds to C++ `DPHandler::Run(vector<Sequence>, ...)`.
+    /// `seqvector` is borrowed: each pointed-to Sequence's heap buffers must
+    /// outlive the call; the internal Sequences container holds shallow
+    /// struct-copies that share those buffers (items 2 + 16 of issue #342).
+    /// The container's items are not deinit'd at function end — only the
+    /// backing array allocation is freed.
     pub fn run(
         self: *DPHandler,
-        seqvector: []const Sequence,
+        seqvector: []const *const Sequence,
         kbounds: KBounds,
         only_gene_list: []const []const u8,
         overall_mute_freq: f64,
         clear_cache: bool,
     ) !Result {
-        const allocator = self.allocator;
+        // Per-query scratch arena: every internal allocation routes here.
+        // `parent` is reserved for the returned Result and any RecoEvent
+        // strings the caller will read after run() exits. Item 4, #342.
+        //
+        // `clear_cache` MUST run before any per-call scratch allocations.
+        // `clear()` resets the arena, which would invalidate any seqs /
+        // only_genes / etc. already built off `scratchAllocator()`.
+        if (clear_cache) self.clear();
+        const allocator = self.scratchAllocator();
+        const parent = self.parent_allocator;
         const run_start = std.time.milliTimestamp();
 
+        // Build a Sequences container that borrows from `seqvector`.
+        // Each Sequence is a shallow struct-copy: slice headers are duplicated,
+        // but the underlying name/header/undigitized/seqq buffers are shared
+        // with `seqvector`. We must not deinit the items at end-of-call —
+        // only the backing array allocation is freed.
         var seqs = Sequences.init();
-        defer seqs.deinit(allocator);
-        for (seqvector) |*sq| {
-            try seqs.addSeq(allocator, try sq.clone(allocator));
+        defer seqs.seqs.deinit(allocator);
+        try seqs.seqs.ensureTotalCapacityPrecise(allocator, seqvector.len);
+        for (seqvector) |sq_ptr| {
+            const sq = sq_ptr.*;
+            if (seqs.seqs.items.len == 0) {
+                seqs.sequence_length = sq.size();
+            } else if (sq.size() != seqs.sequence_length) {
+                return error.SequenceLengthMismatch;
+            }
+            seqs.seqs.appendAssumeCapacity(sq);
         }
 
         // Build only_genes map: region → set of gene names
@@ -208,8 +298,6 @@ pub const DPHandler = struct {
             kbounds.vmax <= kbounds.vmin or kbounds.dmax <= kbounds.dmin)
             return error.TrivialKBounds;
 
-        if (clear_cache) self.clear();
-
         var best_scores: std.AutoHashMapUnmanaged(KSet, f64) = .{};
         defer best_scores.deinit(allocator);
         var total_scores: std.AutoHashMapUnmanaged(KSet, f64) = .{};
@@ -231,7 +319,7 @@ pub const DPHandler = struct {
             try self.hmms.rescaleOverallMuteFreqs(&only_genes, overall_mute_freq);
         }
 
-        var result = try Result.init(allocator, kbounds, self.args.locus);
+        var result = try Result.init(parent, kbounds, self.args.locus);
 
         var best_score: f64 = mathutils.NEG_INF;
         var best_kset = KSet{ .v = 0, .d = 0 };
@@ -331,8 +419,14 @@ pub const DPHandler = struct {
 
     /// Get subsequences for one region.
     /// Corresponds to C++ `DPHandler::GetSubSeqs(seqs, kset, region)`.
-    fn getSubSeqs(self: *DPHandler, seqs: *const Sequences, kset: KSet, region: Region) !Sequences {
-        const allocator = self.allocator;
+    ///
+    /// `allocator` is taken explicitly so the caller (`runKSet`) can route
+    /// the per-region clones through its per-kset arena rather than the
+    /// per-query arena. The clone strings live only for the region's
+    /// inner loop. (Item 4, #342.)
+    ///
+    /// Free function (no `self` access): nothing here reads DPHandler state.
+    fn getSubSeqs(allocator: std.mem.Allocator, seqs: *const Sequences, kset: KSet, region: Region) !Sequences {
         var result = Sequences.init();
         errdefer result.deinit(allocator);
 
@@ -357,42 +451,39 @@ pub const DPHandler = struct {
         return result;
     }
 
-    /// Collect undigitized strings for the given region's subsequences.
-    fn getQueryStrs(self: *DPHandler, seqs: *const Sequences, kset: KSet, region: Region) !std.ArrayListUnmanaged([]u8) {
-        const allocator = self.allocator;
-        var query_seqs = try self.getSubSeqs(seqs, kset, region);
-        defer query_seqs.deinit(allocator);
-
-        var strs: std.ArrayListUnmanaged([]u8) = .{};
-        errdefer {
-            for (strs.items) |s| allocator.free(s);
-            strs.deinit(allocator);
-        }
-        for (query_seqs.seqs.items) |*sq| {
-            try strs.append(allocator, try allocator.dupe(u8, sq.undigitized));
-        }
-        return strs;
+    /// Borrow the undigitized strings of `seqs` into a freshly-allocated slice
+    /// of `[]const u8` (slice-of-slices, no string copies). The returned slice
+    /// is allocated with `allocator` and must be `free`d by the caller; the
+    /// individual strings borrow into `seqs.seqs.items[i].undigitized` and
+    /// must not outlive `seqs`.
+    fn borrowQueryStrs(allocator: std.mem.Allocator, seqs: *const Sequences) ![][]const u8 {
+        const out = try allocator.alloc([]const u8, seqs.seqs.items.len);
+        for (seqs.seqs.items, 0..) |*sq, i| out[i] = sq.undigitized;
+        return out;
     }
 
     /// Ensure per-gene caches are initialised for `gene`.
-    /// Three separate key copies are needed because each HashMap owns its key independently.
+    /// One duped key is shared across `scratch_cachefo`, `paths`, and `scores`
+    /// (item 5 of #342). All three maps live on `query_arena` and are torn
+    /// down together by `clear()` / `deinit()`, so shared ownership is safe.
+    /// Capacity is reserved up front so the puts cannot fail after the dupe,
+    /// keeping the failure mode obvious if these maps ever move off the arena.
     fn initCache(self: *DPHandler, gene: []const u8) !void {
         if (self.scores.contains(gene)) return;
 
-        const key = try self.allocator.dupe(u8, gene);
-        errdefer self.allocator.free(key);
-        try self.scratch_cachefo.put(self.allocator, key, .{});
+        const allocator = self.scratchAllocator();
+        try self.scratch_cachefo.ensureUnusedCapacity(allocator, 1);
+        try self.paths.ensureUnusedCapacity(allocator, 1);
+        try self.scores.ensureUnusedCapacity(allocator, 1);
 
-        const key2 = try self.allocator.dupe(u8, gene);
-        errdefer self.allocator.free(key2);
-        try self.paths.put(self.allocator, key2, .{});
-
-        const key3 = try self.allocator.dupe(u8, gene);
-        errdefer self.allocator.free(key3);
-        try self.scores.put(self.allocator, key3, .{});
+        const key = try allocator.dupe(u8, gene);
+        self.scratch_cachefo.putAssumeCapacity(key, .{});
+        self.paths.putAssumeCapacity(key, .{});
+        self.scores.putAssumeCapacity(key, .{});
     }
 
-    /// Look for a cached kset whose region sequences are a prefix of `query_strs`.
+    /// Look for a cached kset whose region sequences are a prefix of the
+    /// query's per-region undigitized strings (built via `getSubSeqs`).
     /// Returns null-kset if none found.
     fn findPartialCacheMatch(self: *DPHandler, region: Region, gene: []const u8, kset: KSet) KSet {
         const gene_scores = self.scores.get(gene) orelse return KSet{ .v = 0, .d = 0 };
@@ -431,25 +522,39 @@ pub const DPHandler = struct {
 
     /// Fill the trellis for the given (gene, kset, query_seqs).
     /// Stores result in scores_[gene][kset] and (for viterbi) paths_[gene][kset].
+    /// `query_seqs` is borrowed; its lifetime must span the call. For the
+    /// fresh path (no chunk-cache hit), the trellis is stored in
+    /// `scratch_cachefo[gene]` and a clone of `query_seqs` is heap-allocated
+    /// to give the stored trellis a stable, long-lived borrow target.
+    /// `kset_alloc` is the per-kset arena. Used **only** for the chunk-cache
+    /// temp trellis (its scoring buffers and traceback_table are reset at
+    /// end-of-kset). Everything that lives across ksets — `scratch_cachefo`
+    /// entries, `paths`, `scores` — uses `scratchAllocator()`. The
+    /// traceback path's items are explicitly routed through `scratch` even
+    /// when the temp trellis runs viterbi: they are stored in `self.paths`
+    /// and outlive the kset. (Item 4, #342.)
     fn fillTrellis(
         self: *DPHandler,
+        kset_alloc: std.mem.Allocator,
         kset: KSet,
-        query_seqs: Sequences,
-        query_strs: []const []const u8,
+        query_seqs: *const Sequences,
         gene: []const u8,
     ) ![]const u8 {
-        const allocator = self.allocator;
+        const allocator = self.scratchAllocator();
 
-        // Look for a chunk-cached trellis
+        // Look for a chunk-cached trellis. Prefix-match is on undigitized
+        // strings of the cached trellis's stored query_seqs.
         var cached_trellis: ?*const Trellis = null;
         if (!self.args.no_chunk_cache) {
             if (self.scratch_cachefo.getPtr(gene)) |cache_list| {
-                for (cache_list.items) |*te| {
-                    if (te.query_strs.items.len != query_strs.len) continue;
+                for (cache_list.items) |te| {
+                    const cached_seqs = te.query_seqs.seqs.items;
+                    const current_seqs = query_seqs.seqs.items;
+                    if (cached_seqs.len != current_seqs.len) continue;
                     var all_match = true;
-                    for (te.query_strs.items, query_strs) |cached, current| {
+                    for (cached_seqs, current_seqs) |*cached, *current| {
                         // cached must START WITH current (prefix match)
-                        if (!std.mem.startsWith(u8, cached, current)) {
+                        if (!std.mem.startsWith(u8, cached.undigitized, current.undigitized)) {
                             all_match = false;
                             break;
                         }
@@ -471,16 +576,6 @@ pub const DPHandler = struct {
         // This is critical: when no cache, do NOT create a second trellis that borrows from
         // the (empty) scratch — the scratch itself is the working trellis.
 
-        // Build the TrellisEntry query strings (needed if storing a new scratch).
-        var qstrs: std.ArrayListUnmanaged([]u8) = .{};
-        defer {
-            for (qstrs.items) |s| allocator.free(s);
-            qstrs.deinit(allocator);
-        }
-        for (query_strs) |s| {
-            try qstrs.append(allocator, try allocator.dupe(u8, s));
-        }
-
         // trell_ptr points to the trellis on which the algorithm is run.
         // tmptrell is only used when borrowing from a cached trellis.
         var tmptrell: ?Trellis = null;
@@ -488,26 +583,44 @@ pub const DPHandler = struct {
 
         var origin: []const u8 = "scratch";
         const trell_ptr: *Trellis = if (cached_trellis == null) blk: {
-            // No cache: create scratch WITHOUT cached_trellis, store it, use it directly.
-            var fresh = try Trellis.initWithSeqs(allocator, model, query_seqs, null);
-            errdefer fresh.deinit();
-            const entry = TrellisEntry{ .query_strs = qstrs, .trellis = fresh };
-            qstrs = .{}; // ownership transferred to entry
-            origin = "scratch";
+            // No cache: heap-allocate a TrellisEntry to give the stored trellis
+            // a stable borrow target. Inline `query_seqs` lives at a fixed offset
+            // from the entry's heap address, so `trellis.seqs = &entry.query_seqs`
+            // stays valid across cache_list appends (which only move the *entry
+            // pointers in the list, not the entries themselves).
+            const entry = try allocator.create(TrellisEntry);
+            errdefer allocator.destroy(entry);
+            entry.query_seqs = try query_seqs.clone(allocator);
+            errdefer entry.query_seqs.deinit(allocator);
+            entry.trellis = try Trellis.initWithSeqs(allocator, model, &entry.query_seqs, null);
+            errdefer entry.trellis.deinit();
+
             if (self.scratch_cachefo.getPtr(gene)) |cache_list| {
                 try cache_list.append(allocator, entry);
-                break :blk &cache_list.items[cache_list.items.len - 1].trellis;
+                break :blk &entry.trellis;
             } else {
-                // gene not in scratch_cachefo (shouldn't happen after initCache), discard
-                var e = entry;
-                for (e.query_strs.items) |s| allocator.free(s);
-                e.query_strs.deinit(allocator);
-                e.trellis.deinit();
+                // gene not in scratch_cachefo (shouldn't happen after initCache).
+                // Assert so safe builds (Debug, ReleaseSafe — including the
+                // rung-1 UAF-coverage run) panic loudly; ReleaseFast keeps
+                // the cleanup + error-return path as a defensive fallback.
+                std.debug.assert(false);
+                entry.trellis.deinit();
+                entry.query_seqs.deinit(allocator);
+                allocator.destroy(entry);
                 return error.GeneNotInScratchCache;
             }
         } else blk: {
-            // Have cache: create temp trellis that borrows from the cached scratch.
-            tmptrell = try Trellis.initWithSeqs(allocator, model, query_seqs, cached_trellis);
+            // Have cache: temp trellis borrows from the caller's query_seqs
+            // (no clone — lifetime is just this call). Backed by the per-kset
+            // arena (`kset_alloc`): scoring buffers + traceback_table are
+            // reset at end-of-kset rather than accumulating across ksets in
+            // the per-query arena. Worst case under the per-query arena
+            // would be n_genes × n_ksets × seq_len × n_states × 2 bytes per
+            // viterbi-mode query — hundreds of MB on annotation workloads.
+            // The path items below are explicitly routed through `allocator`
+            // (per-query scratch), not `kset_alloc`, since they're stored in
+            // `self.paths` and outlive the kset. (Item 4, #342.)
+            tmptrell = try Trellis.initWithSeqs(kset_alloc, model, query_seqs, cached_trellis);
             origin = "chunk";
             break :blk &tmptrell.?;
         };
@@ -520,7 +633,9 @@ pub const DPHandler = struct {
             var path = TracebackPath.initWithModel(model);
             errdefer path.deinit(allocator);
             if (sc != mathutils.NEG_INF) {
-                try trell_ptr.traceback(&path);
+                // Explicitly pass `allocator` (per-query scratch) so the path's
+                // items don't capture the temp trellis's per-kset arena.
+                try trell_ptr.traceback(allocator, &path);
             }
             if (self.paths.getPtr(gene)) |gene_paths| {
                 try gene_paths.put(allocator, kset, path);
@@ -546,7 +661,7 @@ pub const DPHandler = struct {
     /// Print colored germline alignment for a gene path (debug==2 viterbi output).
     /// Corresponds to C++ `DPHandler::PrintPath`.
     fn printPath(self: *DPHandler, kset: KSet, query_strs: []const []const u8, gene: []const u8, score: f64, extra_str: []const u8) !void {
-        const allocator = self.allocator;
+        const allocator = self.scratchAllocator();
         if (score == mathutils.NEG_INF) return;
 
         const path_names_list = try self.getPathNames(gene, kset, allocator);
@@ -662,6 +777,18 @@ pub const DPHandler = struct {
     }
 
     /// Run all genes for one kset.
+    ///
+    /// Two arenas are in play here (item 4, #342):
+    ///   - `scratch` (per-query): backs the maps that outlive this kset —
+    ///     `best_scores` / `total_scores` / `best_genes` (passed in, owned
+    ///     by `run()`), the `gene_val` dupe written into `best_genes[kset]`,
+    ///     the cached-path copy stored in `self.paths`, and updates to
+    ///     `self.scores` / `self.per_gene_support`.
+    ///   - `kset_alloc` (per-kset): backs everything that dies at end of
+    ///     this function — `regional_best/total`, `per_gene_support_this_kset`,
+    ///     per-region sub-seq clones, debug-output buffers, sorted-gene
+    ///     slices, and the chunk-cache temp trellis routed through
+    ///     `fillTrellis`. `kset_arena.deinit()` reclaims it all in one shot.
     fn runKSet(
         self: *DPHandler,
         seqs: *Sequences,
@@ -671,12 +798,15 @@ pub const DPHandler = struct {
         total_scores: *std.AutoHashMapUnmanaged(KSet, f64),
         best_genes: *std.AutoHashMapUnmanaged(KSet, std.AutoHashMapUnmanaged(Region, []u8)),
     ) !void {
-        const allocator = self.allocator;
+        const scratch = self.scratchAllocator();
+        var kset_arena = std.heap.ArenaAllocator.init(self.parent_allocator);
+        defer kset_arena.deinit();
+        const allocator = kset_arena.allocator();
 
-        try best_scores.put(allocator, kset, mathutils.NEG_INF);
-        try total_scores.put(allocator, kset, mathutils.NEG_INF);
+        try best_scores.put(scratch, kset, mathutils.NEG_INF);
+        try total_scores.put(scratch, kset, mathutils.NEG_INF);
         const bg_entry: std.AutoHashMapUnmanaged(Region, []u8) = .{};
-        try best_genes.put(allocator, kset, bg_entry);
+        try best_genes.put(scratch, kset, bg_entry);
 
         // Debug: kset header
         if (self.args.debug == 2) {
@@ -695,25 +825,30 @@ pub const DPHandler = struct {
         defer regional_best.deinit(allocator);
         var regional_total: std.AutoHashMapUnmanaged(Region, f64) = .{};
         defer regional_total.deinit(allocator);
+        // per_gene_support_this_kset borrows its keys from `only_genes`'s
+        // arena-duped strings (item 22 of #342). `only_genes`'s key bytes
+        // live on the per-query arena (`scratchAllocator()`); they outlive
+        // any single `runKSet` call (per-kset arena dies first), and in
+        // fact persist until the next `clear()` resets the arena.
         var per_gene_support_this_kset: std.StringHashMapUnmanaged(f64) = .{};
-        defer {
-            var it = per_gene_support_this_kset.iterator();
-            while (it.next()) |e| allocator.free(e.key_ptr.*);
-            per_gene_support_this_kset.deinit(allocator);
-        }
+        defer per_gene_support_this_kset.deinit(allocator);
 
         for (bcr.germ_lines.regions) |region| {
             try regional_best.put(allocator, region, mathutils.NEG_INF);
             try regional_total.put(allocator, region, mathutils.NEG_INF);
 
-            var query_strs = try self.getQueryStrs(seqs, kset, region);
-            defer {
-                for (query_strs.items) |s| allocator.free(s);
-                query_strs.deinit(allocator);
-            }
-
-            var query_seqs = try self.getSubSeqs(seqs, kset, region);
+            var query_seqs = try getSubSeqs(allocator, seqs, kset, region);
             defer query_seqs.deinit(allocator);
+
+            // Borrow the undigitized strings (slice headers only — no string copies).
+            // Only the args.debug == 2 paths consume this slice (the region-display
+            // block below and printPath); skip the allocation otherwise.
+            // Lifetime is bounded by query_seqs above.
+            const query_strs: [][]const u8 = if (self.args.debug == 2)
+                try borrowQueryStrs(allocator, &query_seqs)
+            else
+                &.{};
+            defer if (self.args.debug == 2) allocator.free(query_strs);
 
             // Debug: region query display
             if (self.args.debug == 2) {
@@ -722,24 +857,20 @@ pub const DPHandler = struct {
                     // Get ambiguous char from args (matches C++ hmms_.track()->ambiguous_char())
                     const ambig = self.args.ambig_base;
                     const ambig_ch: u8 = if (ambig.len > 0) ambig[0] else 0;
-                    if (query_strs.items.len > 0) {
+                    if (query_strs.len > 0) {
                         const colored = if (ambig_ch != 0)
-                            try TermColors.colorChars(allocator, ambig_ch, "light_blue", query_strs.items[0])
+                            try TermColors.colorChars(allocator, ambig_ch, "light_blue", query_strs[0])
                         else
-                            try allocator.dupe(u8, query_strs.items[0]);
+                            try allocator.dupe(u8, query_strs[0]);
                         defer allocator.free(colored);
                         const line = try std.fmt.allocPrint(allocator, "                {s} query {s}\n", .{ rs, colored });
                         defer allocator.free(line);
                         try std.fs.File.stdout().writeAll(line);
                     }
                     // Additional query strings colored as mutants relative to first
-                    if (query_strs.items.len > 1) {
-                        // Build const slice for colorMutants
-                        const const_strs = try allocator.alloc([]const u8, query_strs.items.len);
-                        defer allocator.free(const_strs);
-                        for (query_strs.items, 0..) |s, i| const_strs[i] = s;
-                        for (query_strs.items[1..]) |qs| {
-                            const mutant = try TermColors.colorMutants(allocator, "purple", qs, "", const_strs, ambig);
+                    if (query_strs.len > 1) {
+                        for (query_strs[1..]) |qs| {
+                            const mutant = try TermColors.colorMutants(allocator, "purple", qs, "", query_strs, ambig);
                             defer allocator.free(mutant);
                             const colored2 = if (ambig_ch != 0)
                                 try TermColors.colorChars(allocator, ambig_ch, "light_blue", mutant)
@@ -778,35 +909,33 @@ pub const DPHandler = struct {
                 var origin: []const u8 = "";
                 const partial_match = self.findPartialCacheMatch(region, gene, kset);
                 if (!partial_match.isNull()) {
-                    // Copy path and score from cached kset
+                    // Copy path and score from cached kset. Both go into
+                    // `self.paths` / `self.scores`, which outlive the kset
+                    // — route through `scratch`, not `allocator`.
                     if (self.paths.getPtr(gene)) |gp| {
                         if (gp.get(partial_match)) |cached_path| {
                             var path_copy = TracebackPath.init();
-                            errdefer path_copy.deinit(allocator);
-                            try path_copy.path.appendSlice(allocator, cached_path.path.items);
+                            errdefer path_copy.deinit(scratch);
+                            try path_copy.path.appendSlice(scratch, cached_path.path.items);
                             path_copy.setScore(cached_path.score);
                             path_copy.setModel(cached_path.hmm.?);
-                            try gp.put(allocator, kset, path_copy);
+                            try gp.put(scratch, kset, path_copy);
                         }
                     }
                     if (self.scores.getPtr(gene)) |gs| {
                         const cached_score = gs.get(partial_match) orelse mathutils.NEG_INF;
-                        try gs.put(allocator, kset, cached_score);
+                        try gs.put(scratch, kset, cached_score);
                     }
                     origin = "cached";
                 } else {
-                    origin = try self.fillTrellis(kset, query_seqs, query_strs.items, gene);
+                    origin = try self.fillTrellis(allocator, kset, &query_seqs, gene);
                 }
 
                 const gene_score = if (self.scores.getPtr(gene)) |gs| gs.get(kset) orelse mathutils.NEG_INF else mathutils.NEG_INF;
 
                 // Debug: per-gene viterbi output
                 if (self.args.debug == 2 and std.mem.eql(u8, self.algorithm, "viterbi")) {
-                    // Build const slice for printPath
-                    const const_strs = try allocator.alloc([]const u8, query_strs.items.len);
-                    defer allocator.free(const_strs);
-                    for (query_strs.items, 0..) |s, i| const_strs[i] = s;
-                    try self.printPath(kset, const_strs, gene, gene_score, origin);
+                    try self.printPath(kset, query_strs, gene, gene_score, origin);
                 }
 
                 // Update regional totals
@@ -824,24 +953,27 @@ pub const DPHandler = struct {
                     try std.fs.File.stdout().writeAll(fwd_line);
                 }
 
-                // Update regional best + best_genes for this kset
+                // Update regional best + best_genes for this kset.
+                // `regional_best` is kset-local but `best_genes` is owned by
+                // `run()` and read in `fillRecoEvent` after this kset
+                // returns — its `gene_val` dupe must live on `scratch`,
+                // not the per-kset arena.
                 const reg_best = regional_best.get(region) orelse mathutils.NEG_INF;
                 if (gene_score > reg_best) {
                     if (regional_best.getPtr(region)) |rb| rb.* = gene_score;
                     if (best_genes.getPtr(kset)) |bg_map| {
-                        const gene_val = try allocator.dupe(u8, gene);
-                        errdefer allocator.free(gene_val);
+                        const gene_val = try scratch.dupe(u8, gene);
+                        errdefer scratch.free(gene_val);
                         if (bg_map.fetchRemove(region)) |old| {
-                            allocator.free(old.value);
+                            scratch.free(old.value);
                         }
-                        try bg_map.put(allocator, region, gene_val);
+                        try bg_map.put(scratch, region, gene_val);
                     }
                 }
 
-                // per_gene_support for this kset
-                const pg_key = try allocator.dupe(u8, gene);
-                errdefer allocator.free(pg_key);
-                try per_gene_support_this_kset.put(allocator, pg_key, gene_score);
+                // per_gene_support for this kset. `gene` is borrowed from
+                // `only_genes` (see map declaration above for lifetime).
+                try per_gene_support_this_kset.put(allocator, gene, gene_score);
             }
 
             // If no gene found for this region, return early
@@ -865,8 +997,8 @@ pub const DPHandler = struct {
         const rt_d = regional_total.get(.d) orelse mathutils.NEG_INF;
         const rt_j = regional_total.get(.j) orelse mathutils.NEG_INF;
 
-        try best_scores.put(allocator, kset, mathutils.addWithMinusInfinities(rb_v, mathutils.addWithMinusInfinities(rb_d, rb_j)));
-        try total_scores.put(allocator, kset, mathutils.addWithMinusInfinities(rt_v, mathutils.addWithMinusInfinities(rt_d, rt_j)));
+        try best_scores.put(scratch, kset, mathutils.addWithMinusInfinities(rb_v, mathutils.addWithMinusInfinities(rb_d, rb_j)));
+        try total_scores.put(scratch, kset, mathutils.addWithMinusInfinities(rt_v, mathutils.addWithMinusInfinities(rt_d, rt_j)));
 
         // Compute per_gene_support across ksets
         for (bcr.germ_lines.regions) |region| {
@@ -899,9 +1031,9 @@ pub const DPHandler = struct {
                     if (self.per_gene_support.contains(gene)) {
                         self.per_gene_support.getPtr(gene).?.* = score_this_kset;
                     } else {
-                        const pg_key = try self.allocator.dupe(u8, gene);
-                        errdefer self.allocator.free(pg_key);
-                        try self.per_gene_support.put(self.allocator, pg_key, score_this_kset);
+                        const pg_key = try scratch.dupe(u8, gene);
+                        errdefer scratch.free(pg_key);
+                        try self.per_gene_support.put(scratch, pg_key, score_this_kset);
                     }
                 }
             }
@@ -909,6 +1041,13 @@ pub const DPHandler = struct {
     }
 
     /// Build a RecoEvent for the given kset and best gene assignments.
+    ///
+    /// The returned `RecoEvent` is pushed into `Result.events` (and possibly
+    /// `Result.best_event`), which is handed back to the caller of `run()`.
+    /// All allocations that end up owned by the event (gene names,
+    /// deletion keys, insertion seqs, naive_seq) therefore route through
+    /// `parent_allocator`. Transient workspace (path_names_list, del_3p/
+    /// del_5p format strings) uses `scratchAllocator()`. (Item 4, #342.)
     fn fillRecoEvent(
         self: *DPHandler,
         seqs: *Sequences,
@@ -916,9 +1055,10 @@ pub const DPHandler = struct {
         best_genes_for_kset: *const std.AutoHashMapUnmanaged(Region, []u8),
         score: f64,
     ) !RecoEvent {
-        const allocator = self.allocator;
-        var event = try RecoEvent.init(allocator);
-        errdefer event.deinit(allocator);
+        const parent = self.parent_allocator;
+        const scratch = self.scratchAllocator();
+        var event = try RecoEvent.init(parent);
+        errdefer event.deinit(parent);
 
         for (bcr.germ_lines.regions) |region| {
             const rs = regionStr(region);
@@ -927,22 +1067,20 @@ pub const DPHandler = struct {
                 return event;
             };
 
-            var query_strs = try self.getQueryStrs(seqs, kset, region);
-            defer {
-                for (query_strs.items) |s| allocator.free(s);
-                query_strs.deinit(allocator);
-            }
-            if (query_strs.items.len == 0) {
+            // The original C++ path called GetQueryStrs and checked items.len > 0;
+            // in practice that's always equal to seqs.nSeqs(), so check directly
+            // and skip the unused string list.
+            if (seqs.nSeqs() == 0) {
                 event.setScore(mathutils.NEG_INF);
                 return event;
             }
 
-            // Get traceback path names
-            const path_names_list = try self.getPathNames(gene, kset, allocator);
+            // Get traceback path names — transient workspace, scratch alloc.
+            const path_names_list = try self.getPathNames(gene, kset, scratch);
             defer {
-                for (path_names_list.items) |s| allocator.free(s);
+                for (path_names_list.items) |s| scratch.free(s);
                 var pl = path_names_list;
-                pl.deinit(allocator);
+                pl.deinit(scratch);
             }
 
             if (path_names_list.items.len == 0) {
@@ -950,18 +1088,18 @@ pub const DPHandler = struct {
                 return event;
             }
 
-            try event.setGene(allocator, rs, gene);
-            const del_3p = try std.fmt.allocPrint(allocator, "{s}_3p", .{rs});
-            defer allocator.free(del_3p);
-            const del_5p = try std.fmt.allocPrint(allocator, "{s}_5p", .{rs});
-            defer allocator.free(del_5p);
-            try event.setDeletion(allocator, del_3p, self.getErosionLength("right", path_names_list.items, gene));
-            try event.setDeletion(allocator, del_5p, self.getErosionLength("left", path_names_list.items, gene));
+            try event.setGene(parent, rs, gene);
+            const del_3p = try std.fmt.allocPrint(scratch, "{s}_3p", .{rs});
+            defer scratch.free(del_3p);
+            const del_5p = try std.fmt.allocPrint(scratch, "{s}_5p", .{rs});
+            defer scratch.free(del_5p);
+            try event.setDeletion(parent, del_3p, self.getErosionLength("right", path_names_list.items, gene));
+            try event.setDeletion(parent, del_5p, self.getErosionLength("left", path_names_list.items, gene));
             try self.setInsertions(region, path_names_list.items, &event);
         }
 
         event.setScore(score);
-        try event.setNaiveSeq(allocator, self.gl);
+        try event.setNaiveSeq(parent, self.gl);
         return event;
     }
 
@@ -980,7 +1118,9 @@ pub const DPHandler = struct {
     /// Set insertions on `event` based on path state names for `region`.
     /// Corresponds to C++ `DPHandler::SetInsertions`.
     fn setInsertions(self: *DPHandler, region: Region, path_names: []const []const u8, event: *RecoEvent) !void {
-        const allocator = self.allocator;
+        // Insertion seqs are dupe'd onto the event, which lives in
+        // Result returned to the caller — parent_allocator. (Item 4, #342.)
+        const allocator = self.parent_allocator;
         const ins = Insertions{};
         for (ins.forRegion(region)) |insertion| {
             const side: []const u8 = if (std.mem.eql(u8, insertion, "jf")) "right" else "left";
@@ -1078,20 +1218,32 @@ pub const DPHandler = struct {
     pub fn handleFishyAnnotations(
         self: *DPHandler,
         multi_seq_result: *Result,
-        qry_seqs: []const Sequence,
+        qry_seqs: []const *const Sequence,
         kbounds: KBounds,
         only_gene_list: []const []const u8,
         overall_mute_freq: f64,
     ) !void {
-        const allocator = self.allocator;
+        // `multi_seq_result` was built by an earlier `run()` call with
+        // `parent_allocator`; mutating its `best_event` here must use the
+        // same allocator so the existing entries' frees match. (Item 4, #342.)
+        //
+        // `naive_seq` MUST also use `parent_allocator`, NOT scratch: the
+        // inner `self.run(... clear_cache=true)` call on the line below
+        // calls `self.clear()` as its first action, which resets the
+        // per-query arena. Any naive_seq buffers (`name`/`header`/
+        // `undigitized`/`seqq`) allocated on scratch would be reclaimed
+        // before the inner DP loop reads `seqq[i]` in `emissionLogprobSeqs`,
+        // producing a use-after-reset. The fix is to keep naive_seq's
+        // backing on the caller's long-lived allocator.
+        const parent = self.parent_allocator;
         const best_ev = multi_seq_result.best_event orelse return;
 
         // Create naive sequence (use first query's track)
         const first_track = qry_seqs[0].track orelse return;
-        var naive_seq = try Sequence.initFromString(allocator, first_track, "naive-seq", best_ev.naive_seq);
-        defer naive_seq.deinit(allocator);
+        var naive_seq = try Sequence.initFromString(parent, first_track, "naive-seq", best_ev.naive_seq);
+        defer naive_seq.deinit(parent);
 
-        const naive_seqs = [_]Sequence{naive_seq};
+        const naive_seqs = [_]*const Sequence{&naive_seq};
         var naive_result = try self.run(&naive_seqs, kbounds, only_gene_list, overall_mute_freq, true);
         defer naive_result.deinit();
 
@@ -1100,17 +1252,17 @@ pub const DPHandler = struct {
             for (bcr.germ_lines.regions) |region| {
                 const rs = regionStr(region);
                 const ng = naive_ev.genes.get(rs) orelse continue;
-                try me.setGene(allocator, rs, ng);
+                try me.setGene(parent, rs, ng);
             }
             const all_dels = [_][]const u8{ "v_5p", "v_3p", "d_5p", "d_3p", "j_5p", "j_3p" };
             for (all_dels) |delname| {
                 const nd = naive_ev.deletions.get(delname) orelse 0;
-                try me.setDeletion(allocator, delname, nd);
+                try me.setDeletion(parent, delname, nd);
             }
             const all_ins = [_][]const u8{ "fv", "vd", "dj", "jf" };
             for (all_ins) |ins_name| {
                 const ni = naive_ev.insertions.get(ins_name) orelse "";
-                try me.setInsertion(allocator, ins_name, ni);
+                try me.setInsertion(parent, ins_name, ni);
             }
         }
     }

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -34,117 +34,6 @@ const GeneKSetKey = struct {
     kset: KSet,
 };
 
-/// Per-gene dense score grid over the kset rectangle. Replaces the
-/// `AutoHashMapUnmanaged(KSet, f64)` inner-map of `DPHandler.scores`
-/// (item 2.1 of #366). The C++ `map<KSet, double>` it descends from gave
-/// `findPartialCacheMatch` an `O(n_filled_ksets)` scan per call, called
-/// `n_genes × 3 × n_ksets` times per query — `O(n_genes × n_ksets²)`
-/// per query of map iteration. The dense grid replaces that with O(1)
-/// direct lookup and an `O(d_dim)` (V-region) or `O(v_dim)` (J-region)
-/// bounded scan, plus drops the per-cell HashMap pointer-chasing.
-///
-/// Layout: row-major `[v_dim * d_dim]` indexed as
-/// `idx = (k_v - kgrid_vmin) * d_dim + (k_d - kgrid_dmin)`. The query's
-/// `kbounds` pin both the offsets and the dims, so the grid covers
-/// every kset that `run()` will ever write.
-///
-/// "Unfilled" is tracked by a parallel `DynamicBitSetUnmanaged` rather
-/// than a NaN sentinel in `cells`. The bitset is 1 bit per cell (memset 0
-/// = 1/64 the bandwidth of a NaN memset over the f64 backing array), so
-/// the per-gene init cost stays small even when most cells go unread —
-/// which is the common case in partition workloads, where many
-/// (gene, kset) pairs are never visited.
-const ScoreGrid = struct {
-    cells: []f64,
-    filled: std.DynamicBitSetUnmanaged,
-    v_dim: usize,
-    d_dim: usize,
-
-    fn init(allocator: std.mem.Allocator, v_dim: usize, d_dim: usize) !ScoreGrid {
-        const total = v_dim * d_dim;
-        const cells = try allocator.alloc(f64, total);
-        errdefer allocator.free(cells);
-        // Cells are intentionally NOT initialised — `filled` gates every read,
-        // so an unfilled cell is never observed.
-        const filled = try std.DynamicBitSetUnmanaged.initEmpty(allocator, total);
-        return .{ .cells = cells, .filled = filled, .v_dim = v_dim, .d_dim = d_dim };
-    }
-
-    fn deinit(self: *ScoreGrid, allocator: std.mem.Allocator) void {
-        self.filled.deinit(allocator);
-        allocator.free(self.cells);
-    }
-
-    inline fn idx(self: *const ScoreGrid, v_off: usize, d_off: usize) usize {
-        return v_off * self.d_dim + d_off;
-    }
-
-    inline fn isFilled(self: *const ScoreGrid, v_off: usize, d_off: usize) bool {
-        return self.filled.isSet(self.idx(v_off, d_off));
-    }
-
-    inline fn get(self: *const ScoreGrid, v_off: usize, d_off: usize) ?f64 {
-        const i = self.idx(v_off, d_off);
-        return if (self.filled.isSet(i)) self.cells[i] else null;
-    }
-
-    inline fn put(self: *ScoreGrid, v_off: usize, d_off: usize, score: f64) void {
-        const i = self.idx(v_off, d_off);
-        self.cells[i] = score;
-        self.filled.set(i);
-    }
-};
-
-/// Per-gene dense traceback-path grid. Mirrors `ScoreGrid` for the
-/// `DPHandler.paths` map; only allocated under the viterbi algorithm
-/// (forward leaves the gene's entry absent from the outer map).
-///
-/// "Unfilled" is tracked by a parallel `DynamicBitSetUnmanaged` so the
-/// `cells` slice can be left uninitialised — skipping a per-cell
-/// `TracebackPath.init()` over `v_dim × d_dim` cells. The same logic as
-/// `ScoreGrid`: under partition-style workloads, most cells go unread,
-/// and the prior eager init was the dominant cost.
-const PathGrid = struct {
-    cells: []TracebackPath,
-    filled: std.DynamicBitSetUnmanaged,
-    v_dim: usize,
-    d_dim: usize,
-
-    fn init(allocator: std.mem.Allocator, v_dim: usize, d_dim: usize) !PathGrid {
-        const total = v_dim * d_dim;
-        const cells = try allocator.alloc(TracebackPath, total);
-        errdefer allocator.free(cells);
-        // See `ScoreGrid.init` — `filled` gates every read, cells stay garbage
-        // until written.
-        const filled = try std.DynamicBitSetUnmanaged.initEmpty(allocator, total);
-        return .{ .cells = cells, .filled = filled, .v_dim = v_dim, .d_dim = d_dim };
-    }
-
-    fn deinit(self: *PathGrid, allocator: std.mem.Allocator) void {
-        // Walk only filled cells: unfilled cells hold uninitialised memory
-        // and `TracebackPath.deinit` would read its `path` ArrayList field.
-        var it = self.filled.iterator(.{});
-        while (it.next()) |i| self.cells[i].deinit(allocator);
-        self.filled.deinit(allocator);
-        allocator.free(self.cells);
-    }
-
-    inline fn idx(self: *const PathGrid, v_off: usize, d_off: usize) usize {
-        return v_off * self.d_dim + d_off;
-    }
-
-    inline fn getPtr(self: *PathGrid, v_off: usize, d_off: usize) ?*TracebackPath {
-        const i = self.idx(v_off, d_off);
-        return if (self.filled.isSet(i)) &self.cells[i] else null;
-    }
-
-    inline fn put(self: *PathGrid, v_off: usize, d_off: usize, path: TracebackPath) void {
-        const i = self.idx(v_off, d_off);
-        self.cells[i] = path;
-        self.filled.set(i);
-    }
-};
-
 /// Cached trellis entry. Owns the Sequences the trellis was built over.
 ///
 /// The entry itself is **heap-allocated** and the cache list holds pointers
@@ -197,29 +86,14 @@ pub const DPHandler = struct {
     /// call (item 5 of #342). `scores` owns the duped key bytes; `clear()`
     /// frees keys only when iterating `scores` to avoid a triple-free.
     scratch_cachefo: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(*TrellisEntry)),
-    /// paths_: gene → dense kset-grid of TracebackPath (only populated under
-    /// viterbi; absent in forward). Keys are borrowed (see `scratch_cachefo`
-    /// doc-block); the canonical owner is `scores`. Item 2.1 of #366: dense
-    /// grid replaces the prior `AutoHashMapUnmanaged(KSet, TracebackPath)`.
-    paths: std.StringHashMapUnmanaged(PathGrid),
-    /// scores_: gene → dense kset-grid of f64. Owns the gene-name keys shared
-    /// with `scratch_cachefo` and `paths` (item 5 of #342). Item 2.1 of #366:
-    /// dense grid replaces the prior `AutoHashMapUnmanaged(KSet, f64)`; see
-    /// `ScoreGrid` for layout and the NaN-sentinel "unfilled" semantics.
-    scores: std.StringHashMapUnmanaged(ScoreGrid),
+    /// paths_: gene → (KSet → TracebackPath). Keys are borrowed (see
+    /// `scratch_cachefo` doc-block); the canonical owner is `scores`.
+    paths: std.StringHashMapUnmanaged(std.AutoHashMapUnmanaged(KSet, TracebackPath)),
+    /// scores_: gene → (KSet → f64). Owns the gene-name keys shared with
+    /// `scratch_cachefo` and `paths` (item 5 of #342).
+    scores: std.StringHashMapUnmanaged(std.AutoHashMapUnmanaged(KSet, f64)),
     /// per_gene_support_: gene → best full-annotation log-prob
     per_gene_support: std.StringHashMapUnmanaged(f64),
-
-    /// Kgrid offsets and dimensions. Set at the top of every `run()` from
-    /// `kbounds` and used by every `ScoreGrid` / `PathGrid` allocation in
-    /// the call. Stale between `run()` calls; only the live query reads them.
-    /// Stored on the handler rather than per-grid because every grid in a
-    /// query shares the same dims, and the conversion from `KSet` to
-    /// `(v_off, d_off)` happens at every read/write site.
-    kgrid_vmin: usize,
-    kgrid_dmin: usize,
-    kgrid_v_dim: usize,
-    kgrid_d_dim: usize,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -239,21 +113,7 @@ pub const DPHandler = struct {
             .paths = .{},
             .scores = .{},
             .per_gene_support = .{},
-            .kgrid_vmin = 0,
-            .kgrid_dmin = 0,
-            .kgrid_v_dim = 0,
-            .kgrid_d_dim = 0,
         };
-    }
-
-    /// Convert a KSet to its dense-grid (v_off, d_off). Asserts the kset is
-    /// inside the current query's grid bounds — every write site routes
-    /// ksets from the `runKSet` loop, which iterates over `[vmin, vmax) ×
-    /// [dmin, dmax)`, so an out-of-bounds kset here is a programmer bug.
-    inline fn kgridOff(self: *const DPHandler, kset: KSet) struct { v: usize, d: usize } {
-        std.debug.assert(kset.v >= self.kgrid_vmin and kset.v < self.kgrid_vmin + self.kgrid_v_dim);
-        std.debug.assert(kset.d >= self.kgrid_dmin and kset.d < self.kgrid_dmin + self.kgrid_d_dim);
-        return .{ .v = kset.v - self.kgrid_vmin, .d = kset.d - self.kgrid_dmin };
     }
 
     /// Per-query scratch allocator. **Always re-derive at the use site** —
@@ -300,21 +160,18 @@ pub const DPHandler = struct {
         self.scratch_cachefo.deinit(allocator);
         self.scratch_cachefo = .{};
 
-        // Free paths. Keys are shared with `scores` (see above). Item 2.1
-        // of #366: each value is now a dense `PathGrid` rather than a
-        // `AutoHashMap`; `PathGrid.deinit` walks the dense cells, deiniting
-        // every filled traceback path.
+        // Free paths. Keys are shared with `scores` (see above).
         var pit = self.paths.iterator();
         while (pit.next()) |entry| {
+            var inner_it = entry.value_ptr.iterator();
+            while (inner_it.next()) |kv| kv.value_ptr.deinit(allocator);
             entry.value_ptr.deinit(allocator);
         }
         self.paths.deinit(allocator);
         self.paths = .{};
 
         // Free scores. This is the canonical owner of the gene-name keys
-        // shared with `scratch_cachefo` and `paths`. Item 2.1 of #366: each
-        // value is now a dense `ScoreGrid` (single backing slice) rather
-        // than an `AutoHashMap`.
+        // shared with `scratch_cachefo` and `paths`.
         var sit = self.scores.iterator();
         while (sit.next()) |entry| {
             allocator.free(entry.key_ptr.*);
@@ -446,15 +303,6 @@ pub const DPHandler = struct {
         if (kbounds.vmin == 0 or kbounds.dmin == 0 or
             kbounds.vmax <= kbounds.vmin or kbounds.dmax <= kbounds.dmin)
             return error.TrivialKBounds;
-
-        // Item 2.1 of #366: pin the dense kset-grid bounds for this query.
-        // Every `ScoreGrid` / `PathGrid` allocated under `initCache` below
-        // sizes itself against these dims, and every `kgridOff` conversion
-        // resolves against these offsets.
-        self.kgrid_vmin = kbounds.vmin;
-        self.kgrid_dmin = kbounds.dmin;
-        self.kgrid_v_dim = kbounds.vmax - kbounds.vmin;
-        self.kgrid_d_dim = kbounds.dmax - kbounds.dmin;
 
         var best_scores: std.AutoHashMapUnmanaged(KSet, f64) = .{};
         defer best_scores.deinit(allocator);
@@ -701,85 +549,47 @@ pub const DPHandler = struct {
 
         const allocator = self.scratchAllocator();
         try self.scratch_cachefo.ensureUnusedCapacity(allocator, 1);
+        try self.paths.ensureUnusedCapacity(allocator, 1);
         try self.scores.ensureUnusedCapacity(allocator, 1);
 
-        // Allocate the grids before any map insertion so a mid-init OOM
-        // can't leave `scratch_cachefo` populated while `scores` is still
-        // empty — `clear()` is the canonical key owner and would miss a
-        // dangling `scratch_cachefo` entry if the order were inverted.
-        // After this block, every `putAssumeCapacity` is infallible.
-        var grid = try ScoreGrid.init(allocator, self.kgrid_v_dim, self.kgrid_d_dim);
-        errdefer grid.deinit(allocator);
-
-        // `paths` is only populated under viterbi; in forward mode the gene's
-        // entry is left absent, so `self.paths.getPtr(gene)` returns null at
-        // every read site (`fillTrellis` path-store, `findPartialCacheMatch`
-        // cache-copy block, `getPathNames`). This matches the old behaviour
-        // where the inner `AutoHashMap` was put-but-never-populated under
-        // forward — same observable, less allocation.
-        const want_paths = std.mem.eql(u8, self.algorithm, "viterbi");
-        var path_grid: PathGrid = undefined;
-        if (want_paths) {
-            try self.paths.ensureUnusedCapacity(allocator, 1);
-            path_grid = try PathGrid.init(allocator, self.kgrid_v_dim, self.kgrid_d_dim);
-        }
-        errdefer if (want_paths) path_grid.deinit(allocator);
-
         const key = try allocator.dupe(u8, gene);
-
-        // Infallible from here: every map has its capacity reserved and the
-        // grids are constructed. No partial-state window.
         self.scratch_cachefo.putAssumeCapacity(key, .{});
-        self.scores.putAssumeCapacity(key, grid);
-        if (want_paths) self.paths.putAssumeCapacity(key, path_grid);
+        self.paths.putAssumeCapacity(key, .{});
+        self.scores.putAssumeCapacity(key, .{});
     }
 
     /// Look for a cached kset whose region sequences are a prefix of the
     /// query's per-region undigitized strings (built via `getSubSeqs`).
     /// Returns null-kset if none found.
     fn findPartialCacheMatch(self: *DPHandler, region: Region, gene: []const u8, kset: KSet) KSet {
-        const gene_scores = self.scores.getPtr(gene) orelse return KSet{ .v = 0, .d = 0 };
+        const gene_scores = self.scores.get(gene) orelse return KSet{ .v = 0, .d = 0 };
+        if (gene_scores.get(kset) != null) return kset;
 
-        // Direct hit on the requested kset — same fast-path as the prior
-        // map-based version.
-        const off = self.kgridOff(kset);
-        if (gene_scores.get(off.v, off.d) != null) return kset;
-
-        // Item 2.1 of #366. The C++ source iterated `map<KSet,double>` in
-        // ascending `(v, d)` order; the Zig `AutoHashMap` was unordered, so
-        // the prior scan hand-tracked the minimum. Both produced the same
-        // logical match; the dense scan below produces it in O(d_dim) for
-        // V-region and O(v_dim) for J-region instead of O(n_filled_ksets).
         switch (region) {
             .v => {
-                // V-region: smallest filled d at fixed v. Iterate d_off in
-                // ascending order; first non-null is the smallest-d match.
-                var d_off: usize = 0;
-                while (d_off < gene_scores.d_dim) : (d_off += 1) {
-                    if (gene_scores.get(off.v, d_off) != null) {
-                        return KSet{ .v = kset.v, .d = self.kgrid_dmin + d_off };
+                // C++ map<KSet,double> iterates in ascending (v,d) order, so
+                // it returns the smallest-d match. We must replicate that.
+                var best: ?KSet = null;
+                var it = gene_scores.iterator();
+                while (it.next()) |kv| {
+                    if (kv.key_ptr.v == kset.v) {
+                        if (best == null or kv.key_ptr.d < best.?.d)
+                            best = kv.key_ptr.*;
                     }
                 }
+                if (best) |b| return b;
             },
             .j => {
-                // J-region: among entries with v + d == target, smallest
-                // (v, d) lexicographically. On the diagonal each v has at
-                // most one d, so this is just the smallest filled v on the
-                // diagonal — iterate v_off ascending; for each, if the
-                // matching d is in-bounds and filled, return it.
-                const target = kset.v + kset.d;
-                var v_off: usize = 0;
-                while (v_off < gene_scores.v_dim) : (v_off += 1) {
-                    const v = self.kgrid_vmin + v_off;
-                    if (target < v) break; // ascending v means d would go negative from here on
-                    const d = target - v;
-                    if (d < self.kgrid_dmin) continue;
-                    const d_off_j = d - self.kgrid_dmin;
-                    if (d_off_j >= gene_scores.d_dim) continue;
-                    if (gene_scores.get(v_off, d_off_j) != null) {
-                        return KSet{ .v = v, .d = d };
+                var best: ?KSet = null;
+                var it = gene_scores.iterator();
+                while (it.next()) |kv| {
+                    if (kv.key_ptr.v + kv.key_ptr.d == kset.v + kset.d) {
+                        if (best == null or kv.key_ptr.v < best.?.v or
+                            (kv.key_ptr.v == best.?.v and kv.key_ptr.d < best.?.d))
+                            best = kv.key_ptr.*;
                     }
                 }
+                if (best) |b| return b;
             },
             .d => {},
         }
@@ -907,8 +717,7 @@ pub const DPHandler = struct {
                 try trell_ptr.traceback(allocator, &path);
             }
             if (self.paths.getPtr(gene)) |gene_paths| {
-                const off = self.kgridOff(kset);
-                gene_paths.put(off.v, off.d, path);
+                try gene_paths.put(allocator, kset, path);
             } else {
                 path.deinit(allocator);
             }
@@ -922,8 +731,7 @@ pub const DPHandler = struct {
         const final_score = mathutils.addWithMinusInfinities(uncorrected_score, gene_choice_score);
 
         if (self.scores.getPtr(gene)) |gene_scores| {
-            const off = self.kgridOff(kset);
-            gene_scores.put(off.v, off.d, final_score);
+            try gene_scores.put(allocator, kset, final_score);
         }
 
         return origin;
@@ -1183,29 +991,26 @@ pub const DPHandler = struct {
                     // Copy path and score from cached kset. Both go into
                     // `self.paths` / `self.scores`, which outlive the kset
                     // — route through `scratch`, not `allocator`.
-                    const dst_off = self.kgridOff(kset);
-                    const src_off = self.kgridOff(partial_match);
                     if (self.paths.getPtr(gene)) |gp| {
-                        if (gp.getPtr(src_off.v, src_off.d)) |cached_path| {
+                        if (gp.get(partial_match)) |cached_path| {
                             var path_copy = TracebackPath.init();
                             errdefer path_copy.deinit(scratch);
                             try path_copy.path.appendSlice(scratch, cached_path.path.items);
                             path_copy.setScore(cached_path.score);
                             path_copy.setModel(cached_path.hmm.?);
-                            gp.put(dst_off.v, dst_off.d, path_copy);
+                            try gp.put(scratch, kset, path_copy);
                         }
                     }
                     if (self.scores.getPtr(gene)) |gs| {
-                        const cached_score = gs.get(src_off.v, src_off.d) orelse mathutils.NEG_INF;
-                        gs.put(dst_off.v, dst_off.d, cached_score);
+                        const cached_score = gs.get(partial_match) orelse mathutils.NEG_INF;
+                        try gs.put(scratch, kset, cached_score);
                     }
                     origin = "cached";
                 } else {
                     origin = try self.fillTrellis(allocator, kset, &query_seqs, gene);
                 }
 
-                const off = self.kgridOff(kset);
-                const gene_score = if (self.scores.getPtr(gene)) |gs| gs.get(off.v, off.d) orelse mathutils.NEG_INF else mathutils.NEG_INF;
+                const gene_score = if (self.scores.getPtr(gene)) |gs| gs.get(kset) orelse mathutils.NEG_INF else mathutils.NEG_INF;
 
                 // Debug: per-gene viterbi output
                 if (self.args.debug == 2 and std.mem.eql(u8, self.algorithm, "viterbi")) {
@@ -1385,8 +1190,7 @@ pub const DPHandler = struct {
         allocator: std.mem.Allocator,
     ) !std.ArrayListUnmanaged([]u8) {
         const gene_paths = self.paths.getPtr(gene) orelse return .{};
-        const off = self.kgridOff(kset);
-        const path = gene_paths.getPtr(off.v, off.d) orelse return .{};
+        const path = gene_paths.getPtr(kset) orelse return .{};
         return path.nameVector(allocator);
     }
 

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -442,10 +442,11 @@ pub const DPHandler = struct {
             // Accumulate into the process-lifetime counter for Glomerator
             // attribution. dpHandler_run_total_ns gets reset() to zero on
             // the next run() entry, so we mirror it here BEFORE the reset.
-            if (perf_counters.enabled) {
+            // `comptime` so the dead-write in Debug builds collapses too.
+            if (comptime perf_counters.enabled) {
                 perf_counters.cumul_dpHandler_run_ns +%= perf_counters.dpHandler_run_total_ns;
             }
-            try self.dumpPerfCounters(&seqs);
+            if (comptime perf_counters.enabled) try self.dumpPerfCounters(&seqs);
             return result;
         }
 
@@ -481,10 +482,11 @@ pub const DPHandler = struct {
         perf_counters.addElapsed(&perf_counters.dpHandler_run_total_ns, t_run);
         // See the no-path early-return above for the rationale: mirror
         // into the process-lifetime cumul before the next reset() fires.
-        if (perf_counters.enabled) {
+        // `comptime` so the dead-write in Debug builds collapses too.
+        if (comptime perf_counters.enabled) {
             perf_counters.cumul_dpHandler_run_ns +%= perf_counters.dpHandler_run_total_ns;
         }
-        try self.dumpPerfCounters(&seqs);
+        if (comptime perf_counters.enabled) try self.dumpPerfCounters(&seqs);
         return result;
     }
 

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -51,6 +51,49 @@ const TrellisEntry = struct {
     trellis: Trellis,
 };
 
+/// Per-gene inner-map pointer bundle hoisted once at the top of
+/// `runKSet`'s per-gene loop iteration. Replaces 2-3 redundant
+/// `self.{scratch_cachefo,paths,scores}.getPtr(gene)` lookups in the
+/// gene-block body and inside `fillTrellis` with a single struct of
+/// pre-resolved pointers.
+///
+/// Honest cost framing: the lookups this hoist eliminates show as
+/// 0.00% of partition wall in the post-#380 perf-record (the
+/// `getIndex` symbols for value-types `AutoHashMapUnmanaged(KSet,
+/// TracebackPath)`, `AutoHashMapUnmanaged(KSet, f64)`, and
+/// `ArrayListUnmanaged(*TrellisEntry)` do not appear at the top of
+/// `/tmp/perf-1.1-results/partition-5k.perf.report`). The 24.63%
+/// `getIndex__anon_27622` bucket cited in the Phase A memo is
+/// HMMHolder's `[]const u8 → *Model` map only — a different value
+/// type, with one call per (gene, kset) on the cache-miss path that
+/// this hoist intentionally does NOT touch (hoisting it would add a
+/// `hmms.get` call on the cache-hit path where the original code
+/// uses `cached_path.hmm.?` instead). So this hoist is best framed
+/// as a code-clarity / dead-error-path-removal refactor; any wall
+/// improvement is in the noise.
+///
+/// Pointer-stability invariants (load-bearing):
+///   - `initCache(gene)` is the only site that grows
+///     `scratch_cachefo` / `paths` / `scores`. It runs immediately
+///     above the cache build at the top of each gene-block iteration.
+///   - Within one gene-block iteration, the outer string-keyed maps
+///     don't grow. Inner-map writes (`gp.put(scratch, kset, ...)`,
+///     `cache_list.append(allocator, entry)`, etc.) modify the inner
+///     map's internal pointers but don't relocate the outer-map
+///     value slot.
+///   - `.?` unwraps below would panic in `Debug`/`ReleaseSafe` if
+///     the invariant ever broke; `ReleaseFast` would silently UAF.
+///     The `partis-test.py --paired --safe` rung covers the
+///     `ReleaseSafe` build mode (originally added so the UAF risk
+///     of caching pointers across put-calls would surface loudly in
+///     CI). If you change the locking around `initCache` or add a
+///     new outer-map writer, also re-confirm via that rung.
+const PerGeneCache = struct {
+    cachefo: *std.ArrayListUnmanaged(*TrellisEntry),
+    paths: *std.AutoHashMapUnmanaged(KSet, TracebackPath),
+    scores: *std.AutoHashMapUnmanaged(KSet, f64),
+};
+
 /// Corresponds to C++ `ham::DPHandler`.
 pub const DPHandler = struct {
     algorithm: []const u8,
@@ -560,9 +603,10 @@ pub const DPHandler = struct {
 
     /// Look for a cached kset whose region sequences are a prefix of the
     /// query's per-region undigitized strings (built via `getSubSeqs`).
-    /// Returns null-kset if none found.
-    fn findPartialCacheMatch(self: *DPHandler, region: Region, gene: []const u8, kset: KSet) KSet {
-        const gene_scores = self.scores.get(gene) orelse return KSet{ .v = 0, .d = 0 };
+    /// Returns null-kset if none found. `gene_scores` is the per-gene
+    /// inner map hoisted by the caller (see `PerGeneCache`); replaces
+    /// the prior `self.scores.get(gene)` lookup at this site.
+    fn findPartialCacheMatch(_: *DPHandler, region: Region, gene_scores: *const std.AutoHashMapUnmanaged(KSet, f64), kset: KSet) KSet {
         if (gene_scores.get(kset) != null) return kset;
 
         switch (region) {
@@ -615,6 +659,7 @@ pub const DPHandler = struct {
         kset: KSet,
         query_seqs: *const Sequences,
         gene: []const u8,
+        gc: *const PerGeneCache,
     ) ![]const u8 {
         const allocator = self.scratchAllocator();
         perf_counters.bumpFillTrellis();
@@ -624,29 +669,25 @@ pub const DPHandler = struct {
         var cached_trellis: ?*const Trellis = null;
         if (!self.args.no_chunk_cache) {
             perf_counters.bumpChunkCacheLookup();
-            if (self.scratch_cachefo.getPtr(gene)) |cache_list| {
-                for (cache_list.items) |te| {
-                    const cached_seqs = te.query_seqs.seqs.items;
-                    const current_seqs = query_seqs.seqs.items;
-                    if (cached_seqs.len != current_seqs.len) continue;
-                    var all_match = true;
-                    for (cached_seqs, current_seqs) |*cached, *current| {
-                        // cached must START WITH current (prefix match)
-                        if (!std.mem.startsWith(u8, cached.undigitized, current.undigitized)) {
-                            all_match = false;
-                            break;
-                        }
-                    }
-                    if (all_match) {
-                        cached_trellis = &te.trellis;
-                        perf_counters.bumpChunkCacheHit();
+            for (gc.cachefo.items) |te| {
+                const cached_seqs = te.query_seqs.seqs.items;
+                const current_seqs = query_seqs.seqs.items;
+                if (cached_seqs.len != current_seqs.len) continue;
+                var all_match = true;
+                for (cached_seqs, current_seqs) |*cached, *current| {
+                    // cached must START WITH current (prefix match)
+                    if (!std.mem.startsWith(u8, cached.undigitized, current.undigitized)) {
+                        all_match = false;
                         break;
                     }
                 }
+                if (all_match) {
+                    cached_trellis = &te.trellis;
+                    perf_counters.bumpChunkCacheHit();
+                    break;
+                }
             }
         }
-
-        const model = try self.hmms.get(gene);
 
         // Match C++ DPHandler::FillTrellis logic exactly:
         //   - When no cached trellis: create scratch, store it, run algorithm ON THE SCRATCH directly.
@@ -659,6 +700,13 @@ pub const DPHandler = struct {
         // tmptrell is only used when borrowing from a cached trellis.
         var tmptrell: ?Trellis = null;
         defer if (tmptrell) |*t| t.deinit();
+
+        // Lazy model load. We do NOT hoist this into PerGeneCache: the
+        // original code only paid `hmms.get(gene)` on the cache-miss path
+        // (the cache-hit path in runKSet uses `cached_path.hmm.?` instead).
+        // Phase 0 reports cache-hit at 78–86% of ksets, so hoisting model
+        // would *add* a per-kset `hmms.get` call to that majority path.
+        const model = try self.hmms.get(gene);
 
         var origin: []const u8 = "scratch";
         const trell_ptr: *Trellis = if (cached_trellis == null) blk: {
@@ -674,20 +722,10 @@ pub const DPHandler = struct {
             entry.trellis = try Trellis.initWithSeqs(allocator, model, &entry.query_seqs, null);
             errdefer entry.trellis.deinit();
 
-            if (self.scratch_cachefo.getPtr(gene)) |cache_list| {
-                try cache_list.append(allocator, entry);
-                break :blk &entry.trellis;
-            } else {
-                // gene not in scratch_cachefo (shouldn't happen after initCache).
-                // Assert so safe builds (Debug, ReleaseSafe — including the
-                // rung-1 UAF-coverage run) panic loudly; ReleaseFast keeps
-                // the cleanup + error-return path as a defensive fallback.
-                std.debug.assert(false);
-                entry.trellis.deinit();
-                entry.query_seqs.deinit(allocator);
-                allocator.destroy(entry);
-                return error.GeneNotInScratchCache;
-            }
+            // gc.cachefo is guaranteed non-null by the caller (initCache
+            // ran before the gc was built — see PerGeneCache doc-block).
+            try gc.cachefo.append(allocator, entry);
+            break :blk &entry.trellis;
         } else blk: {
             // Have cache: temp trellis borrows from the caller's query_seqs
             // (no clone — lifetime is just this call). Backed by the per-kset
@@ -716,11 +754,7 @@ pub const DPHandler = struct {
                 // items don't capture the temp trellis's per-kset arena.
                 try trell_ptr.traceback(allocator, &path);
             }
-            if (self.paths.getPtr(gene)) |gene_paths| {
-                try gene_paths.put(allocator, kset, path);
-            } else {
-                path.deinit(allocator);
-            }
+            try gc.paths.put(allocator, kset, path);
             break :blk sc;
         } else blk: {
             try trell_ptr.forward();
@@ -730,9 +764,7 @@ pub const DPHandler = struct {
         const gene_choice_score = log(model.overall_prob);
         const final_score = mathutils.addWithMinusInfinities(uncorrected_score, gene_choice_score);
 
-        if (self.scores.getPtr(gene)) |gene_scores| {
-            try gene_scores.put(allocator, kset, final_score);
-        }
+        try gc.scores.put(allocator, kset, final_score);
 
         return origin;
     }
@@ -985,32 +1017,40 @@ pub const DPHandler = struct {
             for (sorted_genes) |gene| {
                 try self.initCache(gene);
 
+                // Hoist the three gene-keyed inner-map pointers once per
+                // gene-block. After initCache(gene), the outer string-keyed
+                // maps don't grow within this iteration so the inner-slot
+                // pointers stay stable. We deliberately do NOT hoist
+                // `self.hmms.get(gene)` — see PerGeneCache doc-block for the
+                // cache-hit-path regression rationale.
+                const gc = PerGeneCache{
+                    .cachefo = self.scratch_cachefo.getPtr(gene).?,
+                    .paths = self.paths.getPtr(gene).?,
+                    .scores = self.scores.getPtr(gene).?,
+                };
+
                 var origin: []const u8 = "";
-                const partial_match = self.findPartialCacheMatch(region, gene, kset);
+                const partial_match = self.findPartialCacheMatch(region, gc.scores, kset);
                 if (!partial_match.isNull()) {
                     // Copy path and score from cached kset. Both go into
                     // `self.paths` / `self.scores`, which outlive the kset
                     // — route through `scratch`, not `allocator`.
-                    if (self.paths.getPtr(gene)) |gp| {
-                        if (gp.get(partial_match)) |cached_path| {
-                            var path_copy = TracebackPath.init();
-                            errdefer path_copy.deinit(scratch);
-                            try path_copy.path.appendSlice(scratch, cached_path.path.items);
-                            path_copy.setScore(cached_path.score);
-                            path_copy.setModel(cached_path.hmm.?);
-                            try gp.put(scratch, kset, path_copy);
-                        }
+                    if (gc.paths.get(partial_match)) |cached_path| {
+                        var path_copy = TracebackPath.init();
+                        errdefer path_copy.deinit(scratch);
+                        try path_copy.path.appendSlice(scratch, cached_path.path.items);
+                        path_copy.setScore(cached_path.score);
+                        path_copy.setModel(cached_path.hmm.?);
+                        try gc.paths.put(scratch, kset, path_copy);
                     }
-                    if (self.scores.getPtr(gene)) |gs| {
-                        const cached_score = gs.get(partial_match) orelse mathutils.NEG_INF;
-                        try gs.put(scratch, kset, cached_score);
-                    }
+                    const cached_score = gc.scores.get(partial_match) orelse mathutils.NEG_INF;
+                    try gc.scores.put(scratch, kset, cached_score);
                     origin = "cached";
                 } else {
-                    origin = try self.fillTrellis(allocator, kset, &query_seqs, gene);
+                    origin = try self.fillTrellis(allocator, kset, &query_seqs, gene, &gc);
                 }
 
-                const gene_score = if (self.scores.getPtr(gene)) |gs| gs.get(kset) orelse mathutils.NEG_INF else mathutils.NEG_INF;
+                const gene_score = gc.scores.get(kset) orelse mathutils.NEG_INF;
 
                 // Debug: per-gene viterbi output
                 if (self.args.debug == 2 and std.mem.eql(u8, self.algorithm, "viterbi")) {

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -34,6 +34,117 @@ const GeneKSetKey = struct {
     kset: KSet,
 };
 
+/// Per-gene dense score grid over the kset rectangle. Replaces the
+/// `AutoHashMapUnmanaged(KSet, f64)` inner-map of `DPHandler.scores`
+/// (item 2.1 of #366). The C++ `map<KSet, double>` it descends from gave
+/// `findPartialCacheMatch` an `O(n_filled_ksets)` scan per call, called
+/// `n_genes × 3 × n_ksets` times per query — `O(n_genes × n_ksets²)`
+/// per query of map iteration. The dense grid replaces that with O(1)
+/// direct lookup and an `O(d_dim)` (V-region) or `O(v_dim)` (J-region)
+/// bounded scan, plus drops the per-cell HashMap pointer-chasing.
+///
+/// Layout: row-major `[v_dim * d_dim]` indexed as
+/// `idx = (k_v - kgrid_vmin) * d_dim + (k_d - kgrid_dmin)`. The query's
+/// `kbounds` pin both the offsets and the dims, so the grid covers
+/// every kset that `run()` will ever write.
+///
+/// "Unfilled" is tracked by a parallel `DynamicBitSetUnmanaged` rather
+/// than a NaN sentinel in `cells`. The bitset is 1 bit per cell (memset 0
+/// = 1/64 the bandwidth of a NaN memset over the f64 backing array), so
+/// the per-gene init cost stays small even when most cells go unread —
+/// which is the common case in partition workloads, where many
+/// (gene, kset) pairs are never visited.
+const ScoreGrid = struct {
+    cells: []f64,
+    filled: std.DynamicBitSetUnmanaged,
+    v_dim: usize,
+    d_dim: usize,
+
+    fn init(allocator: std.mem.Allocator, v_dim: usize, d_dim: usize) !ScoreGrid {
+        const total = v_dim * d_dim;
+        const cells = try allocator.alloc(f64, total);
+        errdefer allocator.free(cells);
+        // Cells are intentionally NOT initialised — `filled` gates every read,
+        // so an unfilled cell is never observed.
+        const filled = try std.DynamicBitSetUnmanaged.initEmpty(allocator, total);
+        return .{ .cells = cells, .filled = filled, .v_dim = v_dim, .d_dim = d_dim };
+    }
+
+    fn deinit(self: *ScoreGrid, allocator: std.mem.Allocator) void {
+        self.filled.deinit(allocator);
+        allocator.free(self.cells);
+    }
+
+    inline fn idx(self: *const ScoreGrid, v_off: usize, d_off: usize) usize {
+        return v_off * self.d_dim + d_off;
+    }
+
+    inline fn isFilled(self: *const ScoreGrid, v_off: usize, d_off: usize) bool {
+        return self.filled.isSet(self.idx(v_off, d_off));
+    }
+
+    inline fn get(self: *const ScoreGrid, v_off: usize, d_off: usize) ?f64 {
+        const i = self.idx(v_off, d_off);
+        return if (self.filled.isSet(i)) self.cells[i] else null;
+    }
+
+    inline fn put(self: *ScoreGrid, v_off: usize, d_off: usize, score: f64) void {
+        const i = self.idx(v_off, d_off);
+        self.cells[i] = score;
+        self.filled.set(i);
+    }
+};
+
+/// Per-gene dense traceback-path grid. Mirrors `ScoreGrid` for the
+/// `DPHandler.paths` map; only allocated under the viterbi algorithm
+/// (forward leaves the gene's entry absent from the outer map).
+///
+/// "Unfilled" is tracked by a parallel `DynamicBitSetUnmanaged` so the
+/// `cells` slice can be left uninitialised — skipping a per-cell
+/// `TracebackPath.init()` over `v_dim × d_dim` cells. The same logic as
+/// `ScoreGrid`: under partition-style workloads, most cells go unread,
+/// and the prior eager init was the dominant cost.
+const PathGrid = struct {
+    cells: []TracebackPath,
+    filled: std.DynamicBitSetUnmanaged,
+    v_dim: usize,
+    d_dim: usize,
+
+    fn init(allocator: std.mem.Allocator, v_dim: usize, d_dim: usize) !PathGrid {
+        const total = v_dim * d_dim;
+        const cells = try allocator.alloc(TracebackPath, total);
+        errdefer allocator.free(cells);
+        // See `ScoreGrid.init` — `filled` gates every read, cells stay garbage
+        // until written.
+        const filled = try std.DynamicBitSetUnmanaged.initEmpty(allocator, total);
+        return .{ .cells = cells, .filled = filled, .v_dim = v_dim, .d_dim = d_dim };
+    }
+
+    fn deinit(self: *PathGrid, allocator: std.mem.Allocator) void {
+        // Walk only filled cells: unfilled cells hold uninitialised memory
+        // and `TracebackPath.deinit` would read its `path` ArrayList field.
+        var it = self.filled.iterator(.{});
+        while (it.next()) |i| self.cells[i].deinit(allocator);
+        self.filled.deinit(allocator);
+        allocator.free(self.cells);
+    }
+
+    inline fn idx(self: *const PathGrid, v_off: usize, d_off: usize) usize {
+        return v_off * self.d_dim + d_off;
+    }
+
+    inline fn getPtr(self: *PathGrid, v_off: usize, d_off: usize) ?*TracebackPath {
+        const i = self.idx(v_off, d_off);
+        return if (self.filled.isSet(i)) &self.cells[i] else null;
+    }
+
+    inline fn put(self: *PathGrid, v_off: usize, d_off: usize, path: TracebackPath) void {
+        const i = self.idx(v_off, d_off);
+        self.cells[i] = path;
+        self.filled.set(i);
+    }
+};
+
 /// Cached trellis entry. Owns the Sequences the trellis was built over.
 ///
 /// The entry itself is **heap-allocated** and the cache list holds pointers
@@ -86,14 +197,29 @@ pub const DPHandler = struct {
     /// call (item 5 of #342). `scores` owns the duped key bytes; `clear()`
     /// frees keys only when iterating `scores` to avoid a triple-free.
     scratch_cachefo: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(*TrellisEntry)),
-    /// paths_: gene → (KSet → TracebackPath). Keys are borrowed (see
-    /// `scratch_cachefo` doc-block); the canonical owner is `scores`.
-    paths: std.StringHashMapUnmanaged(std.AutoHashMapUnmanaged(KSet, TracebackPath)),
-    /// scores_: gene → (KSet → f64). Owns the gene-name keys shared with
-    /// `scratch_cachefo` and `paths` (item 5 of #342).
-    scores: std.StringHashMapUnmanaged(std.AutoHashMapUnmanaged(KSet, f64)),
+    /// paths_: gene → dense kset-grid of TracebackPath (only populated under
+    /// viterbi; absent in forward). Keys are borrowed (see `scratch_cachefo`
+    /// doc-block); the canonical owner is `scores`. Item 2.1 of #366: dense
+    /// grid replaces the prior `AutoHashMapUnmanaged(KSet, TracebackPath)`.
+    paths: std.StringHashMapUnmanaged(PathGrid),
+    /// scores_: gene → dense kset-grid of f64. Owns the gene-name keys shared
+    /// with `scratch_cachefo` and `paths` (item 5 of #342). Item 2.1 of #366:
+    /// dense grid replaces the prior `AutoHashMapUnmanaged(KSet, f64)`; see
+    /// `ScoreGrid` for layout and the NaN-sentinel "unfilled" semantics.
+    scores: std.StringHashMapUnmanaged(ScoreGrid),
     /// per_gene_support_: gene → best full-annotation log-prob
     per_gene_support: std.StringHashMapUnmanaged(f64),
+
+    /// Kgrid offsets and dimensions. Set at the top of every `run()` from
+    /// `kbounds` and used by every `ScoreGrid` / `PathGrid` allocation in
+    /// the call. Stale between `run()` calls; only the live query reads them.
+    /// Stored on the handler rather than per-grid because every grid in a
+    /// query shares the same dims, and the conversion from `KSet` to
+    /// `(v_off, d_off)` happens at every read/write site.
+    kgrid_vmin: usize,
+    kgrid_dmin: usize,
+    kgrid_v_dim: usize,
+    kgrid_d_dim: usize,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -113,7 +239,21 @@ pub const DPHandler = struct {
             .paths = .{},
             .scores = .{},
             .per_gene_support = .{},
+            .kgrid_vmin = 0,
+            .kgrid_dmin = 0,
+            .kgrid_v_dim = 0,
+            .kgrid_d_dim = 0,
         };
+    }
+
+    /// Convert a KSet to its dense-grid (v_off, d_off). Asserts the kset is
+    /// inside the current query's grid bounds — every write site routes
+    /// ksets from the `runKSet` loop, which iterates over `[vmin, vmax) ×
+    /// [dmin, dmax)`, so an out-of-bounds kset here is a programmer bug.
+    inline fn kgridOff(self: *const DPHandler, kset: KSet) struct { v: usize, d: usize } {
+        std.debug.assert(kset.v >= self.kgrid_vmin and kset.v < self.kgrid_vmin + self.kgrid_v_dim);
+        std.debug.assert(kset.d >= self.kgrid_dmin and kset.d < self.kgrid_dmin + self.kgrid_d_dim);
+        return .{ .v = kset.v - self.kgrid_vmin, .d = kset.d - self.kgrid_dmin };
     }
 
     /// Per-query scratch allocator. **Always re-derive at the use site** —
@@ -160,18 +300,21 @@ pub const DPHandler = struct {
         self.scratch_cachefo.deinit(allocator);
         self.scratch_cachefo = .{};
 
-        // Free paths. Keys are shared with `scores` (see above).
+        // Free paths. Keys are shared with `scores` (see above). Item 2.1
+        // of #366: each value is now a dense `PathGrid` rather than a
+        // `AutoHashMap`; `PathGrid.deinit` walks the dense cells, deiniting
+        // every filled traceback path.
         var pit = self.paths.iterator();
         while (pit.next()) |entry| {
-            var inner_it = entry.value_ptr.iterator();
-            while (inner_it.next()) |kv| kv.value_ptr.deinit(allocator);
             entry.value_ptr.deinit(allocator);
         }
         self.paths.deinit(allocator);
         self.paths = .{};
 
         // Free scores. This is the canonical owner of the gene-name keys
-        // shared with `scratch_cachefo` and `paths`.
+        // shared with `scratch_cachefo` and `paths`. Item 2.1 of #366: each
+        // value is now a dense `ScoreGrid` (single backing slice) rather
+        // than an `AutoHashMap`.
         var sit = self.scores.iterator();
         while (sit.next()) |entry| {
             allocator.free(entry.key_ptr.*);
@@ -303,6 +446,15 @@ pub const DPHandler = struct {
         if (kbounds.vmin == 0 or kbounds.dmin == 0 or
             kbounds.vmax <= kbounds.vmin or kbounds.dmax <= kbounds.dmin)
             return error.TrivialKBounds;
+
+        // Item 2.1 of #366: pin the dense kset-grid bounds for this query.
+        // Every `ScoreGrid` / `PathGrid` allocated under `initCache` below
+        // sizes itself against these dims, and every `kgridOff` conversion
+        // resolves against these offsets.
+        self.kgrid_vmin = kbounds.vmin;
+        self.kgrid_dmin = kbounds.dmin;
+        self.kgrid_v_dim = kbounds.vmax - kbounds.vmin;
+        self.kgrid_d_dim = kbounds.dmax - kbounds.dmin;
 
         var best_scores: std.AutoHashMapUnmanaged(KSet, f64) = .{};
         defer best_scores.deinit(allocator);
@@ -549,47 +701,85 @@ pub const DPHandler = struct {
 
         const allocator = self.scratchAllocator();
         try self.scratch_cachefo.ensureUnusedCapacity(allocator, 1);
-        try self.paths.ensureUnusedCapacity(allocator, 1);
         try self.scores.ensureUnusedCapacity(allocator, 1);
 
+        // Allocate the grids before any map insertion so a mid-init OOM
+        // can't leave `scratch_cachefo` populated while `scores` is still
+        // empty — `clear()` is the canonical key owner and would miss a
+        // dangling `scratch_cachefo` entry if the order were inverted.
+        // After this block, every `putAssumeCapacity` is infallible.
+        var grid = try ScoreGrid.init(allocator, self.kgrid_v_dim, self.kgrid_d_dim);
+        errdefer grid.deinit(allocator);
+
+        // `paths` is only populated under viterbi; in forward mode the gene's
+        // entry is left absent, so `self.paths.getPtr(gene)` returns null at
+        // every read site (`fillTrellis` path-store, `findPartialCacheMatch`
+        // cache-copy block, `getPathNames`). This matches the old behaviour
+        // where the inner `AutoHashMap` was put-but-never-populated under
+        // forward — same observable, less allocation.
+        const want_paths = std.mem.eql(u8, self.algorithm, "viterbi");
+        var path_grid: PathGrid = undefined;
+        if (want_paths) {
+            try self.paths.ensureUnusedCapacity(allocator, 1);
+            path_grid = try PathGrid.init(allocator, self.kgrid_v_dim, self.kgrid_d_dim);
+        }
+        errdefer if (want_paths) path_grid.deinit(allocator);
+
         const key = try allocator.dupe(u8, gene);
+
+        // Infallible from here: every map has its capacity reserved and the
+        // grids are constructed. No partial-state window.
         self.scratch_cachefo.putAssumeCapacity(key, .{});
-        self.paths.putAssumeCapacity(key, .{});
-        self.scores.putAssumeCapacity(key, .{});
+        self.scores.putAssumeCapacity(key, grid);
+        if (want_paths) self.paths.putAssumeCapacity(key, path_grid);
     }
 
     /// Look for a cached kset whose region sequences are a prefix of the
     /// query's per-region undigitized strings (built via `getSubSeqs`).
     /// Returns null-kset if none found.
     fn findPartialCacheMatch(self: *DPHandler, region: Region, gene: []const u8, kset: KSet) KSet {
-        const gene_scores = self.scores.get(gene) orelse return KSet{ .v = 0, .d = 0 };
-        if (gene_scores.get(kset) != null) return kset;
+        const gene_scores = self.scores.getPtr(gene) orelse return KSet{ .v = 0, .d = 0 };
 
+        // Direct hit on the requested kset — same fast-path as the prior
+        // map-based version.
+        const off = self.kgridOff(kset);
+        if (gene_scores.get(off.v, off.d) != null) return kset;
+
+        // Item 2.1 of #366. The C++ source iterated `map<KSet,double>` in
+        // ascending `(v, d)` order; the Zig `AutoHashMap` was unordered, so
+        // the prior scan hand-tracked the minimum. Both produced the same
+        // logical match; the dense scan below produces it in O(d_dim) for
+        // V-region and O(v_dim) for J-region instead of O(n_filled_ksets).
         switch (region) {
             .v => {
-                // C++ map<KSet,double> iterates in ascending (v,d) order, so
-                // it returns the smallest-d match. We must replicate that.
-                var best: ?KSet = null;
-                var it = gene_scores.iterator();
-                while (it.next()) |kv| {
-                    if (kv.key_ptr.v == kset.v) {
-                        if (best == null or kv.key_ptr.d < best.?.d)
-                            best = kv.key_ptr.*;
+                // V-region: smallest filled d at fixed v. Iterate d_off in
+                // ascending order; first non-null is the smallest-d match.
+                var d_off: usize = 0;
+                while (d_off < gene_scores.d_dim) : (d_off += 1) {
+                    if (gene_scores.get(off.v, d_off) != null) {
+                        return KSet{ .v = kset.v, .d = self.kgrid_dmin + d_off };
                     }
                 }
-                if (best) |b| return b;
             },
             .j => {
-                var best: ?KSet = null;
-                var it = gene_scores.iterator();
-                while (it.next()) |kv| {
-                    if (kv.key_ptr.v + kv.key_ptr.d == kset.v + kset.d) {
-                        if (best == null or kv.key_ptr.v < best.?.v or
-                            (kv.key_ptr.v == best.?.v and kv.key_ptr.d < best.?.d))
-                            best = kv.key_ptr.*;
+                // J-region: among entries with v + d == target, smallest
+                // (v, d) lexicographically. On the diagonal each v has at
+                // most one d, so this is just the smallest filled v on the
+                // diagonal — iterate v_off ascending; for each, if the
+                // matching d is in-bounds and filled, return it.
+                const target = kset.v + kset.d;
+                var v_off: usize = 0;
+                while (v_off < gene_scores.v_dim) : (v_off += 1) {
+                    const v = self.kgrid_vmin + v_off;
+                    if (target < v) break; // ascending v means d would go negative from here on
+                    const d = target - v;
+                    if (d < self.kgrid_dmin) continue;
+                    const d_off_j = d - self.kgrid_dmin;
+                    if (d_off_j >= gene_scores.d_dim) continue;
+                    if (gene_scores.get(v_off, d_off_j) != null) {
+                        return KSet{ .v = v, .d = d };
                     }
                 }
-                if (best) |b| return b;
             },
             .d => {},
         }
@@ -717,7 +907,8 @@ pub const DPHandler = struct {
                 try trell_ptr.traceback(allocator, &path);
             }
             if (self.paths.getPtr(gene)) |gene_paths| {
-                try gene_paths.put(allocator, kset, path);
+                const off = self.kgridOff(kset);
+                gene_paths.put(off.v, off.d, path);
             } else {
                 path.deinit(allocator);
             }
@@ -731,7 +922,8 @@ pub const DPHandler = struct {
         const final_score = mathutils.addWithMinusInfinities(uncorrected_score, gene_choice_score);
 
         if (self.scores.getPtr(gene)) |gene_scores| {
-            try gene_scores.put(allocator, kset, final_score);
+            const off = self.kgridOff(kset);
+            gene_scores.put(off.v, off.d, final_score);
         }
 
         return origin;
@@ -991,26 +1183,29 @@ pub const DPHandler = struct {
                     // Copy path and score from cached kset. Both go into
                     // `self.paths` / `self.scores`, which outlive the kset
                     // — route through `scratch`, not `allocator`.
+                    const dst_off = self.kgridOff(kset);
+                    const src_off = self.kgridOff(partial_match);
                     if (self.paths.getPtr(gene)) |gp| {
-                        if (gp.get(partial_match)) |cached_path| {
+                        if (gp.getPtr(src_off.v, src_off.d)) |cached_path| {
                             var path_copy = TracebackPath.init();
                             errdefer path_copy.deinit(scratch);
                             try path_copy.path.appendSlice(scratch, cached_path.path.items);
                             path_copy.setScore(cached_path.score);
                             path_copy.setModel(cached_path.hmm.?);
-                            try gp.put(scratch, kset, path_copy);
+                            gp.put(dst_off.v, dst_off.d, path_copy);
                         }
                     }
                     if (self.scores.getPtr(gene)) |gs| {
-                        const cached_score = gs.get(partial_match) orelse mathutils.NEG_INF;
-                        try gs.put(scratch, kset, cached_score);
+                        const cached_score = gs.get(src_off.v, src_off.d) orelse mathutils.NEG_INF;
+                        gs.put(dst_off.v, dst_off.d, cached_score);
                     }
                     origin = "cached";
                 } else {
                     origin = try self.fillTrellis(allocator, kset, &query_seqs, gene);
                 }
 
-                const gene_score = if (self.scores.getPtr(gene)) |gs| gs.get(kset) orelse mathutils.NEG_INF else mathutils.NEG_INF;
+                const off = self.kgridOff(kset);
+                const gene_score = if (self.scores.getPtr(gene)) |gs| gs.get(off.v, off.d) orelse mathutils.NEG_INF else mathutils.NEG_INF;
 
                 // Debug: per-gene viterbi output
                 if (self.args.debug == 2 and std.mem.eql(u8, self.algorithm, "viterbi")) {
@@ -1190,7 +1385,8 @@ pub const DPHandler = struct {
         allocator: std.mem.Allocator,
     ) !std.ArrayListUnmanaged([]u8) {
         const gene_paths = self.paths.getPtr(gene) orelse return .{};
-        const path = gene_paths.getPtr(kset) orelse return .{};
+        const off = self.kgridOff(kset);
+        const path = gene_paths.getPtr(off.v, off.d) orelse return .{};
         return path.nameVector(allocator);
     }
 

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -14,6 +14,7 @@ const Model = @import("model.zig").Model;
 const Sequences = @import("sequences.zig").Sequences;
 const Sequence = @import("sequences.zig").Sequence;
 const mathutils = @import("mathutils.zig");
+const perf_counters = @import("perf_counters.zig");
 const Args = @import("args.zig").Args;
 const bcr = @import("bcr_utils/root.zig");
 const GermLines = bcr.GermLines;
@@ -234,6 +235,11 @@ pub const DPHandler = struct {
         const parent = self.parent_allocator;
         const run_start = std.time.milliTimestamp();
 
+        // Phase-0 diagnostics (#366): per-query counter reset. No-op when
+        // `-Dperf-counters=false` (default), so the bit-equal default build
+        // is unaffected.
+        perf_counters.reset();
+
         // Build a Sequences container that borrows from `seqvector`.
         // Each Sequence is a shallow struct-copy: slice headers are duplicated,
         // but the underlying name/header/undigitized/seqq buffers are shared
@@ -337,6 +343,7 @@ pub const DPHandler = struct {
                     n_too_long += 1;
                 } else {
                     const kset = KSet{ .v = k_v, .d = k_d };
+                    perf_counters.bumpKSet();
                     try self.runKSet(&seqs, kset, &only_genes, &best_scores, &total_scores, &best_genes);
                     n_run += 1;
                     const total_kset = total_scores.get(kset) orelse mathutils.NEG_INF;
@@ -382,6 +389,7 @@ pub const DPHandler = struct {
             if (!self.args.dont_rescale_emissions) {
                 try self.hmms.unRescaleOverallMuteFreqs(&only_genes);
             }
+            try self.dumpPerfCounters(&seqs);
             return result;
         }
 
@@ -414,7 +422,75 @@ pub const DPHandler = struct {
             try self.hmms.unRescaleOverallMuteFreqs(&only_genes);
         }
 
+        try self.dumpPerfCounters(&seqs);
         return result;
+    }
+
+    /// Phase-0 diagnostics dump (#366). No-op when `-Dperf-counters=false`.
+    /// Emits one PERFCOUNTER and one PERFCOUNTER_CACHE line per query.
+    ///
+    /// Output target: file path from `PARTIS_ZIG_PERF_LOG` env var (append).
+    /// Side-channel rather than stdout because partis captures bcrham stdout
+    /// and discards everything except recognised dbgstrs (utils.py:5896+);
+    /// the env-var redirect keeps the diagnostic output entirely outside
+    /// the partis input/output protocol so partis-test.py's parity checks
+    /// stay clean. When the env var is unset, the dump is silent.
+    fn dumpPerfCounters(self: *DPHandler, seqs: *const Sequences) !void {
+        if (!perf_counters.enabled) return;
+        const allocator = self.scratchAllocator();
+
+        const log_path = std.process.getEnvVarOwned(allocator, "PARTIS_ZIG_PERF_LOG") catch |err| switch (err) {
+            error.EnvironmentVariableNotFound => return,
+            else => return err,
+        };
+        defer allocator.free(log_path);
+
+        const name_str = try seqs.nameStr(allocator, ":");
+        defer allocator.free(name_str);
+
+        // cache_list length histogram across all genes in scratch_cachefo.
+        // Buckets are log-ish (0,1,2,3,4,5,[6-9],[10-19],[20-49],[50-99],
+        // [100-199],[200+]) — matches the order-of-magnitude questions the
+        // issue asks about chunk-cache state.
+        var buckets = [_]u64{0} ** 12;
+        var it = self.scratch_cachefo.iterator();
+        while (it.next()) |entry| {
+            const n = entry.value_ptr.items.len;
+            const idx: usize =
+                if (n == 0) 0 else if (n == 1) 1 else if (n == 2) 2 else if (n == 3) 3 else if (n == 4) 4 else if (n == 5) 5 else if (n < 10) 6 else if (n < 20) 7 else if (n < 50) 8 else if (n < 100) 9 else if (n < 200) 10 else 11;
+            buckets[idx] += 1;
+        }
+
+        // Build the PERFCOUNTER + PERFCOUNTER_CACHE block in one buffer
+        // and emit with a single writeAll. With multiple bcrham processes
+        // appending to the same log (`partis --n-procs N > 1`), splitting
+        // this into two writes would let another process slip a line
+        // between ours, separating the pair. Concatenated, the two lines
+        // share one O_APPEND atomic write.
+        const main_line = (try perf_counters.formatPerfCounters(allocator, self.algorithm, name_str, seqs.seqs.items.len)) orelse return;
+        defer allocator.free(main_line);
+        const cache_line = try std.fmt.allocPrint(
+            allocator,
+            "PERFCOUNTER_CACHE alg={s} q={s} 0={d} 1={d} 2={d} 3={d} 4={d} 5={d} 6_9={d} 10_19={d} 20_49={d} 50_99={d} 100_199={d} 200p={d}\n",
+            .{ self.algorithm, name_str, buckets[0], buckets[1], buckets[2], buckets[3], buckets[4], buckets[5], buckets[6], buckets[7], buckets[8], buckets[9], buckets[10], buckets[11] },
+        );
+        defer allocator.free(cache_line);
+        const blob = try std.mem.concat(allocator, u8, &.{ main_line, cache_line });
+        defer allocator.free(blob);
+
+        // O_APPEND on regular files: Linux serializes the
+        // seek-to-end-and-write pair at the syscall level, so each
+        // writeAll lands as one atomic append regardless of size — there
+        // is no PIPE_BUF-style upper bound for regular files. (PIPE_BUF
+        // applies to pipes, not files.) Concurrent bcrham processes
+        // therefore can't interleave the bytes of a single writeAll.
+        const log_path_z = try allocator.dupeZ(u8, log_path);
+        defer allocator.free(log_path_z);
+        const flags: std.posix.O = .{ .ACCMODE = .WRONLY, .APPEND = true, .CREAT = true };
+        const fd = try std.posix.openZ(log_path_z, flags, 0o644);
+        const file = std.fs.File{ .handle = fd };
+        defer file.close();
+        try file.writeAll(blob);
     }
 
     /// Get subsequences for one region.
@@ -541,11 +617,13 @@ pub const DPHandler = struct {
         gene: []const u8,
     ) ![]const u8 {
         const allocator = self.scratchAllocator();
+        perf_counters.bumpFillTrellis();
 
         // Look for a chunk-cached trellis. Prefix-match is on undigitized
         // strings of the cached trellis's stored query_seqs.
         var cached_trellis: ?*const Trellis = null;
         if (!self.args.no_chunk_cache) {
+            perf_counters.bumpChunkCacheLookup();
             if (self.scratch_cachefo.getPtr(gene)) |cache_list| {
                 for (cache_list.items) |te| {
                     const cached_seqs = te.query_seqs.seqs.items;
@@ -561,6 +639,7 @@ pub const DPHandler = struct {
                     }
                     if (all_match) {
                         cached_trellis = &te.trellis;
+                        perf_counters.bumpChunkCacheHit();
                         break;
                     }
                 }

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -282,6 +282,12 @@ pub const DPHandler = struct {
         // `-Dperf-counters=false` (default), so the bit-equal default build
         // is unaffected.
         perf_counters.reset();
+        // Phase-B outer-perimeter timer: total time inside this run() body
+        // (excluding the reset() above). Tick AFTER reset so reset doesn't
+        // wipe it. Read in `dumpPerfCounters` via a final `addElapsed` at
+        // each exit point that dumps; non-dumping early returns leak the
+        // tick but contribute zero work.
+        const t_run = perf_counters.tick();
 
         // Build a Sequences container that borrows from `seqvector`.
         // Each Sequence is a shallow struct-copy: slice headers are duplicated,
@@ -432,6 +438,13 @@ pub const DPHandler = struct {
             if (!self.args.dont_rescale_emissions) {
                 try self.hmms.unRescaleOverallMuteFreqs(&only_genes);
             }
+            perf_counters.addElapsed(&perf_counters.dpHandler_run_total_ns, t_run);
+            // Accumulate into the process-lifetime counter for Glomerator
+            // attribution. dpHandler_run_total_ns gets reset() to zero on
+            // the next run() entry, so we mirror it here BEFORE the reset.
+            if (perf_counters.enabled) {
+                perf_counters.cumul_dpHandler_run_ns +%= perf_counters.dpHandler_run_total_ns;
+            }
             try self.dumpPerfCounters(&seqs);
             return result;
         }
@@ -465,6 +478,12 @@ pub const DPHandler = struct {
             try self.hmms.unRescaleOverallMuteFreqs(&only_genes);
         }
 
+        perf_counters.addElapsed(&perf_counters.dpHandler_run_total_ns, t_run);
+        // See the no-path early-return above for the rationale: mirror
+        // into the process-lifetime cumul before the next reset() fires.
+        if (perf_counters.enabled) {
+            perf_counters.cumul_dpHandler_run_ns +%= perf_counters.dpHandler_run_total_ns;
+        }
         try self.dumpPerfCounters(&seqs);
         return result;
     }
@@ -504,12 +523,13 @@ pub const DPHandler = struct {
             buckets[idx] += 1;
         }
 
-        // Build the PERFCOUNTER + PERFCOUNTER_CACHE block in one buffer
-        // and emit with a single writeAll. With multiple bcrham processes
-        // appending to the same log (`partis --n-procs N > 1`), splitting
-        // this into two writes would let another process slip a line
-        // between ours, separating the pair. Concatenated, the two lines
-        // share one O_APPEND atomic write.
+        // Build the PERFCOUNTER + PERFCOUNTER_CACHE + PERFCOUNTER_TIMING
+        // block in one buffer and emit with a single writeAll. With
+        // multiple bcrham processes appending to the same log
+        // (`partis --n-procs N > 1`), splitting this into multiple writes
+        // would let another process slip a line between ours, separating
+        // the trio. Concatenated, all three share one O_APPEND atomic
+        // write.
         const main_line = (try perf_counters.formatPerfCounters(allocator, self.algorithm, name_str, seqs.seqs.items.len)) orelse return;
         defer allocator.free(main_line);
         const cache_line = try std.fmt.allocPrint(
@@ -518,7 +538,9 @@ pub const DPHandler = struct {
             .{ self.algorithm, name_str, buckets[0], buckets[1], buckets[2], buckets[3], buckets[4], buckets[5], buckets[6], buckets[7], buckets[8], buckets[9], buckets[10], buckets[11] },
         );
         defer allocator.free(cache_line);
-        const blob = try std.mem.concat(allocator, u8, &.{ main_line, cache_line });
+        const timing_line = (try perf_counters.formatPerfCountersTiming(allocator, self.algorithm, name_str, seqs.seqs.items.len)) orelse return;
+        defer allocator.free(timing_line);
+        const blob = try std.mem.concat(allocator, u8, &.{ main_line, cache_line, timing_line });
         defer allocator.free(blob);
 
         // O_APPEND on regular files: Linux serializes the
@@ -663,12 +685,19 @@ pub const DPHandler = struct {
     ) ![]const u8 {
         const allocator = self.scratchAllocator();
         perf_counters.bumpFillTrellis();
+        // Phase-B: time the whole fillTrellis body so we can divide the
+        // chunkScan/init/tmpInit/viterbi/forward/traceback/put numbers by
+        // their parent total instead of by bcrham wall (which includes
+        // runKSet overhead and the cache-hit path).
+        const t_total = perf_counters.tick();
+        defer perf_counters.addElapsed(&perf_counters.fillTrellis_total_ns, t_total);
 
         // Look for a chunk-cached trellis. Prefix-match is on undigitized
         // strings of the cached trellis's stored query_seqs.
         var cached_trellis: ?*const Trellis = null;
         if (!self.args.no_chunk_cache) {
             perf_counters.bumpChunkCacheLookup();
+            const t_scan = perf_counters.tick();
             for (gc.cachefo.items) |te| {
                 const cached_seqs = te.query_seqs.seqs.items;
                 const current_seqs = query_seqs.seqs.items;
@@ -687,6 +716,7 @@ pub const DPHandler = struct {
                     break;
                 }
             }
+            perf_counters.addElapsed(&perf_counters.fillTrellis_chunkScan_ns, t_scan);
         }
 
         // Match C++ DPHandler::FillTrellis logic exactly:
@@ -715,6 +745,7 @@ pub const DPHandler = struct {
             // from the entry's heap address, so `trellis.seqs = &entry.query_seqs`
             // stays valid across cache_list appends (which only move the *entry
             // pointers in the list, not the entries themselves).
+            const t_init = perf_counters.tick();
             const entry = try allocator.create(TrellisEntry);
             errdefer allocator.destroy(entry);
             entry.query_seqs = try query_seqs.clone(allocator);
@@ -725,6 +756,7 @@ pub const DPHandler = struct {
             // gc.cachefo is guaranteed non-null by the caller (initCache
             // ran before the gc was built — see PerGeneCache doc-block).
             try gc.cachefo.append(allocator, entry);
+            perf_counters.addElapsed(&perf_counters.fillTrellis_init_ns, t_init);
             break :blk &entry.trellis;
         } else blk: {
             // Have cache: temp trellis borrows from the caller's query_seqs
@@ -737,14 +769,18 @@ pub const DPHandler = struct {
             // The path items below are explicitly routed through `allocator`
             // (per-query scratch), not `kset_alloc`, since they're stored in
             // `self.paths` and outlive the kset. (Item 4, #342.)
+            const t_tmpInit = perf_counters.tick();
             tmptrell = try Trellis.initWithSeqs(kset_alloc, model, query_seqs, cached_trellis);
+            perf_counters.addElapsed(&perf_counters.fillTrellis_tmpInit_ns, t_tmpInit);
             origin = "chunk";
             break :blk &tmptrell.?;
         };
 
         // Run the algorithm on trell_ptr
         const uncorrected_score: f64 = if (std.mem.eql(u8, self.algorithm, "viterbi")) blk: {
+            const t_vit = perf_counters.tick();
             try trell_ptr.viterbi();
+            perf_counters.addElapsed(&perf_counters.fillTrellis_viterbi_ns, t_vit);
             const sc = trell_ptr.ending_viterbi_log_prob;
             // Store traceback path
             var path = TracebackPath.initWithModel(model);
@@ -752,19 +788,27 @@ pub const DPHandler = struct {
             if (sc != mathutils.NEG_INF) {
                 // Explicitly pass `allocator` (per-query scratch) so the path's
                 // items don't capture the temp trellis's per-kset arena.
+                const t_tb = perf_counters.tick();
                 try trell_ptr.traceback(allocator, &path);
+                perf_counters.addElapsed(&perf_counters.fillTrellis_traceback_ns, t_tb);
             }
+            const t_put_p = perf_counters.tick();
             try gc.paths.put(allocator, kset, path);
+            perf_counters.addElapsed(&perf_counters.fillTrellis_put_ns, t_put_p);
             break :blk sc;
         } else blk: {
+            const t_fwd = perf_counters.tick();
             try trell_ptr.forward();
+            perf_counters.addElapsed(&perf_counters.fillTrellis_forward_ns, t_fwd);
             break :blk trell_ptr.ending_forward_log_prob;
         };
 
         const gene_choice_score = log(model.overall_prob);
         const final_score = mathutils.addWithMinusInfinities(uncorrected_score, gene_choice_score);
 
+        const t_put_s = perf_counters.tick();
         try gc.scores.put(allocator, kset, final_score);
+        perf_counters.addElapsed(&perf_counters.fillTrellis_put_ns, t_put_s);
 
         return origin;
     }
@@ -909,6 +953,13 @@ pub const DPHandler = struct {
         total_scores: *std.AutoHashMapUnmanaged(KSet, f64),
         best_genes: *std.AutoHashMapUnmanaged(KSet, std.AutoHashMapUnmanaged(Region, []u8)),
     ) !void {
+        // Phase-B outer-perimeter: time the full runKSet body. Pair with
+        // fillTrellis_total_ns + cachedPath_ns to expose runKSet plumbing
+        // (sorted_genes, findPartialCacheMatch, regional_total updates,
+        // per-region sub-seq clones, debug output) as the residual.
+        const t_kset = perf_counters.tick();
+        defer perf_counters.addElapsed(&perf_counters.runKSet_total_ns, t_kset);
+
         const scratch = self.scratchAllocator();
         var kset_arena = std.heap.ArenaAllocator.init(self.parent_allocator);
         defer kset_arena.deinit();
@@ -1032,6 +1083,10 @@ pub const DPHandler = struct {
                 var origin: []const u8 = "";
                 const partial_match = self.findPartialCacheMatch(region, gc.scores, kset);
                 if (!partial_match.isNull()) {
+                    // Phase-B: time the cache-hit path so we can compare it
+                    // to fillTrellis_total_ns. Excludes findPartialCacheMatch
+                    // above (which runs on both branches).
+                    const t_cached = perf_counters.tick();
                     // Copy path and score from cached kset. Both go into
                     // `self.paths` / `self.scores`, which outlive the kset
                     // — route through `scratch`, not `allocator`.
@@ -1046,6 +1101,7 @@ pub const DPHandler = struct {
                     const cached_score = gc.scores.get(partial_match) orelse mathutils.NEG_INF;
                     try gc.scores.put(scratch, kset, cached_score);
                     origin = "cached";
+                    perf_counters.addElapsed(&perf_counters.cachedPath_ns, t_cached);
                 } else {
                     origin = try self.fillTrellis(allocator, kset, &query_seqs, gene, &gc);
                 }

--- a/packages/zig-core/src/ham/emission.zig
+++ b/packages/zig-core/src/ham/emission.zig
@@ -79,14 +79,14 @@ pub const Emission = struct {
 
     /// Replace log probs (for mute-freq rescaling).
     /// Corresponds to C++ `void ReplaceLogProbs(vector<double>)`.
-    pub fn replaceLogProbs(self: *Emission, allocator: std.mem.Allocator, new_log_probs: []const f64) !void {
-        try self.scores.replaceLogProbs(allocator, new_log_probs);
+    pub fn replaceLogProbs(self: *Emission, new_log_probs: []const f64) !void {
+        try self.scores.replaceLogProbs(new_log_probs);
     }
 
     /// Revert to original log probs.
     /// Corresponds to C++ `void UnReplaceLogProbs()`.
-    pub fn unReplaceLogProbs(self: *Emission, allocator: std.mem.Allocator) void {
-        self.scores.unReplaceLogProbs(allocator);
+    pub fn unReplaceLogProbs(self: *Emission) void {
+        self.scores.unReplaceLogProbs();
     }
 
     /// Score (log-probability) for a digitized symbol index.

--- a/packages/zig-core/src/ham/fast_math.c
+++ b/packages/zig-core/src/ham/fast_math.c
@@ -1,0 +1,80 @@
+/* fast_math.c — fast log-sum-exp via tabulated softplus.
+ *
+ * Drop-in replacement for the `log(1 + exp(d))` work in AddInLogSpace
+ * (mathutils.h:98). Replaces 1 log + 1 exp glibc call (~5–17 ns combined,
+ * arch-dependent) with a single 65 K-entry linear-interpolation lookup
+ * (~3.5–10 ns per call).
+ *
+ * Pre-flight measurements at issue #366 item 3.2:
+ *   - Zen 5 (glibc 2.39): glibc 9.6 ns → LUT64K 7.3 ns per addInLogSpace
+ *   - Broadwell:          glibc 16.7 ns → LUT64K 10.0 ns
+ *   - LUT64K accuracy: max abs error 6.5e-9 over [-30, 0] (5 orders under
+ *     the partis-test 1e-5 gate).
+ *
+ * Why a 65 K linear-interp table:
+ *   The Cephes scalar polynomial alternative (~7-15 ns) loses to modern
+ *   glibc's FMA-optimized scalar log/exp on every CPU we tested. LUT
+ *   wins because it replaces ~10 ALU ops + branches with a single load
+ *   + 1 multiply + 1 fma. Smaller LUTs (256, 4 K, 16 K) fail the worst-
+ *   case error budget; LUT64K passes by 4×. Cubic interp at 1 K entries
+ *   would also pass speed-wise but not accuracy-wise.
+ *
+ * The linear-interp arithmetic dominates over the table size in cycle
+ * count (LUT256 ≈ LUT64K on every benchmarked CPU), so going larger is
+ * effectively free as long as the hot region stays cache-resident — and
+ * it does, because real DP traffic concentrates near d = 0.
+ *
+ * Built with -O3 -ffp-contract=off so that the linear-interp arithmetic
+ * is bit-deterministic across g++/clang/zig from the same C source.
+ * (Without that flag, cross-compiler drift would be 1–2 ULP — far under
+ * the partis-test gate, but bit-equality between backends is cheap to
+ * keep so we keep it.)
+ *
+ * Mirrored on the Zig side at packages/zig-core/src/ham/fast_math.c.
+ * Both sides MUST stay in sync; the table is data so cross-backend
+ * parity is trivial as long as the same source compiles to both.
+ */
+#include <math.h>
+
+/* Range of d for which the table covers softplus(d) = log(1 + exp(d))
+ * directly. Outside this range, we use the closed-form fall-throughs:
+ *   d < LUT_LO:  exp(d) is well under double precision, softplus ≈ 0.
+ *   d > 0:       use the symmetry softplus(d) = d + softplus(-d).
+ *
+ * Within addInLogSpace's standard form (see mathutils.h AddInLogSpace),
+ * the argument is always (smaller - larger) ≤ 0. The d > 0 branch is
+ * defensive — should not be exercised in practice, but keeps the
+ * function safe to call independently.
+ */
+#define LUT_N  65536
+#define LUT_LO -30.0
+#define LUT_HI 0.0
+
+static double softplus_lut[LUT_N + 1];
+
+/* (LUT_N / |LUT_LO|) precomputed for the index calculation. Using a
+ * macro keeps it a compile-time constant, which the compiler can fold
+ * into the multiply at the call site. */
+#define LUT_SCALE ((double) LUT_N / -(LUT_LO))
+
+__attribute__((constructor))
+static void init_softplus_lut(void) {
+    /* log1p(exp(d)) is the numerically stable form of log(1 + exp(d))
+     * for the table-build phase. Build is one-shot at process start. */
+    for (int i = 0; i <= LUT_N; ++i) {
+        double d = LUT_LO + (LUT_HI - LUT_LO) * (double) i / (double) LUT_N;
+        softplus_lut[i] = log1p(exp(d));
+    }
+}
+
+double fast_softplus(double d) {
+    if (d < LUT_LO) return 0.0;
+    if (d > 0.0)    return d + fast_softplus(-d);   /* symmetry */
+    /* d ∈ [LUT_LO, 0] — index in [0, LUT_N] */
+    double t = (d - LUT_LO) * LUT_SCALE;
+    int i = (int) t;
+    double frac = t - (double) i;
+    double y0 = softplus_lut[i];
+    double y1 = softplus_lut[i + 1];
+    return y0 + frac * (y1 - y0);
+}

--- a/packages/zig-core/src/ham/fast_math.c
+++ b/packages/zig-core/src/ham/fast_math.c
@@ -73,6 +73,14 @@ double fast_softplus(double d) {
     /* d ∈ [LUT_LO, 0] — index in [0, LUT_N] */
     double t = (d - LUT_LO) * LUT_SCALE;
     int i = (int) t;
+    /* Clamp `i` so `i+1` stays in bounds. At d == 0 (or d so close to 0
+     * that float rounding gives t == LUT_N), the unclamped i would equal
+     * LUT_N and the `softplus_lut[i+1]` read would be one past the array.
+     * The production result was correct only because `frac == 0` masked
+     * the OOB read; Debug-mode bounds checks fired. With the clamp,
+     * frac becomes 1.0 at the boundary and y0 + 1.0*(y1-y0) = y1 =
+     * softplus_lut[LUT_N], identical to the unclamped value. */
+    if (i >= LUT_N) i = LUT_N - 1;
     double frac = t - (double) i;
     double y0 = softplus_lut[i];
     double y1 = softplus_lut[i + 1];

--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -44,6 +44,16 @@ pub const Glomerator = struct {
     initial_partition: Partition,
 
     /// All actual sequences, keyed by sequence name.
+    ///
+    /// Write-once during `init`; **frozen** thereafter (no inserts, no
+    /// removals, no replacements). Per issue #342 items 6 and 16, every
+    /// other `Query.seqs` in the glomerator stores `*const Sequence`
+    /// pointers into this map's value slots. Mutating this map post-init
+    /// (or growing it past its `ensureTotalCapacity` bound during init)
+    /// can rehash and invalidate those pointers — `init` populates this
+    /// map fully in a first pass before any cachefo Query is built.
+    /// Adding any write to this map outside `init` requires reworking
+    /// the borrowed-Sequence contract (see Query struct doc).
     single_seqs: std.StringHashMapUnmanaged(Sequence),
     /// Single-sequence cache entries.
     single_seq_cachefo: std.StringHashMapUnmanaged(Query),
@@ -135,6 +145,28 @@ pub const Glomerator = struct {
 
         try self.readCacheFile();
 
+        // Pass 1: populate `single_seqs` fully. Item 16 stores `*const Sequence`
+        // pointers into this map's value slots in `single_seq_cachefo` and
+        // `cachefo` `Query.seqs`; those pointers must be taken only after the
+        // map is stable, since `put` on a growing map can rehash and invalidate
+        // pointers returned by earlier `getPtr` calls.
+        var total_seqs: usize = 0;
+        for (qry_seq_lists) |seq_list| total_seqs += seq_list.len;
+        try self.single_seqs.ensureTotalCapacity(allocator, @intCast(total_seqs));
+        for (qry_seq_lists) |seq_list| {
+            for (seq_list) |*sq| {
+                if (self.single_seqs.contains(sq.name)) continue;
+                const name_key = try allocator.dupe(u8, sq.name);
+                errdefer allocator.free(name_key);
+                var cloned = try sq.clone(allocator);
+                errdefer cloned.deinit(allocator);
+                try self.single_seqs.put(allocator, name_key, cloned);
+            }
+        }
+
+        // Pass 2: build cachefo / single_seq_cachefo / initial_partition.
+        // `single_seqs` is now frozen; `getPtr` results are stable for the
+        // remaining lifetime of the Glomerator.
         for (qry_seq_lists, 0..) |seq_list, iqry| {
             // Build the colon-separated key for this query group
             var names: std.ArrayListUnmanaged([]const u8) = .{};
@@ -144,17 +176,6 @@ pub const Glomerator = struct {
             }
             const key = try ham_text.joinStrings(allocator, names.items, ":");
             defer allocator.free(key);
-
-            // Stash all sequences in single_seqs
-            for (seq_list) |*sq| {
-                const name_key = try allocator.dupe(u8, sq.name);
-                errdefer allocator.free(name_key);
-                if (!self.single_seqs.contains(name_key)) {
-                    try self.single_seqs.put(allocator, name_key, try sq.clone(allocator));
-                } else {
-                    allocator.free(name_key);
-                }
-            }
 
             // Build bounds from args queries
             const qrow = &args.queries.items[iqry];
@@ -174,52 +195,41 @@ pub const Glomerator = struct {
                 try only_genes.append(allocator, g);
             }
 
-            // Build single_seq_cachefo entries
-            const names_in_key = try splitName(allocator, key);
-            defer {
-                for (names_in_key.items) |n| allocator.free(n);
-                var nl = names_in_key;
-                nl.deinit(allocator);
-            }
-            for (names_in_key.items) |uid| {
-                if (!self.single_seq_cachefo.contains(uid)) {
-                    const uid_seqs = try self.getSeqs(uid);
-                    defer {
-                        for (uid_seqs.items) |*sq| sq.deinit(allocator);
-                        var s = uid_seqs;
-                        s.deinit(allocator);
-                    }
-                    const is_seed_missing = !ham_text.inString(args.seed_unique_id, uid, ":");
-                    var uid_q = try Query.create(
-                        allocator,
-                        uid,
-                        uid_seqs.items,
-                        is_seed_missing,
-                        only_genes.items,
-                        kbounds,
-                        @floatCast(qrow.mut_freq),
-                        @intCast(@max(0, qrow.cdr3_length)),
-                        null, null,
-                    );
-                    errdefer uid_q.deinit(allocator);
-                    const uid_key = try allocator.dupe(u8, uid);
-                    errdefer allocator.free(uid_key);
-                    try self.single_seq_cachefo.put(allocator, uid_key, uid_q);
-                }
+            // Build single_seq_cachefo entries. `key` outlives this block, so
+            // we iterate splitScalar without duping the names (item 16).
+            var key_iter = std.mem.splitScalar(u8, key, ':');
+            while (key_iter.next()) |uid| {
+                if (uid.len == 0) continue;
+                if (self.single_seq_cachefo.contains(uid)) continue;
+                const sq_ptr = self.single_seqs.getPtr(uid) orelse return error.SequenceNotFound;
+                const uid_seq_ptrs = [_]*const Sequence{sq_ptr};
+                const is_seed_missing = !ham_text.inString(args.seed_unique_id, uid, ":");
+                var uid_q = try Query.create(
+                    allocator,
+                    uid,
+                    &uid_seq_ptrs,
+                    is_seed_missing,
+                    only_genes.items,
+                    kbounds,
+                    @floatCast(qrow.mut_freq),
+                    @intCast(@max(0, qrow.cdr3_length)),
+                    null, null,
+                );
+                errdefer uid_q.deinit(allocator);
+                const uid_key = try allocator.dupe(u8, uid);
+                errdefer allocator.free(uid_key);
+                try self.single_seq_cachefo.put(allocator, uid_key, uid_q);
             }
 
             // Build cachefo entry for the full query group
-            const key_seqs = try self.getSeqs(key);
-            defer {
-                for (key_seqs.items) |*ks| ks.deinit(allocator);
-                var ksl = key_seqs;
-                ksl.deinit(allocator);
-            }
+            var key_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
+            defer key_seq_ptrs.deinit(allocator);
+            try self.appendSeqPtrsForQuery(&key_seq_ptrs, allocator, key);
             const is_seed_missing = !ham_text.inString(args.seed_unique_id, key, ":");
             var q = try Query.create(
                 allocator,
                 key,
-                key_seqs.items,
+                key_seq_ptrs.items,
                 is_seed_missing,
                 only_genes.items,
                 kbounds,
@@ -244,17 +254,22 @@ pub const Glomerator = struct {
         for (self.initial_partition.items) |s| allocator.free(s);
         self.initial_partition.deinit(allocator);
 
-        // Free single_seqs
+        // Free Query maps before single_seqs: Query.seqs borrows from
+        // single_seqs (items 6 and 16 — `*const Sequence` pointers into the
+        // map's value slots). Query.deinit no longer touches Sequence values,
+        // so the order is not load-bearing for correctness, but freeing
+        // borrowers before owners keeps the invariant explicit.
+        freeQueryMap(allocator, &self.single_seq_cachefo);
+        freeQueryMap(allocator, &self.cachefo);
+        freeQueryMap(allocator, &self.tmp_cachefo);
+
+        // Free single_seqs (the unique owner of Sequence buffers).
         var ssit = self.single_seqs.iterator();
         while (ssit.next()) |e| {
             allocator.free(e.key_ptr.*);
             e.value_ptr.deinit(allocator);
         }
         self.single_seqs.deinit(allocator);
-
-        freeQueryMap(allocator, &self.single_seq_cachefo);
-        freeQueryMap(allocator, &self.cachefo);
-        freeQueryMap(allocator, &self.tmp_cachefo);
 
         freeStringF64Map(allocator, &self.log_probs);
         freeStringF64Map(allocator, &self.naive_hfracs);
@@ -422,7 +437,10 @@ pub const Glomerator = struct {
             return;
         }
 
-        const content = try std.fs.cwd().readFileAlloc(allocator, self.args.input_cachefname, 256 * 1024 * 1024);
+        // 4 GiB cap accommodates collision-heavy paired runs (e.g. 50k all-singleton
+        // events) where the partition cache grows past 256 MiB. Not a memory guard —
+        // if RSS is genuinely tight the program will OOM regardless.
+        const content = try std.fs.cwd().readFileAlloc(allocator, self.args.input_cachefname, 4 * 1024 * 1024 * 1024);
         defer allocator.free(content);
 
         var line_iter = std.mem.splitScalar(u8, content, '\n');
@@ -732,6 +750,10 @@ pub const Glomerator = struct {
         }
         self.tmp_cachefo.clearRetainingCapacity();
 
+        // Issue #342 item 7: parents p1 and p2 are no longer in the partition;
+        // drop their entries from the per-cluster and pair-keyed scoring caches.
+        try self.pruneMergedParentCaches(p1, p2);
+
         // Check if we're done
         const new_size = path.currentPartition().items.len;
         const new_largest = largestClusterSize(path.currentPartition());
@@ -785,7 +807,7 @@ pub const Glomerator = struct {
         const only_genes_slice = try self.geneListToSlice(cacheref.only_genes.items);
         defer self.allocator.free(only_genes_slice);
 
-        var result = try dph.run(cacheref.seqs.items, cacheref.kbounds, only_genes_slice, cacheref.mute_freq, true);
+        var result = try dph.run(cacheref.seqs, cacheref.kbounds, only_genes_slice, cacheref.mute_freq, true);
         defer result.deinit();
 
         if (result.no_path) {
@@ -836,6 +858,7 @@ pub const Glomerator = struct {
         }
 
         const lr_key = try self.allocator.dupe(u8, joint_name);
+        errdefer self.allocator.free(lr_key);
         try self.lratios.put(self.allocator, lr_key, lratio);
         return lratio;
     }
@@ -902,7 +925,7 @@ pub const Glomerator = struct {
         const only_genes_slice = try self.geneListToSlice(cacheref.only_genes.items);
         defer self.allocator.free(only_genes_slice);
 
-        var result = try dph.run(cacheref.seqs.items, cacheref.kbounds, only_genes_slice, cacheref.mute_freq, true);
+        var result = try dph.run(cacheref.seqs, cacheref.kbounds, only_genes_slice, cacheref.mute_freq, true);
         defer result.deinit();
 
         if (result.no_path) {
@@ -957,6 +980,7 @@ pub const Glomerator = struct {
 
         const hf = try self.calculateHfrac(ns_a, ns_b);
         const jk = try self.allocator.dupe(u8, joint_key);
+        errdefer self.allocator.free(jk);
         try self.naive_hfracs.put(self.allocator, jk, hf);
         return hf;
     }
@@ -1110,7 +1134,10 @@ pub const Glomerator = struct {
         if (self.cachefo.getPtr(queries)) |q| return q;
         if (self.tmp_cachefo.getPtr(queries)) |q| return q;
 
-        // Build on the fly from single_seq_cachefo
+        // Build on the fly from single_seq_cachefo. Single splitScalar pass
+        // over `queries` (item 16): the same iteration drives only_gene_set
+        // / kbounds / mute_freq and the seqs-pointer list, with no name dupes
+        // and no intermediate ArrayList from a separate getSeqs call.
         var only_gene_set: std.StringHashMapUnmanaged(void) = .{};
         defer {
             var it = only_gene_set.iterator();
@@ -1122,21 +1149,21 @@ pub const Glomerator = struct {
         var mute_freq_total: f64 = 0.0;
         var cdr3_length: usize = 0;
 
-        const names = try splitName(self.allocator, queries);
-        defer {
-            for (names.items) |n| self.allocator.free(n);
-            var nl = names;
-            nl.deinit(self.allocator);
-        }
+        var key_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
+        defer key_seq_ptrs.deinit(self.allocator);
+        try key_seq_ptrs.ensureUnusedCapacity(self.allocator, @intCast(countMembers(queries)));
 
-        for (names.items, 0..) |uid, is| {
+        var n_names: usize = 0;
+        var name_it = std.mem.splitScalar(u8, queries, ':');
+        while (name_it.next()) |uid| {
+            if (uid.len == 0) continue;
             const scache = self.single_seq_cachefo.getPtr(uid) orelse return error.MissingSeqCache;
             for (scache.only_genes.items) |g| {
                 if (!only_gene_set.contains(g)) {
                     try only_gene_set.put(self.allocator, try self.allocator.dupe(u8, g), {});
                 }
             }
-            if (is == 0) {
+            if (n_names == 0) {
                 kbounds = scache.kbounds;
                 cdr3_length = scache.cdr3_length;
             } else {
@@ -1144,7 +1171,16 @@ pub const Glomerator = struct {
                 if (cdr3_length != scache.cdr3_length) return error.Cdr3LengthMismatch;
             }
             mute_freq_total += scache.mute_freq;
+
+            const sq_ptr = self.single_seqs.getPtr(uid) orelse return error.SequenceNotFound;
+            key_seq_ptrs.appendAssumeCapacity(sq_ptr);
+            n_names += 1;
         }
+        // Defensive: an all-colon `queries` would yield no non-empty parts and
+        // would otherwise produce NaN from the mute_freq division below. Real
+        // cluster keys derive from non-empty UIDs, so this is not reachable on
+        // valid input — but the explicit error is cheaper than tracing NaN.
+        if (n_names == 0) return error.MissingSeqCache;
 
         var only_genes_list: std.ArrayListUnmanaged([]const u8) = .{};
         defer only_genes_list.deinit(self.allocator);
@@ -1161,21 +1197,15 @@ pub const Glomerator = struct {
             }
         }.lessThan);
 
-        const key_seqs = try self.getSeqs(queries);
-        defer {
-            var ks = key_seqs;
-            ks.deinit(self.allocator);
-        }
-
         const is_seed_missing = !ham_text.inString(self.args.seed_unique_id, queries, ":");
         var new_q = try Query.create(
             self.allocator,
             queries,
-            key_seqs.items,
+            key_seq_ptrs.items,
             is_seed_missing,
             only_genes_list.items,
             kbounds,
-            @floatCast(mute_freq_total / @as(f64, @floatFromInt(names.items.len))),
+            @floatCast(mute_freq_total / @as(f64, @floatFromInt(n_names))),
             cdr3_length,
             null, null,
         );
@@ -1243,17 +1273,14 @@ pub const Glomerator = struct {
         const joint_mute_freq: f32 = @floatCast((n_a_f64 * @as(f64, ref_a.mute_freq) + n_b_f64 * @as(f64, ref_b.mute_freq)) / n_total_f64);
         const is_seed_missing = !ham_text.inString(self.args.seed_unique_id, joint_name, ":");
 
-        const key_seqs = try self.getSeqs(joint_name);
-        defer {
-            for (key_seqs.items) |*ks| ks.deinit(self.allocator);
-            var ksl = key_seqs;
-            ksl.deinit(self.allocator);
-        }
+        var key_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
+        defer key_seq_ptrs.deinit(self.allocator);
+        try self.appendSeqPtrsForQuery(&key_seq_ptrs, self.allocator, joint_name);
 
         var q = try Query.create(
             self.allocator,
             joint_name,
-            key_seqs.items,
+            key_seq_ptrs.items,
             is_seed_missing,
             genes_list.items,
             joint_kbounds,
@@ -1428,16 +1455,14 @@ pub const Glomerator = struct {
         // merge cascade truncation) must be used for consistency with C++.
         const cacheref = try self.getCachefo(queries);
         {
-            const sub_seqs = try self.getSeqs(subqueries);
-            defer {
-                var ss = sub_seqs;
-                ss.deinit(self.allocator);
-            }
+            var sub_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
+            defer sub_seq_ptrs.deinit(self.allocator);
+            try self.appendSeqPtrsForQuery(&sub_seq_ptrs, self.allocator, subqueries);
             const is_seed_missing = !ham_text.inString(self.args.seed_unique_id, subqueries, ":");
             var sub_q = try Query.create(
                 self.allocator,
                 subqueries,
-                sub_seqs.items,
+                sub_seq_ptrs.items,
                 is_seed_missing,
                 cacheref.only_genes.items,
                 cacheref.kbounds,
@@ -1566,16 +1591,14 @@ pub const Glomerator = struct {
             try self.cachefo.put(self.allocator, key, val);
         } else {
             const supercache = try self.getCachefo(superquery);
-            const key_seqs = try self.getSeqs(translated_query);
-            defer {
-                var ks = key_seqs;
-                ks.deinit(self.allocator);
-            }
+            var key_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
+            defer key_seq_ptrs.deinit(self.allocator);
+            try self.appendSeqPtrsForQuery(&key_seq_ptrs, self.allocator, translated_query);
             const is_seed_missing = !ham_text.inString(self.args.seed_unique_id, translated_query, ":");
             var q = try Query.create(
                 self.allocator,
                 translated_query,
-                key_seqs.items,
+                key_seq_ptrs.items,
                 is_seed_missing,
                 supercache.only_genes.items,
                 supercache.kbounds,
@@ -1592,43 +1615,112 @@ pub const Glomerator = struct {
 
     // ── Utility helpers ───────────────────────────────────────────────────────
 
-    /// C++: Glomerator::GetSeqs() — glomerator.cc:850
-    fn getSeqs(self: *Glomerator, query: []const u8) !std.ArrayListUnmanaged(Sequence) {
-        const names = try splitName(self.allocator, query);
-        defer {
-            for (names.items) |n| self.allocator.free(n);
-            var nl = names;
-            nl.deinit(self.allocator);
-        }
-
-        var result: std.ArrayListUnmanaged(Sequence) = .{};
-        errdefer {
-            for (result.items) |*sq| sq.deinit(self.allocator);
-            result.deinit(self.allocator);
-        }
-        for (names.items) |uid| {
+    /// Append `*const Sequence` pointers into `single_seqs` to `dst`, one per
+    /// colon-separated UID in `query`. Iterates `splitScalar` directly — no
+    /// per-name `dupe`, no intermediate ArrayList. The pointed-to Sequences
+    /// must outlive any consumer that holds these pointers.
+    /// C++: corresponds to the `Glomerator::GetSeqs()` callers' inline build
+    /// pattern (glomerator.cc:850 + the lookup loop in cachefo()).
+    /// Issue #342, items 6 + 16.
+    fn appendSeqPtrsForQuery(
+        self: *Glomerator,
+        dst: *std.ArrayListUnmanaged(*const Sequence),
+        allocator: std.mem.Allocator,
+        query: []const u8,
+    ) !void {
+        try dst.ensureUnusedCapacity(allocator, @intCast(countMembers(query)));
+        var it = std.mem.splitScalar(u8, query, ':');
+        while (it.next()) |uid| {
+            if (uid.len == 0) continue;
             const sq = self.single_seqs.getPtr(uid) orelse return error.SequenceNotFound;
-            try result.append(self.allocator, try sq.clone(self.allocator));
+            dst.appendAssumeCapacity(sq);
         }
-        return result;
     }
 
     /// C++: Glomerator::AddFailedQuery() — glomerator.cc:776
     fn addFailedQuery(self: *Glomerator, queries: []const u8, error_str: []const u8) !void {
-        const key = try self.allocator.dupe(u8, queries);
-        errdefer self.allocator.free(key);
+        // Reserve capacity up-front so the puts below are infallible. This lets
+        // every fallible allocation happen under errdefer protection, and the
+        // ownership transfer to the maps stays atomic.
+        try self.errors.ensureUnusedCapacity(self.allocator, 1);
+        try self.failed_queries.ensureUnusedCapacity(self.allocator, 1);
 
-        // Append error string
+        const fq_key = try self.allocator.dupe(u8, queries);
+        errdefer self.allocator.free(fq_key);
+
+        const errors_key = try self.allocator.dupe(u8, queries);
+        errdefer self.allocator.free(errors_key);
+
         const old_err = self.errors.get(queries) orelse "";
         const new_err = try std.fmt.allocPrint(self.allocator, "{s}:{s}", .{ old_err, error_str });
         errdefer self.allocator.free(new_err);
 
-        if (self.errors.fetchRemove(key)) |old| {
+        if (self.errors.fetchRemove(queries)) |old| {
             self.allocator.free(old.key);
             self.allocator.free(old.value);
         }
-        try self.errors.put(self.allocator, try self.allocator.dupe(u8, queries), new_err);
-        try self.failed_queries.put(self.allocator, key, {});
+        self.errors.putAssumeCapacity(errors_key, new_err);
+        self.failed_queries.putAssumeCapacity(fq_key, {});
+    }
+
+    // ── Cache pruning after merge (issue #342, item 7) ────────────────────────
+
+    /// True iff `key` is a pair-key (joinNames result, "name1:name2") with `parent`
+    /// occupying one whole side. Anchors at colon boundaries to avoid substring
+    /// false positives between distinct UID names (e.g. "u1" vs "u11").
+    fn keyHasParent(key: []const u8, parent: []const u8) bool {
+        if (key.len <= parent.len) return false;
+        if (std.mem.startsWith(u8, key, parent) and key[parent.len] == ':') return true;
+        // key[key.len - parent.len - 1] is the byte immediately before the suffix match
+        // (i.e. the colon separator). The bounds check above guarantees this is in range.
+        if (std.mem.endsWith(u8, key, parent) and key[key.len - parent.len - 1] == ':') return true;
+        return false;
+    }
+
+    /// Drop a single-cluster-keyed entry, freeing the duped key (and the duped value
+    /// when V == []u8). The `if (V == []u8)` branch is comptime-evaluated.
+    fn pruneSingleKey(self: *Glomerator, comptime V: type, map: *std.StringHashMapUnmanaged(V), key: []const u8) void {
+        if (map.fetchRemove(key)) |kv| {
+            self.allocator.free(kv.key);
+            if (V == []u8) self.allocator.free(kv.value);
+        }
+    }
+
+    /// Drop every pair-keyed f64 entry whose key has p1 or p2 as one whole side.
+    /// Two-pass to avoid invalidating the map iterator: collect dead keys first,
+    /// then fetchRemove + free.
+    fn pruneParentPairsF64(self: *Glomerator, map: *std.StringHashMapUnmanaged(f64), p1: []const u8, p2: []const u8) !void {
+        var dead_keys: std.ArrayListUnmanaged([]const u8) = .{};
+        defer dead_keys.deinit(self.allocator);
+        var it = map.iterator();
+        while (it.next()) |e| {
+            const k = e.key_ptr.*;
+            if (keyHasParent(k, p1) or keyHasParent(k, p2)) {
+                try dead_keys.append(self.allocator, k);
+            }
+        }
+        for (dead_keys.items) |k| {
+            if (map.fetchRemove(k)) |kv| self.allocator.free(kv.key);
+        }
+    }
+
+    /// After a merge of (p1, p2) → AB, drop entries that are now unreachable:
+    ///   - log_probs[p1], log_probs[p2]
+    ///   - naive_seqs[p1], naive_seqs[p2]      (NOT naive_seqs[AB] — that's live)
+    ///   - errors[p1], errors[p2]
+    ///   - lratios[K] / naive_hfracs[K] for every K = joinNames(p1, _) or joinNames(p2, _)
+    /// Cachefo / single_seqs / single_seq_cachefo are intentionally retained
+    /// (translation lookup paths). initial_* are read-only ingest-time guards
+    /// for `--only-cache-new-vals` and must not be touched.
+    fn pruneMergedParentCaches(self: *Glomerator, p1: []const u8, p2: []const u8) !void {
+        self.pruneSingleKey(f64, &self.log_probs, p1);
+        self.pruneSingleKey(f64, &self.log_probs, p2);
+        self.pruneSingleKey([]u8, &self.naive_seqs, p1);
+        self.pruneSingleKey([]u8, &self.naive_seqs, p2);
+        self.pruneSingleKey([]u8, &self.errors, p1);
+        self.pruneSingleKey([]u8, &self.errors, p2);
+        try self.pruneParentPairsF64(&self.lratios, p1, p2);
+        try self.pruneParentPairsF64(&self.naive_hfracs, p1, p2);
     }
 
     /// C++: Glomerator::JoinNames() — glomerator.cc:404
@@ -1802,7 +1894,7 @@ fn cloneQuery(allocator: std.mem.Allocator, q: *const Query) !Query {
     return Query.create(
         allocator,
         q.name,
-        q.seqs.items,
+        q.seqs,
         q.seed_missing,
         q.only_genes.items,
         q.kbounds,

--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -828,8 +828,11 @@ pub const Glomerator = struct {
         self.tmp_cachefo.clearRetainingCapacity();
 
         // Issue #342 item 7: parents p1 and p2 are no longer in the partition;
-        // drop their entries from the per-cluster and pair-keyed scoring caches.
-        try self.pruneMergedParentCaches(p1, p2);
+        // drop their entries from the pair-keyed lratios cache. Narrowed to
+        // lratios only in #387 to preserve zig/cpp cache-file parity — cpp
+        // keeps log_probs, naive_seqs, errors, and naive_hfracs until process
+        // exit and writes them to hmm_cached_info.csv.
+        try self.pruneMergedLratios(p1, p2);
 
         // Check if we're done
         const new_size = path.currentPartition().items.len;
@@ -1783,23 +1786,16 @@ pub const Glomerator = struct {
         }
     }
 
-    /// After a merge of (p1, p2) → AB, drop entries that are now unreachable:
-    ///   - log_probs[p1], log_probs[p2]
-    ///   - naive_seqs[p1], naive_seqs[p2]      (NOT naive_seqs[AB] — that's live)
-    ///   - errors[p1], errors[p2]
-    ///   - lratios[K] / naive_hfracs[K] for every K = joinNames(p1, _) or joinNames(p2, _)
-    /// Cachefo / single_seqs / single_seq_cachefo are intentionally retained
-    /// (translation lookup paths). initial_* are read-only ingest-time guards
-    /// for `--only-cache-new-vals` and must not be touched.
-    fn pruneMergedParentCaches(self: *Glomerator, p1: []const u8, p2: []const u8) !void {
-        self.pruneSingleKey(f64, &self.log_probs, p1);
-        self.pruneSingleKey(f64, &self.log_probs, p2);
-        self.pruneSingleKey([]u8, &self.naive_seqs, p1);
-        self.pruneSingleKey([]u8, &self.naive_seqs, p2);
-        self.pruneSingleKey([]u8, &self.errors, p1);
-        self.pruneSingleKey([]u8, &self.errors, p2);
+    /// After a merge of (p1, p2) → AB, drop pair-keyed lratios[K] for every
+    /// K = joinNames(p1, _) or joinNames(p2, _). lratios is compute-only and
+    /// never persisted to the cache file (see partis/utils.py:955), so this
+    /// prune is a free memory win without affecting cache-file parity with
+    /// cpp. The other post-merge maps (log_probs, naive_seqs, errors,
+    /// naive_hfracs) are *not* pruned here: cpp keeps them until process exit
+    /// and writes them to hmm_cached_info.csv, and pruning them on the zig
+    /// side caused the cache-file divergence reported in issue #387.
+    fn pruneMergedLratios(self: *Glomerator, p1: []const u8, p2: []const u8) !void {
         try self.pruneParentPairsF64(&self.lratios, p1, p2);
-        try self.pruneParentPairsF64(&self.naive_hfracs, p1, p2);
     }
 
     /// C++: Glomerator::JoinNames() — glomerator.cc:404

--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -211,7 +211,7 @@ pub const Glomerator = struct {
                     is_seed_missing,
                     only_genes.items,
                     kbounds,
-                    @floatCast(qrow.mut_freq),
+                    qrow.mut_freq,
                     @intCast(@max(0, qrow.cdr3_length)),
                     null, null,
                 );
@@ -233,7 +233,7 @@ pub const Glomerator = struct {
                 is_seed_missing,
                 only_genes.items,
                 kbounds,
-                @floatCast(qrow.mut_freq),
+                qrow.mut_freq,
                 @intCast(@max(0, qrow.cdr3_length)),
                 null, null,
             );
@@ -344,7 +344,7 @@ pub const Glomerator = struct {
     /// Run full hierarchical clustering and write output.
     /// Corresponds to C++ `Glomerator::Cluster`.
     pub fn cluster(self: *Glomerator) !void {
-        if (self.args.logprob_ratio_threshold == -std.math.inf(f32)) {
+        if (self.args.logprob_ratio_threshold == -std.math.inf(f64)) {
             return error.LogprobRatioThresholdNotSet;
         }
 
@@ -1214,7 +1214,7 @@ pub const Glomerator = struct {
             is_seed_missing,
             only_genes_list.items,
             kbounds,
-            @floatCast(mute_freq_total / @as(f64, @floatFromInt(n_names))),
+            mute_freq_total / @as(f64, @floatFromInt(n_names)),
             cdr3_length,
             null, null,
         );
@@ -1279,7 +1279,7 @@ pub const Glomerator = struct {
         const n_a_f64: f64 = @floatFromInt(ref_a.nSeqs());
         const n_b_f64: f64 = @floatFromInt(ref_b.nSeqs());
         const n_total_f64: f64 = n_a_f64 + n_b_f64;
-        const joint_mute_freq: f32 = @floatCast((n_a_f64 * @as(f64, ref_a.mute_freq) + n_b_f64 * @as(f64, ref_b.mute_freq)) / n_total_f64);
+        const joint_mute_freq: f64 = (n_a_f64 * ref_a.mute_freq + n_b_f64 * ref_b.mute_freq) / n_total_f64;
         const is_seed_missing = !ham_text.inString(self.args.seed_unique_id, joint_name, ":");
 
         var key_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
@@ -1460,8 +1460,10 @@ pub const Glomerator = struct {
         // C++ caches the subset in tmp_cachefo_ using the parent cluster's attributes
         // (only_genes, kbounds, mute_freq, cdr3_length). This is important because
         // later getCachefo() calls for the subset will find this entry instead of
-        // rebuilding from singles, and the parent's mute_freq (which carries f32
-        // merge cascade truncation) must be used for consistency with C++.
+        // rebuilding from singles, so the parent's mute_freq (the weighted-average
+        // value carried through the merge cascade) must be used for consistency
+        // with C++. Pre-#377 both backends stored mute_freq as f32, so the cascade
+        // also accumulated f32 truncation; #377 promoted both to f64.
         const cacheref = try self.getCachefo(queries);
         {
             var sub_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};

--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -468,10 +468,17 @@ pub const Glomerator = struct {
             }
 
             if (logprob_str.len > 0) {
-                // C++ uses stof() which parses to float32 then widens to double.
-                // We must match that precision loss.
-                const val32: f32 = std.fmt.parseFloat(f32, logprob_str) catch continue;
-                const val: f64 = @as(f64, val32);
+                // C++ uses stod() (since ham f41e055 "fix precision: stof→stod for cache reads"):
+                // log_probs_ is map<string,double> and the cache file is written with setprecision(20).
+                // Parse as f64 to preserve full precision (the previous f32 truncation drove the
+                // 30k Zig-vs-C++ partition divergence — issue #375).
+                // `catch` warns and skips: a corrupted/truncated cache line shouldn't kill the
+                // run, but it should be visible. Cache files written with setprecision(20) are
+                // valid ASCII decimal so this should not fire under normal operation.
+                const val: f64 = std.fmt.parseFloat(f64, logprob_str) catch |e| {
+                    std.debug.print("WARN cache logprob parse failed for {s}: {} (skipping)\n", .{ query, e });
+                    continue;
+                };
                 const gop_lp = try self.log_probs.getOrPut(allocator, query);
                 if (!gop_lp.found_existing) gop_lp.key_ptr.* = try allocator.dupe(u8, query);
                 gop_lp.value_ptr.* = val;
@@ -480,9 +487,11 @@ pub const Glomerator = struct {
             }
 
             if (naive_hfrac_str.len > 0) {
-                // C++ uses stof() which parses to float32 then widens to double.
-                const val32: f32 = std.fmt.parseFloat(f32, naive_hfrac_str) catch continue;
-                const val: f64 = @as(f64, val32);
+                // C++ uses stod() (see logprob branch above).
+                const val: f64 = std.fmt.parseFloat(f64, naive_hfrac_str) catch |e| {
+                    std.debug.print("WARN cache naive_hfrac parse failed for {s}: {} (skipping)\n", .{ query, e });
+                    continue;
+                };
                 const gop_nh = try self.naive_hfracs.getOrPut(allocator, query);
                 if (!gop_nh.found_existing) gop_nh.key_ptr.* = try allocator.dupe(u8, query);
                 gop_nh.value_ptr.* = val;

--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -15,6 +15,7 @@ const Partition = @import("../cluster_path.zig").Partition;
 const Sequence = @import("../sequences.zig").Sequence;
 const mathutils = @import("../mathutils.zig");
 const ham_text = @import("../text.zig");
+const perf_counters = @import("../perf_counters.zig");
 const bcr = @import("../bcr_utils/root.zig");
 const GermLines = bcr.GermLines;
 const HMMHolder = bcr.HMMHolder;
@@ -30,6 +31,54 @@ fn sortPartition(part: *Partition) void {
             return std.mem.order(u8, a, b) == .lt;
         }
     }.lessThan);
+}
+
+/// Phase-B': emit one `PERFCOUNTER_GLOMERATOR` line to `PARTIS_ZIG_PERF_LOG`
+/// at the end of `cluster()` / `cacheNaiveSeqs()`. Pairs with the per-query
+/// `PERFCOUNTER_TIMING` lines from `DPHandler.run()` to expose Glomerator
+/// driver overhead. `kind` is `"cluster"` or `"cacheNaiveSeqs"` so the
+/// aggregator can keep the two modes separate. No-op when counters off or
+/// when the env var is unset (same gate as `dumpPerfCounters`).
+///
+/// Returns `!void` so the caller can choose how to handle failure. Callers
+/// in this module use a defer with `catch reportGlomeratorCountersError`
+/// (below) — they can't propagate via `defer` anyway, so the lowest-noise
+/// useful behavior is to print a one-line diagnostic to stderr instead of
+/// silently dropping the dump. (Advisory from PR #383 review.)
+fn dumpGlomeratorCounters(allocator: std.mem.Allocator, kind: []const u8) !void {
+    if (!perf_counters.enabled) return;
+    const log_path = std.process.getEnvVarOwned(allocator, "PARTIS_ZIG_PERF_LOG") catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => return,
+        else => return err,
+    };
+    defer allocator.free(log_path);
+
+    const line = try std.fmt.allocPrint(
+        allocator,
+        "PERFCOUNTER_GLOMERATOR kind={s} glomerator_total_ns={d} cumul_dpHandler_run_ns={d}\n",
+        .{ kind, perf_counters.glomerator_ns, perf_counters.cumul_dpHandler_run_ns },
+    );
+    defer allocator.free(line);
+
+    const log_path_z = try allocator.dupeZ(u8, log_path);
+    defer allocator.free(log_path_z);
+    const flags: std.posix.O = .{ .ACCMODE = .WRONLY, .APPEND = true, .CREAT = true };
+    const fd = try std.posix.openZ(log_path_z, flags, 0o644);
+    const file = std.fs.File{ .handle = fd };
+    defer file.close();
+    try file.writeAll(line);
+}
+
+/// Stderr-only diagnostic for the defer-catch path. We can't surface
+/// errors via `defer` so the best we can do is leave a breadcrumb when
+/// the perf log was requested but unwritable (wrong path, permissions,
+/// disk full). Silent under the env-var-unset path because that case
+/// returns early from `dumpGlomeratorCounters` itself.
+fn reportGlomeratorCountersError(err: anyerror) void {
+    std.debug.print(
+        "warning: failed to write PERFCOUNTER_GLOMERATOR line to $PARTIS_ZIG_PERF_LOG: {s}\n",
+        .{@errorName(err)},
+    );
 }
 
 /// Corresponds to C++ `ham::Glomerator`.
@@ -344,6 +393,18 @@ pub const Glomerator = struct {
     /// Run full hierarchical clustering and write output.
     /// Corresponds to C++ `Glomerator::Cluster`.
     pub fn cluster(self: *Glomerator) !void {
+        // Phase-B' outer-most timer: total wall in Glomerator.cluster(),
+        // including the merge loop, writePartitions, writeCacheFile, and
+        // setup. Pairs with `cumul_dpHandler_run_ns` to expose Glomerator
+        // driver overhead (merge decisions, partition I/O) as the
+        // residual. Dumped at end of this function via dumpGlomeratorCounters.
+        //
+        // Defer order is LIFO: the dump (registered first) runs LAST, so
+        // it sees the addElapsed-updated counter. Reversing these two
+        // defers would dump a stale 0.
+        const t_glom = perf_counters.tick();
+        defer dumpGlomeratorCounters(self.allocator, "cluster") catch |err| reportGlomeratorCountersError(err);
+        defer perf_counters.addElapsed(&perf_counters.glomerator_ns, t_glom);
         if (self.args.logprob_ratio_threshold == -std.math.inf(f64)) {
             return error.LogprobRatioThresholdNotSet;
         }
@@ -396,6 +457,13 @@ pub const Glomerator = struct {
     /// Cache all naive sequences.
     /// Corresponds to C++ `Glomerator::CacheNaiveSeqs`.
     pub fn cacheNaiveSeqs(self: *Glomerator) !void {
+        // Phase-B' outer-most timer (same as cluster() above): cover the
+        // whole CacheNaiveSeqs path, including writeCacheFile. Defer
+        // order is LIFO — dump registered first runs last, so it sees the
+        // updated counter (see cluster() above for the rationale).
+        const t_glom = perf_counters.tick();
+        defer dumpGlomeratorCounters(self.allocator, "cacheNaiveSeqs") catch |err| reportGlomeratorCountersError(err);
+        defer perf_counters.addElapsed(&perf_counters.glomerator_ns, t_glom);
         try std.fs.File.stdout().writeAll("      caching all naive sequences\n");
         // Sort keys to match C++ map<string,...> iteration order
         const sorted_keys = try self.allocator.alloc([]const u8, self.cachefo.count());

--- a/packages/zig-core/src/ham/glomerator/query.zig
+++ b/packages/zig-core/src/ham/glomerator/query.zig
@@ -8,10 +8,17 @@ const Sequence = @import("../sequences.zig").Sequence;
 const KBounds = @import("../bcr_utils/k_bounds.zig").KBounds;
 
 /// Corresponds to C++ `ham::Query`.
+///
+/// Sequence ownership (issue #342, items 6 and 16): `seqs` holds **borrowed**
+/// `*const Sequence` pointers into buffers owned by `Glomerator.single_seqs`.
+/// The Query must not outlive the Glomerator that owns those buffers, and
+/// `Query.deinit` must not call `Sequence.deinit` on the pointed-to values —
+/// only the pointer slice itself is owned.
 pub const Query = struct {
     name: []u8,
-    /// Owned copies of sequences belonging to this query/cluster.
-    seqs: std.ArrayListUnmanaged(Sequence),
+    /// Borrowed pointers into `Glomerator.single_seqs`. Allocated as a single
+    /// slice at create-time; never grown. Must not be deinit'd per-item.
+    seqs: []*const Sequence,
     seed_missing: bool,
     only_genes: std.ArrayListUnmanaged([]u8),
     kbounds: KBounds,
@@ -24,7 +31,7 @@ pub const Query = struct {
         _ = allocator;
         return Query{
             .name = &.{},
-            .seqs = .{},
+            .seqs = &.{},
             .seed_missing = false,
             .only_genes = .{},
             .kbounds = .{},
@@ -34,11 +41,13 @@ pub const Query = struct {
         };
     }
 
-    /// Create a fully-specified Query.
+    /// Create a fully-specified Query. `seqs` is borrowed: each pointer is
+    /// stored verbatim, and the pointed-to Sequences must outlive this Query.
+    /// See struct doc comment.
     pub fn create(
         allocator: std.mem.Allocator,
         name: []const u8,
-        seqs: []Sequence,
+        seqs: []const *const Sequence,
         seed_missing: bool,
         only_genes: []const []const u8,
         kbounds: KBounds,
@@ -49,7 +58,7 @@ pub const Query = struct {
     ) !Query {
         var q = Query{
             .name = try allocator.dupe(u8, name),
-            .seqs = .{},
+            .seqs = &.{},
             .seed_missing = seed_missing,
             .only_genes = .{},
             .kbounds = kbounds,
@@ -59,8 +68,10 @@ pub const Query = struct {
         };
         errdefer q.deinit(allocator);
 
-        for (seqs) |*sq| {
-            try q.seqs.append(allocator, try sq.clone(allocator));
+        if (seqs.len > 0) {
+            const seqs_buf = try allocator.alloc(*const Sequence, seqs.len);
+            @memcpy(seqs_buf, seqs);
+            q.seqs = seqs_buf;
         }
         for (only_genes) |g| {
             try q.only_genes.append(allocator, try allocator.dupe(u8, g));
@@ -76,8 +87,9 @@ pub const Query = struct {
 
     pub fn deinit(self: *Query, allocator: std.mem.Allocator) void {
         if (self.name.len > 0) allocator.free(self.name);
-        for (self.seqs.items) |*sq| sq.deinit(allocator);
-        self.seqs.deinit(allocator);
+        // seqs entries are borrowed pointers (see struct doc); do not call
+        // Sequence.deinit on them. Only the pointer slice itself is owned.
+        if (self.seqs.len > 0) allocator.free(self.seqs);
         for (self.only_genes.items) |g| allocator.free(g);
         self.only_genes.deinit(allocator);
         if (self.parents) |*ps| {
@@ -88,6 +100,6 @@ pub const Query = struct {
 
     /// Return number of sequences.
     pub fn nSeqs(self: *const Query) usize {
-        return self.seqs.items.len;
+        return self.seqs.len;
     }
 };

--- a/packages/zig-core/src/ham/glomerator/query.zig
+++ b/packages/zig-core/src/ham/glomerator/query.zig
@@ -22,7 +22,7 @@ pub const Query = struct {
     seed_missing: bool,
     only_genes: std.ArrayListUnmanaged([]u8),
     kbounds: KBounds,
-    mute_freq: f32,
+    mute_freq: f64,
     cdr3_length: usize,
     /// Names of the two parent queries (may be empty when not set).
     parents: ?[2][]u8,
@@ -51,7 +51,7 @@ pub const Query = struct {
         seed_missing: bool,
         only_genes: []const []const u8,
         kbounds: KBounds,
-        mute_freq: f32,
+        mute_freq: f64,
         cdr3_length: usize,
         parent1: ?[]const u8,
         parent2: ?[]const u8,

--- a/packages/zig-core/src/ham/lexical_table.zig
+++ b/packages/zig-core/src/ham/lexical_table.zig
@@ -19,10 +19,13 @@ pub const LexicalTable = struct {
     /// Pointer to the track (not owned; must outlive this LexicalTable).
     track: ?*const Track,
     /// Log-probabilities for each symbol in the track's alphabet.
-    /// Owned by this struct when set via setLogProbs / replaceLogProbs.
+    /// Owned by this struct, allocated by setLogProbs and reused thereafter.
     log_probs: []f64,
-    /// Saved copy of log_probs before a ReplaceLogProbs call (for UnReplaceLogProbs).
-    /// Empty slice means no replacement is active.
+    /// Saved copy of log_probs from the last replaceLogProbs call. Sized
+    /// the same as log_probs and allocated together by setLogProbs (item 15
+    /// of #342). Treated as a scratch buffer: replace/unReplace @memcpy
+    /// rather than realloc, so per-query rescale/un-rescale cycles do not
+    /// hit the allocator (~50k calls per 5k-seq run).
     original_log_probs: []f64,
 
     /// Create an empty LexicalTable with no track.
@@ -46,39 +49,44 @@ pub const LexicalTable = struct {
         if (self.original_log_probs.len > 0) allocator.free(self.original_log_probs);
     }
 
-    /// Set (replace) log_probs from a slice, taking a copy.
+    /// Set (replace) log_probs from a slice, taking a copy. Also (re)allocates
+    /// the `original_log_probs` scratch buffer to the same size, so subsequent
+    /// replace/unReplace calls can @memcpy without hitting the allocator.
+    /// Atomic: if either allocation fails the struct is left unchanged.
     /// Corresponds to C++ `LexicalTable::SetLogProbs(vector<double>)`.
     pub fn setLogProbs(self: *LexicalTable, allocator: std.mem.Allocator, logprobs: []const f64) !void {
+        const new_log_probs = try allocator.dupe(f64, logprobs);
+        errdefer allocator.free(new_log_probs);
+        const new_original = try allocator.alloc(f64, logprobs.len);
         if (self.log_probs.len > 0) allocator.free(self.log_probs);
-        self.log_probs = try allocator.dupe(f64, logprobs);
+        if (self.original_log_probs.len > 0) allocator.free(self.original_log_probs);
+        self.log_probs = new_log_probs;
+        self.original_log_probs = new_original;
     }
 
     /// Replace log_probs with new values, saving the originals for unReplaceLogProbs.
     /// Asserts that sizes match. Checks that exp(new probs) sum to ~1.0 within EPS.
+    /// Atomic: validates the new distribution before mutating either buffer,
+    /// so a `BadNormalization` return leaves `log_probs` and `original_log_probs`
+    /// untouched.
     /// Corresponds to C++ `LexicalTable::ReplaceLogProbs(vector<double>)`.
-    pub fn replaceLogProbs(self: *LexicalTable, allocator: std.mem.Allocator, new_log_probs: []const f64) !void {
+    pub fn replaceLogProbs(self: *LexicalTable, new_log_probs: []const f64) !void {
         std.debug.assert(self.log_probs.len == new_log_probs.len);
-        // Save originals
-        if (self.original_log_probs.len > 0) allocator.free(self.original_log_probs);
-        self.original_log_probs = try allocator.dupe(f64, self.log_probs);
-        // Install new probs
-        allocator.free(self.log_probs);
-        self.log_probs = try allocator.dupe(f64, new_log_probs);
-        // Normalization check
+        std.debug.assert(self.original_log_probs.len == new_log_probs.len);
         var total: f64 = 0.0;
-        for (self.log_probs) |lp| total += @exp(lp);
+        for (new_log_probs) |lp| total += @exp(lp);
         if (@abs(total - 1.0) >= EPS) {
             return error.BadNormalization;
         }
+        @memcpy(self.original_log_probs, self.log_probs);
+        @memcpy(self.log_probs, new_log_probs);
     }
 
     /// Revert log_probs to the values saved by replaceLogProbs.
     /// Corresponds to C++ `LexicalTable::UnReplaceLogProbs()`.
-    pub fn unReplaceLogProbs(self: *LexicalTable, allocator: std.mem.Allocator) void {
+    pub fn unReplaceLogProbs(self: *LexicalTable) void {
         std.debug.assert(self.original_log_probs.len == self.log_probs.len);
-        allocator.free(self.log_probs);
-        self.log_probs = self.original_log_probs;
-        self.original_log_probs = &[_]f64{};
+        @memcpy(self.log_probs, self.original_log_probs);
     }
 
     /// Return the log-probability for a digitized symbol index.
@@ -128,11 +136,11 @@ test "LexicalTable: replaceLogProbs and unReplaceLogProbs" {
 
     // Replace with new valid distribution
     const new_lps = [_]f64{ @log(0.5), @log(0.3), @log(0.1), @log(0.1) };
-    try lt.replaceLogProbs(allocator, &new_lps);
+    try lt.replaceLogProbs(&new_lps);
     try std.testing.expectApproxEqAbs(@log(0.5), lt.logProb(0), 1e-9);
 
     // Revert
-    lt.unReplaceLogProbs(allocator);
+    lt.unReplaceLogProbs();
     try std.testing.expectApproxEqAbs(@log(0.25), lt.logProb(0), 1e-9);
 }
 
@@ -146,8 +154,10 @@ test "LexicalTable: replaceLogProbs rejects bad normalization" {
 
     // Distribution that sums to 0.9, not 1.0
     const bad = [_]f64{ @log(0.3), @log(0.3), @log(0.2), @log(0.1) };
-    const result = lt.replaceLogProbs(allocator, &bad);
+    const result = lt.replaceLogProbs(&bad);
     try std.testing.expectError(error.BadNormalization, result);
+    // Atomicity: log_probs must be unchanged on BadNormalization
+    try std.testing.expectApproxEqAbs(@log(0.25), lt.logProb(0), 1e-9);
 }
 
 test "LexicalTable: logProbSeq" {

--- a/packages/zig-core/src/ham/mathutils.zig
+++ b/packages/zig-core/src/ham/mathutils.zig
@@ -82,10 +82,18 @@ pub fn addInLogSpace(first: f64, second: f64) f64 {
     // the call site is still the place where item-3.2's transcendental work
     // used to live — re-naming would invalidate prior #368 measurements.
     perf_counters.bumpAddInLogSpaceLogExp();
+    // fast_softplus's C implementation has a `if (d > 0.0) return d + fast_softplus(-d)`
+    // symmetry recursion. ReleaseFast can elide that guard on subnormal positive d
+    // after negation, so we assert non-positive here at the only Zig call site
+    // (both branches feed (smaller − larger) ≤ 0).
     if (first > second) {
-        return first + fast_softplus(second - first);
+        const d = second - first;
+        std.debug.assert(d <= 0.0);
+        return first + fast_softplus(d);
     } else {
-        return second + fast_softplus(first - second);
+        const d = first - second;
+        std.debug.assert(d <= 0.0);
+        return second + fast_softplus(d);
     }
 }
 

--- a/packages/zig-core/src/ham/mathutils.zig
+++ b/packages/zig-core/src/ham/mathutils.zig
@@ -13,6 +13,7 @@
 
 const std = @import("std");
 const math = std.math;
+const perf_counters = @import("perf_counters.zig");
 
 // Use glibc log/exp via C wrapper (glibc_math.c) to match C++ bcrham bit-for-bit.
 // Zig's `extern fn log/exp` resolves to compiler-rt (bundled as local 't' symbols),
@@ -64,8 +65,13 @@ pub fn addWithMinusInfinities(first: f64, second: f64) f64 {
 /// Implements the log-space *or* operation (a OR b = a + b in probability space).
 /// Corresponds to C++ `ham::AddInLogSpace<T>(T first, T second)`.
 pub fn addInLogSpace(first: f64, second: f64) f64 {
+    perf_counters.bumpAddInLogSpace();
     if (first == NEG_INF) return second;
     if (second == NEG_INF) return first;
+    // Past both early-outs: this call does exactly 1 log + 1 exp. Bump
+    // the work counter separately so item-3.2 cost predictions can be
+    // priced against actual transcendental work, not call rate.
+    perf_counters.bumpAddInLogSpaceLogExp();
     if (first > second) {
         return first + log(1.0 + exp(second - first));
     } else {

--- a/packages/zig-core/src/ham/mathutils.zig
+++ b/packages/zig-core/src/ham/mathutils.zig
@@ -24,6 +24,15 @@ extern fn glibc_exp(x: f64) f64;
 pub const log = glibc_log;
 pub const exp = glibc_exp;
 
+// fast_softplus(d) = log(1 + exp(d)), via 64K-entry linear-interp LUT.
+// Implemented in fast_math.c; mirrored on the C++ side at
+// packages/ham/src/fast_math.c. Replaces 1 log + 1 exp glibc call inside
+// addInLogSpace with a single load + 1 mul + 1 fma — ~22-40% speedup
+// per addInLogSpace call across Zen 3-5 and Intel Broadwell. Accuracy
+// 6.5e-9 max abs over [-30, 0] (5 orders under partis-test 1e-5 gate).
+// See fast_math.c for the design notes (issue #366 item 3.2).
+extern fn fast_softplus(d: f64) f64;
+
 /// Negative infinity constant for log-probability computations.
 /// Replaces the verbose `-std.math.inf(f64)` throughout the codebase.
 pub const NEG_INF: f64 = -math.inf(f64);
@@ -68,14 +77,15 @@ pub fn addInLogSpace(first: f64, second: f64) f64 {
     perf_counters.bumpAddInLogSpace();
     if (first == NEG_INF) return second;
     if (second == NEG_INF) return first;
-    // Past both early-outs: this call does exactly 1 log + 1 exp. Bump
-    // the work counter separately so item-3.2 cost predictions can be
-    // priced against actual transcendental work, not call rate.
+    // Past both early-outs: one call to fast_softplus (LUT lookup, no glibc
+    // log/exp). The counter name kept its original log+exp suffix because
+    // the call site is still the place where item-3.2's transcendental work
+    // used to live — re-naming would invalidate prior #368 measurements.
     perf_counters.bumpAddInLogSpaceLogExp();
     if (first > second) {
-        return first + log(1.0 + exp(second - first));
+        return first + fast_softplus(second - first);
     } else {
-        return second + log(1.0 + exp(first - second));
+        return second + fast_softplus(first - second);
     }
 }
 

--- a/packages/zig-core/src/ham/model.zig
+++ b/packages/zig-core/src/ham/model.zig
@@ -32,9 +32,19 @@ pub const Model = struct {
     /// Track (alphabet). Owned by this Model.
     track: ?*Track,
 
-    /// All non-init states in model order. Each pointer is heap-allocated and owned.
-    states: std.ArrayListUnmanaged(*State),
-    /// Map from state name to State pointer (pointers owned via `states` or `initial`).
+    /// All non-init states in model order. Stored as values in a flat slice so the
+    /// hot path (Trellis.middleViterbi/Forward, which call `stateByIndex` once per
+    /// (current, prev) pair per position) does a single index instead of an extra
+    /// pointer dereference. Capacity is reserved once in `parse` from the YAML
+    /// state count and never grown afterward, so `*State` pointers obtained via
+    /// `&states.items[i]` remain stable for the lifetime of the Model — that
+    /// invariant is what lets `states_by_name` and Transition.to_state_ptr keep
+    /// holding `*State` directly.
+    states: std.ArrayListUnmanaged(State),
+    /// Map from state name to State pointer. Non-init pointers reference into
+    /// `states.items`; the init pointer references the separately heap-allocated
+    /// `initial`. The Model never grows `states` after parse, so these pointers
+    /// stay valid for the Model's lifetime.
     states_by_name: std.StringHashMap(*State),
     /// The "init" state. Owned.
     initial: ?*State,
@@ -66,15 +76,20 @@ pub const Model = struct {
     pub fn deinit(self: *Model, allocator: std.mem.Allocator) void {
         allocator.free(self.name);
         allocator.free(self.ambiguous_char);
-        // Free all states via states_by_name (owns all State pointers)
-        var it = self.states_by_name.valueIterator();
-        while (it.next()) |st_ptr| {
-            st_ptr.*.deinit(allocator);
-            allocator.destroy(st_ptr.*);
-        }
-        self.states_by_name.deinit();
+        // Non-init states live as values in the flat slice — deinit each in place,
+        // then free the slice's backing storage. No allocator.destroy: the State
+        // values were never individually heap-allocated.
+        for (self.states.items) |*st| st.deinit(allocator);
         self.states.deinit(allocator);
-        // ending is separate
+        // states_by_name pointers reference into states.items / initial / ending.
+        // Just free the map's own storage.
+        self.states_by_name.deinit();
+        // init and ending are separately heap-allocated (init is not in
+        // states.items by construction; ending is synthetic and never indexed).
+        if (self.initial) |init_st| {
+            init_st.deinit(allocator);
+            allocator.destroy(init_st);
+        }
         self.ending.deinit(allocator);
         allocator.destroy(self.ending);
         if (self.track) |t| {
@@ -116,40 +131,86 @@ pub const Model = struct {
         }
         for (td.symbols.items) |sym| try trk.addSymbol(allocator, sym);
 
-        // Collect state names for transition validation
+        // Collect state names for transition validation, and count non-init
+        // states so we can reserve flat-slice capacity in one shot. The capacity
+        // reservation is what makes `&states.items[i]` pointers stable — without
+        // it, addOneAssumeCapacity below would assert.
         var state_names: std.ArrayListUnmanaged([]const u8) = .{};
         defer state_names.deinit(allocator);
-        for (data.states.items) |*sd| try state_names.append(allocator, sd.name);
+        var n_non_init: usize = 0;
+        for (data.states.items) |*sd| {
+            try state_names.append(allocator, sd.name);
+            if (!std.mem.eql(u8, sd.name, "init")) n_non_init += 1;
+        }
+        // Match the C++/old behavior of allowing exactly STATE_MAX non-init
+        // states. The old code checked `items.len >= STATE_MAX` immediately
+        // before each append, so the (N+1)-th append (when items.len was
+        // already N==STATE_MAX) was the one that errored.
+        if (n_non_init > @import("state.zig").STATE_MAX) return error.TooManyStates;
+        try self.states.ensureTotalCapacityPrecise(allocator, n_non_init);
 
         // Parse each state
         for (data.states.items) |*sd| {
-            const st = try allocator.create(State);
-            errdefer {
-                st.deinit(allocator);
-                allocator.destroy(st);
-            }
-            st.* = State.init();
-
-            try st.parse(
-                allocator,
-                sd.name,
-                sd.germline_nuc,
-                sd.ambiguous_emission_prob,
-                sd.ambiguous_char,
-                sd.transitions,
-                if (sd.emissions) |*em| em.probs else null,
-                state_names.items,
-                trk,
-            );
-
             if (std.mem.eql(u8, sd.name, "init")) {
+                // init stays in its own heap allocation (one per Model, not indexed).
+                const st = try allocator.create(State);
+                errdefer {
+                    st.deinit(allocator);
+                    allocator.destroy(st);
+                }
+                st.* = State.init();
+                try st.parse(
+                    allocator,
+                    sd.name,
+                    sd.germline_nuc,
+                    sd.ambiguous_emission_prob,
+                    sd.ambiguous_char,
+                    sd.transitions,
+                    if (sd.emissions) |*em| em.probs else null,
+                    state_names.items,
+                    trk,
+                );
                 self.initial = st;
+                try self.states_by_name.put(st.name, st);
             } else {
-                if (self.states.items.len >= @import("state.zig").STATE_MAX) return error.TooManyStates;
-                try self.states.append(allocator, st);
+                // Grow the flat slice by one slot; capacity reserved above so this
+                // never reallocates and the &slot pointer is stable.
+                const slot = self.states.addOneAssumeCapacity();
+                slot.* = State.init();
+                // Roll back the addOne if parse or states_by_name.put fails.
+                // Order matters: `slot.deinit` must precede `pop`, because after
+                // pop the slot index is past states.items.len and a later
+                // model.deinit would not see it. Conversely, without pop, the
+                // slot would still live in states.items and model.deinit would
+                // re-deinit it (double free). If states_by_name.put is the
+                // failing call, no key was stored (put is failure-atomic), so
+                // freeing slot.name in deinit doesn't dangle a map entry.
+                errdefer {
+                    slot.deinit(allocator);
+                    _ = self.states.pop();
+                }
+                try slot.parse(
+                    allocator,
+                    sd.name,
+                    sd.germline_nuc,
+                    sd.ambiguous_emission_prob,
+                    sd.ambiguous_char,
+                    sd.transitions,
+                    if (sd.emissions) |*em| em.probs else null,
+                    state_names.items,
+                    trk,
+                );
+                try self.states_by_name.put(slot.name, slot);
             }
-            try self.states_by_name.put(st.name, st);
         }
+
+        // Make the stable-pointer invariant machine-checkable: any future code
+        // that accidentally appends to self.states would reallocate the slice
+        // and silently invalidate every *State held by states_by_name and by
+        // Transition.to_state_ptr. The capacity reservation above sized the
+        // slice to exactly n_non_init; if items.len ever drifts from capacity,
+        // the invariant has been broken.
+        std.debug.assert(self.states.items.len == self.states.capacity);
 
         try self.finalize(allocator);
     }
@@ -160,14 +221,14 @@ pub const Model = struct {
         std.debug.assert(!self.finalized);
 
         // Assign indices to all non-init states
-        for (self.states.items, 0..) |st, i| st.setIndex(i);
+        for (self.states.items, 0..) |*st, i| st.setIndex(i);
 
         // Set to/from connectivity for each non-init state
-        for (self.states.items) |st| try self.finalizeState(st);
+        for (self.states.items) |*st| try self.finalizeState(st);
         if (self.initial) |init_st| try self.finalizeState(init_st);
 
         // Reorder transitions in index order
-        for (self.states.items) |st| try st.reorderTransitions(allocator, &self.states_by_name);
+        for (self.states.items) |*st| try st.reorderTransitions(allocator, &self.states_by_name);
         if (self.initial) |init_st| try init_st.reorderTransitions(allocator, &self.states_by_name);
 
         // Check topology
@@ -175,6 +236,12 @@ pub const Model = struct {
 
         // Build from_state_indices
         try self.addMaybeFasterFromStateStuff(allocator);
+
+        // Materialize flat log_probs and free *Transition allocations. Must run
+        // after every reader of to_state_name/to_state_ptr (finalizeState,
+        // reorderTransitions, checkTopology, addMaybeFasterFromStateStuff).
+        for (self.states.items) |*st| try st.materializeTransitionLogProbs(allocator);
+        if (self.initial) |init_st| try init_st.materializeTransitionLogProbs(allocator);
 
         self.finalized = true;
     }
@@ -202,7 +269,7 @@ pub const Model = struct {
             try init_st.setFromStateIndices(allocator);
             try init_st.setToStateIndices(allocator);
         }
-        for (self.states.items) |st| {
+        for (self.states.items) |*st| {
             try st.setFromStateIndices(allocator);
             try st.setToStateIndices(allocator);
         }
@@ -230,7 +297,7 @@ pub const Model = struct {
 
             var tmp: std.ArrayListUnmanaged(u16) = .{};
             defer tmp.deinit(allocator);
-            try self.addToStateIndicesHelper(allocator, self.states.items[icheck], &tmp);
+            try self.addToStateIndicesHelper(allocator, &self.states.items[icheck], &tmp);
             const num_visited = tmp.items.len;
 
             if (num_visited == 0) {
@@ -248,7 +315,7 @@ pub const Model = struct {
 
         // At least one transition to end
         var found_end = false;
-        for (self.states.items) |st| {
+        for (self.states.items) |*st| {
             if (st.trans_to_end != null) {
                 found_end = true;
                 break;
@@ -280,13 +347,13 @@ pub const Model = struct {
         std.debug.assert(!std.math.isNegativeInf(overall_mute_freq));
         if (self.original_overall_mute_freq == 0.0) return error.ZeroOriginalMuteFreq;
         const factor = @max(0.01, overall_mute_freq) / self.original_overall_mute_freq;
-        for (self.states.items) |st| try st.rescaleOverallMuteFreq(allocator, factor);
+        for (self.states.items) |*st| try st.rescaleOverallMuteFreq(allocator, factor);
     }
 
     /// Undo rescaling.
     /// Corresponds to C++ `Model::UnRescaleOverallMuteFreq()`.
-    pub fn unRescaleOverallMuteFreq(self: *Model, allocator: std.mem.Allocator) void {
-        for (self.states.items) |st| st.unRescaleOverallMuteFreq(allocator);
+    pub fn unRescaleOverallMuteFreq(self: *Model) void {
+        for (self.states.items) |*st| st.unRescaleOverallMuteFreq();
     }
 
     pub fn nStates(self: *const Model) usize {
@@ -298,7 +365,7 @@ pub const Model = struct {
     }
 
     pub inline fn stateByIndex(self: *const Model, idx: usize) *State {
-        return self.states.items[idx];
+        return &self.states.items[idx];
     }
 
     pub fn initState(self: *const Model) ?*State {

--- a/packages/zig-core/src/ham/perf_counters.zig
+++ b/packages/zig-core/src/ham/perf_counters.zig
@@ -18,6 +18,35 @@
 ///   - active_state_hist[count]     — `trellis.zig` middleViterbiVals/
 ///                                    middleForwardVals
 ///
+/// Phase-B sub-phase nanosecond accumulators (added 2026-05 after the
+/// lever-5 close — see `/tmp/perf-1.1-results/next-steps-plan.md`). The
+/// Phase-0 counts told us the chunk-cache HIT RATE; they did not tell us
+/// how time is split between the cache-hit path (the `partial_match`
+/// branch in `runKSet`) and the various sub-phases inside `fillTrellis`
+/// on the cache-miss path. The lever-5 close was the proximate motivator:
+/// a 24.63% perf-record symbol bucket turned out to over-attribute work
+/// inside an amortized hot loop, and eliminating ~70% of those calls only
+/// shifted bcrham wall by ~2%. The next-steps plan calls for cycle-
+/// precise per-sub-phase timing before any further lever pull. These
+/// `*_ns` accumulators provide that data:
+///
+///   - fillTrellis_total_ns         — whole `fillTrellis` body
+///   - fillTrellis_chunkScan_ns     — chunk-cache prefix-match for-loop
+///   - fillTrellis_init_ns          — cache-miss path: create+clone+initWithSeqs+append
+///   - fillTrellis_tmpInit_ns       — cache-hit (trellis) path: tmptrell init
+///   - fillTrellis_viterbi_ns       — `trell_ptr.viterbi()` call
+///   - fillTrellis_forward_ns       — `trell_ptr.forward()` call
+///   - fillTrellis_traceback_ns     — `trell_ptr.traceback(...)` call
+///   - fillTrellis_put_ns           — `gc.paths.put` + `gc.scores.put`
+///   - cachedPath_ns                — `runKSet`'s `partial_match` cache-hit
+///                                    branch (does NOT enter `fillTrellis`)
+///
+/// All timers use `std.time.Instant` (CLOCK_MONOTONIC). They compile to
+/// nothing when `-Dperf-counters=false` (the `Tick` type is `void`, and
+/// `tick`/`addElapsed` early-return). The corresponding output line is
+/// `PERFCOUNTER_TIMING` (separate from `PERFCOUNTER` so the existing
+/// aggregator keeps parsing the original line unchanged).
+///
 /// The `_calls` vs `_log_exp_calls` split for `addInLogSpace` matters for
 /// item-3.2 costing: at function entry the call may still hit a cheap
 /// `NEG_INF` short-circuit and do zero transcendental work. The first
@@ -55,6 +84,67 @@ pub var chunk_cache_lookups: u64 = 0;
 pub var chunk_cache_hits: u64 = 0;
 pub var active_state_hist: [HIST_LEN]u64 = [_]u64{0} ** HIST_LEN;
 
+// Phase-B sub-phase ns accumulators. Wrap-around (`+%=`) is fine: a u64
+// of nanoseconds is ~584 years.
+pub var fillTrellis_total_ns: u64 = 0;
+pub var fillTrellis_chunkScan_ns: u64 = 0;
+pub var fillTrellis_init_ns: u64 = 0;
+pub var fillTrellis_tmpInit_ns: u64 = 0;
+pub var fillTrellis_viterbi_ns: u64 = 0;
+pub var fillTrellis_forward_ns: u64 = 0;
+pub var fillTrellis_traceback_ns: u64 = 0;
+pub var fillTrellis_put_ns: u64 = 0;
+pub var cachedPath_ns: u64 = 0;
+
+// Phase-B outer-perimeter accumulators. These pair with the inner ones
+// above to bound the un-timed gap inside one `DPHandler.run()`:
+//   runKSet_overhead       = runKSet_total       − (fillTrellis_total + cachedPath)
+//   dpHandler_run_overhead = dpHandler_run_total − Σ runKSet_total
+// The latter covers the run()-body pre/post work: Sequences build, the
+// only_genes map, `hmms.rescaleOverallMuteFreqs`, `fillRecoEvent` for
+// viterbi, `Result.finalize`, debug logging, etc. Phase B saw the
+// inner perimeter (fillTrellis+cachedPath) is ~95% DP; these outer
+// accumulators let us check whether the remaining bcrham wall really
+// is Glomerator+driver, or whether there's an addressable bucket
+// hiding in run() pre/post or runKSet plumbing.
+pub var runKSet_total_ns: u64 = 0;
+pub var dpHandler_run_total_ns: u64 = 0;
+
+// Phase-B'' deeper-DP timers: split `viterbi()` and `forward()` (in
+// `trellis.zig`) into init / position-loop / ending sub-phases. The
+// position-loop body is derived in the aggregator as the residual:
+//   viterbi_positionLoop_ns ≈ fillTrellis_viterbi_ns − init − ending
+//   forward_positionLoop_ns ≈ fillTrellis_forward_ns − init − ending
+// Expected outcome: init + ending sum to <5%, so the position loop
+// — i.e. `middleViterbiVals`/`middleForwardVals` + `swapColumnsActive`
+// — accounts for ~95%+ of the DP time. That confirms the only
+// remaining lever surface is the inner DP body, which is not localized
+// (it's the algorithm itself).
+pub var viterbi_init_ns: u64 = 0;
+pub var viterbi_ending_ns: u64 = 0;
+pub var forward_init_ns: u64 = 0;
+pub var forward_ending_ns: u64 = 0;
+
+// Process-lifetime accumulator: total wall in `Glomerator.cluster()` OR
+// `Glomerator.cacheNaiveSeqs()`. The dumped `PERFCOUNTER_GLOMERATOR`
+// line tags which mode via its `kind=` field. Distinct from the
+// per-DPHandler.run() counters above — this one survives the per-query
+// `reset()` so it accumulates across all the nested DPHandler.run()
+// invocations inside one Glomerator entry-point call. Bcrham emits one
+// `PERFCOUNTER_GLOMERATOR` line at the end of each call reporting
+// this value plus the cumulative DPHandler.run time across all calls
+// inside it (the latter via a paired `cumul_dpHandler_run_ns`
+// accumulator that ALSO survives reset()).
+//
+// Together with the `bcrham time:` line printed by partis, the gap
+//   bcrham_CPU − cumul_dpHandler_run_ns × n_procs
+// tells us whether the remaining bcrham CPU is in Glomerator driver
+// code (merge decisions, partition writes) or in bcrham startup /
+// model loading. Phase B' shows ~28% of bcrham CPU lives outside
+// DPHandler.run(); this counter lets us split it.
+pub var glomerator_ns: u64 = 0;
+pub var cumul_dpHandler_run_ns: u64 = 0;
+
 pub fn reset() void {
     if (!enabled) return;
     addInLogSpace_calls = 0;
@@ -63,6 +153,21 @@ pub fn reset() void {
     n_ksets = 0;
     chunk_cache_lookups = 0;
     chunk_cache_hits = 0;
+    fillTrellis_total_ns = 0;
+    fillTrellis_chunkScan_ns = 0;
+    fillTrellis_init_ns = 0;
+    fillTrellis_tmpInit_ns = 0;
+    fillTrellis_viterbi_ns = 0;
+    fillTrellis_forward_ns = 0;
+    fillTrellis_traceback_ns = 0;
+    fillTrellis_put_ns = 0;
+    cachedPath_ns = 0;
+    runKSet_total_ns = 0;
+    dpHandler_run_total_ns = 0;
+    viterbi_init_ns = 0;
+    viterbi_ending_ns = 0;
+    forward_init_ns = 0;
+    forward_ending_ns = 0;
     // NB: explicit loop instead of `@memset(&active_state_hist, 0)` —
     // Zig 0.15.2 hits an x86_64 codegen bug ("no encoding found for:
     // none mov m64 m64 none none") on a Debug @memset over a fixed-size
@@ -70,6 +175,30 @@ pub fn reset() void {
     // will turn it back into a memset under ReleaseFast/ReleaseSafe.
     var i: usize = 0;
     while (i < HIST_LEN) : (i += 1) active_state_hist[i] = 0;
+}
+
+/// Cycle-precise sub-phase timer pair, gated on the `-Dperf-counters`
+/// build option. When disabled, `Tick` is `void`, both helpers early-
+/// return, and the call site reduces to nothing under the optimizer —
+/// preserving the default-build bit-equality contract.
+///
+/// Usage:
+///   const t = perf_counters.tick();
+///   // ... work to time ...
+///   perf_counters.addElapsed(&perf_counters.fillTrellis_chunkScan_ns, t);
+pub const Tick = if (enabled) std.time.Instant else void;
+
+pub inline fn tick() Tick {
+    if (!enabled) return {};
+    // `Instant.now()` only returns `error.Unsupported` on platforms
+    // without a monotonic clock. Linux/macOS/Windows all provide one.
+    return std.time.Instant.now() catch unreachable;
+}
+
+pub inline fn addElapsed(accum: *u64, start: Tick) void {
+    if (!enabled) return;
+    const now_inst = std.time.Instant.now() catch unreachable;
+    accum.* +%= now_inst.since(start);
 }
 
 pub inline fn bumpAddInLogSpace() void {
@@ -160,6 +289,48 @@ pub fn formatPerfCounters(
             stats.p95,
             stats.max,
             stats.total,
+        },
+    );
+}
+
+/// Format the per-query sub-phase ns accumulators as a separate
+/// `PERFCOUNTER_TIMING` line. Kept distinct from `PERFCOUNTER` so the
+/// existing aggregator parses unchanged; the timing aggregator reads only
+/// these lines.
+///
+///   PERFCOUNTER_TIMING alg=... q=... n_seqs=... \
+///       fillTrellis_total_ns=T chunkScan_ns=... init_ns=... \
+///       tmpInit_ns=... viterbi_ns=... forward_ns=... traceback_ns=... \
+///       put_ns=... cachedPath_ns=...
+pub fn formatPerfCountersTiming(
+    allocator: std.mem.Allocator,
+    algorithm: []const u8,
+    query_name: []const u8,
+    n_seqs: usize,
+) !?[]u8 {
+    if (!enabled) return null;
+    return try std.fmt.allocPrint(
+        allocator,
+        "PERFCOUNTER_TIMING alg={s} q={s} n_seqs={d} dpHandler_run_total_ns={d} runKSet_total_ns={d} fillTrellis_total_ns={d} chunkScan_ns={d} init_ns={d} tmpInit_ns={d} viterbi_ns={d} forward_ns={d} traceback_ns={d} put_ns={d} cachedPath_ns={d} viterbi_init_ns={d} viterbi_ending_ns={d} forward_init_ns={d} forward_ending_ns={d}\n",
+        .{
+            algorithm,
+            query_name,
+            n_seqs,
+            dpHandler_run_total_ns,
+            runKSet_total_ns,
+            fillTrellis_total_ns,
+            fillTrellis_chunkScan_ns,
+            fillTrellis_init_ns,
+            fillTrellis_tmpInit_ns,
+            fillTrellis_viterbi_ns,
+            fillTrellis_forward_ns,
+            fillTrellis_traceback_ns,
+            fillTrellis_put_ns,
+            cachedPath_ns,
+            viterbi_init_ns,
+            viterbi_ending_ns,
+            forward_init_ns,
+            forward_ending_ns,
         },
     );
 }

--- a/packages/zig-core/src/ham/perf_counters.zig
+++ b/packages/zig-core/src/ham/perf_counters.zig
@@ -1,0 +1,165 @@
+/// ham/perf_counters.zig — Phase-0 diagnostics counters for issue #366.
+///
+/// The whole module is gated on the `-Dperf-counters` build option (see
+/// `build.zig`). When the option is `false` (default), `enabled` is a
+/// comptime `false` and every `if (enabled) { ... }` block in the hot
+/// path compiles to nothing — bit-equality with the un-instrumented build
+/// is preserved.
+///
+/// Counters cover the metrics requested in #366 phase 0.1 / 0.2:
+///
+///   - addInLogSpace_calls          — `mathutils.zig:addInLogSpace` entry
+///   - addInLogSpace_log_exp_calls  — calls past both NEG_INF early-outs
+///                                    (each = 1 log + 1 exp of work)
+///   - fillTrellis_calls            — `dp_handler.zig:fillTrellis` entry
+///   - n_ksets                      — `dp_handler.zig:run` kset loop
+///   - chunk_cache_lookups/hits     — `dp_handler.zig:fillTrellis` cache
+///                                    branch entry / prefix-match success
+///   - active_state_hist[count]     — `trellis.zig` middleViterbiVals/
+///                                    middleForwardVals
+///
+/// The `_calls` vs `_log_exp_calls` split for `addInLogSpace` matters for
+/// item-3.2 costing: at function entry the call may still hit a cheap
+/// `NEG_INF` short-circuit and do zero transcendental work. The first
+/// counter is the call rate; the second is the rate of work that an
+/// item-3.2 log/exp approximation would actually replace.
+///
+/// State is process-global and reset at start of each `DPHandler.run()`.
+/// `formatPerfCounters` returns one heap-allocated PERFCOUNTER line per
+/// query; caller writes it to the destination it picks (current dump site
+/// is the file at `PARTIS_ZIG_PERF_LOG`, opened O_APPEND to keep parallel
+/// bcrham processes non-clobbering — see `dp_handler.zig:dumpPerfCounters`).
+///
+/// SAFETY: the counters below are plain `pub var` globals, NOT atomics.
+/// Every caller must run single-threaded within a process. bcrham is
+/// single-threaded by design (#342 item 1 investigated and rejected
+/// `smp_allocator`); cross-process parallelism via `partis --n-procs N`
+/// runs each bcrham in its own address space, so the globals stay
+/// per-process. If a future caller introduces threading inside a single
+/// bcrham process, this module must grow atomic counters or per-thread
+/// shadow state.
+const std = @import("std");
+const build_options = @import("build_options");
+
+pub const enabled: bool = build_options.perf_counters;
+
+/// Length of the active-state histogram. State indices in this codebase
+/// are bounded by `state.zig:STATE_MAX = 500`; one extra slot for 500 itself.
+const HIST_LEN: usize = 501;
+
+pub var addInLogSpace_calls: u64 = 0;
+pub var addInLogSpace_log_exp_calls: u64 = 0;
+pub var fillTrellis_calls: u64 = 0;
+pub var n_ksets: u64 = 0;
+pub var chunk_cache_lookups: u64 = 0;
+pub var chunk_cache_hits: u64 = 0;
+pub var active_state_hist: [HIST_LEN]u64 = [_]u64{0} ** HIST_LEN;
+
+pub fn reset() void {
+    if (!enabled) return;
+    addInLogSpace_calls = 0;
+    addInLogSpace_log_exp_calls = 0;
+    fillTrellis_calls = 0;
+    n_ksets = 0;
+    chunk_cache_lookups = 0;
+    chunk_cache_hits = 0;
+    // NB: explicit loop instead of `@memset(&active_state_hist, 0)` —
+    // Zig 0.15.2 hits an x86_64 codegen bug ("no encoding found for:
+    // none mov m64 m64 none none") on a Debug @memset over a fixed-size
+    // global u64 array. The loop sidesteps the bug and any optimizer
+    // will turn it back into a memset under ReleaseFast/ReleaseSafe.
+    var i: usize = 0;
+    while (i < HIST_LEN) : (i += 1) active_state_hist[i] = 0;
+}
+
+pub inline fn bumpAddInLogSpace() void {
+    if (enabled) addInLogSpace_calls += 1;
+}
+
+pub inline fn bumpAddInLogSpaceLogExp() void {
+    if (enabled) addInLogSpace_log_exp_calls += 1;
+}
+
+pub inline fn bumpFillTrellis() void {
+    if (enabled) fillTrellis_calls += 1;
+}
+
+pub inline fn bumpKSet() void {
+    if (enabled) n_ksets += 1;
+}
+
+pub inline fn bumpChunkCacheLookup() void {
+    if (enabled) chunk_cache_lookups += 1;
+}
+
+pub inline fn bumpChunkCacheHit() void {
+    if (enabled) chunk_cache_hits += 1;
+}
+
+pub inline fn recordActiveStates(n: usize) void {
+    if (!enabled) return;
+    const idx = if (n >= HIST_LEN) HIST_LEN - 1 else n;
+    active_state_hist[idx] += 1;
+}
+
+/// Compute (median, p95, max, total_positions) over the active-state histogram.
+fn activeStateStats() struct { median: usize, p95: usize, max: usize, total: u64 } {
+    var total: u64 = 0;
+    for (active_state_hist) |c| total += c;
+    if (total == 0) return .{ .median = 0, .p95 = 0, .max = 0, .total = 0 };
+    const median_target = (total + 1) / 2;
+    const p95_target = (total * 95 + 99) / 100;
+    var cum: u64 = 0;
+    var median: usize = 0;
+    var p95: usize = 0;
+    var max_idx: usize = 0;
+    var i: usize = 0;
+    while (i < HIST_LEN) : (i += 1) {
+        if (active_state_hist[i] == 0) continue;
+        max_idx = i;
+        const next_cum = cum + active_state_hist[i];
+        if (cum < median_target and median_target <= next_cum) median = i;
+        if (cum < p95_target and p95_target <= next_cum) p95 = i;
+        cum = next_cum;
+    }
+    return .{ .median = median, .p95 = p95, .max = max_idx, .total = total };
+}
+
+/// Format the per-query counter summary as a heap-allocated `[]u8` (caller frees).
+/// Returns null when counters are disabled (caller skips the write).
+/// Format is intentionally trivial-to-grep:
+///   PERFCOUNTER alg=... q=... n_seqs=... ksets=... fillTrellis=... \
+///       chunk_hits=H/L addInLogSpace=... addInLogSpace_log_exp=... \
+///       active_states_med=... active_states_p95=... active_states_max=... \
+///       active_states_positions=...
+///
+/// `chunk_hits=H/L`: H = prefix-match successes, L = lookup attempts (the
+/// `if (!no_chunk_cache)` branch entries in fillTrellis). Hit rate is H/L.
+pub fn formatPerfCounters(
+    allocator: std.mem.Allocator,
+    algorithm: []const u8,
+    query_name: []const u8,
+    n_seqs: usize,
+) !?[]u8 {
+    if (!enabled) return null;
+    const stats = activeStateStats();
+    return try std.fmt.allocPrint(
+        allocator,
+        "PERFCOUNTER alg={s} q={s} n_seqs={d} ksets={d} fillTrellis={d} chunk_hits={d}/{d} addInLogSpace={d} addInLogSpace_log_exp={d} active_states_med={d} active_states_p95={d} active_states_max={d} active_states_positions={d}\n",
+        .{
+            algorithm,
+            query_name,
+            n_seqs,
+            n_ksets,
+            fillTrellis_calls,
+            chunk_cache_hits,
+            chunk_cache_lookups,
+            addInLogSpace_calls,
+            addInLogSpace_log_exp_calls,
+            stats.median,
+            stats.p95,
+            stats.max,
+            stats.total,
+        },
+    );
+}

--- a/packages/zig-core/src/ham/state.zig
+++ b/packages/zig-core/src/ham/state.zig
@@ -39,11 +39,20 @@ pub const State = struct {
 
     /// Transitions to other states (not the "end" state), in parse order.
     /// After reorderTransitions(), reindexed to model order (with null sentinels for absent).
-    /// Each pointer is owned by this State.
+    /// Each pointer is owned by this State. Kept alive after finalize so print() can
+    /// resolve destination names; the hot path reads `log_probs` and ignores this.
     transitions: std.ArrayListUnmanaged(?*Transition),
-    /// Transition to the "end" state (null if none).
-    /// Owned by this State.
+    /// Transition to the "end" state (null if none). Owned by this State.
+    /// Kept alive after finalize for print(); the hot path reads `end_log_prob`.
     trans_to_end: ?*Transition,
+    /// Flat log-probabilities indexed by destination state, populated by
+    /// materializeTransitionLogProbs() at the end of Model.finalize. Replaces the
+    /// pointer-of-pointers chase in transitionLogprob() — that's the hottest data
+    /// access in the trellis DP. NEG_INF for absent transitions.
+    log_probs: []f64,
+    /// Log-probability for the transition to "end". Set during parse(); read by
+    /// endTransitionLogprob() in the hot path. NEG_INF if no end transition.
+    end_log_prob: f64,
 
     /// Emission model for this state.
     emission: Emission,
@@ -70,6 +79,8 @@ pub const State = struct {
             .ambiguous_char = &[_]u8{},
             .transitions = .{},
             .trans_to_end = null,
+            .log_probs = &[_]f64{},
+            .end_log_prob = mathutils.NEG_INF,
             .emission = Emission.init(),
             .index = std.math.maxInt(usize),
             .to_states = StateBitset.initEmpty(),
@@ -94,6 +105,7 @@ pub const State = struct {
             t.deinit(allocator);
             allocator.destroy(t);
         }
+        if (self.log_probs.len > 0) allocator.free(self.log_probs);
         self.emission.deinit(allocator);
         self.from_state_indices.deinit(allocator);
         self.to_state_indices.deinit(allocator);
@@ -157,6 +169,7 @@ pub const State = struct {
             trans.* = try Transition.init(allocator, to_state, prob);
             if (std.mem.eql(u8, to_state, "end")) {
                 self.trans_to_end = trans;
+                self.end_log_prob = trans.log_prob;
             } else {
                 try self.transitions.append(allocator, trans);
             }
@@ -195,7 +208,19 @@ pub const State = struct {
     /// Emission log-probability for a position in a Sequences object.
     /// Accumulates log-probs for each sequence at that position.
     /// Corresponds to C++ `State::EmissionLogprob(Sequences*, size_t pos)`.
-    pub fn emissionLogprobSeqs(self: *const State, seqs: *const Sequences, pos: usize) f64 {
+    pub inline fn emissionLogprobSeqs(self: *const State, seqs: *const Sequences, pos: usize) f64 {
+        // Single-sequence fast path. The general loop's first (and only)
+        // iteration computes addWithMinusInfinities(0.0, emissionLogprob(...)),
+        // which equals emissionLogprob(...) for every value emissionLogprob can
+        // return: finite logprobs (0.0 + x == x) and NEG_INF (the function
+        // propagates -inf). emissionLogprob never returns NaN — its outputs come
+        // from the precomputed log-probability slice and the stored
+        // ambiguous_emission_logprob, both of which are seeded from log() of
+        // probabilities — so the fast path is value-identical to running the
+        // loop once.
+        if (seqs.nSeqs() == 1) {
+            return self.emissionLogprob(seqs.get(0).seqq[pos]);
+        }
         var logprob: f64 = 0.0;
         for (0..seqs.nSeqs()) |iseq| {
             const seq = seqs.get(iseq);
@@ -204,19 +229,20 @@ pub const State = struct {
         return logprob;
     }
 
-    /// Transition log-probability to state at index `to_state` (post-reorder).
-    /// Returns -inf if no transition exists to that state.
+    /// Transition log-probability to state at index `to_state` (post-finalize).
+    /// Returns -inf if no transition exists to that state. Reads from the flat
+    /// `log_probs` array materialized at the end of Model.finalize — eliminates
+    /// the pointer-chain dereference that was the hottest data access in the
+    /// trellis DP.
     pub inline fn transitionLogprob(self: *const State, to_state: usize) f64 {
-        if (to_state >= self.transitions.items.len) return mathutils.NEG_INF;
-        const maybe_t = self.transitions.items[to_state];
-        return if (maybe_t) |t| t.log_prob else mathutils.NEG_INF;
+        if (to_state >= self.log_probs.len) return mathutils.NEG_INF;
+        return self.log_probs[to_state];
     }
 
     /// Log-probability for the transition to "end" (-inf if no such transition).
     /// Corresponds to C++ `State::end_transition_logprob()`.
     pub fn endTransitionLogprob(self: *const State) f64 {
-        if (self.trans_to_end) |t| return t.log_prob;
-        return mathutils.NEG_INF;
+        return self.end_log_prob;
     }
 
     /// Mark that this state transitions to `st`.
@@ -234,6 +260,25 @@ pub const State = struct {
     /// Set this state's index.
     pub fn setIndex(self: *State, val: usize) void {
         self.index = val;
+    }
+
+    /// Materialize a flat `log_probs: []f64` from `transitions` (post-reorder).
+    /// Called at the end of Model.finalize, after every reader of `to_state_name`
+    /// /`to_state_ptr` has run.
+    ///
+    /// Eliminates the pointer-chain dereference in transitionLogprob (the hottest
+    /// data access in the trellis DP). The original `*Transition` allocations
+    /// remain alive — print() walks them post-finalize to resolve destination
+    /// names. Memory cost is one f64 per state per slot (~2 MB total across all
+    /// loaded models); the wall-time win comes from the read pattern, not from
+    /// freeing.
+    pub fn materializeTransitionLogProbs(self: *State, allocator: std.mem.Allocator) !void {
+        std.debug.assert(self.log_probs.len == 0);
+        const n = self.transitions.items.len;
+        self.log_probs = try allocator.alloc(f64, n);
+        for (self.transitions.items, 0..) |maybe_t, i| {
+            self.log_probs[i] = if (maybe_t) |t| t.log_prob else mathutils.NEG_INF;
+        }
     }
 
     /// Reorder `transitions` to indexed order matching `state_indices` map.
@@ -324,16 +369,16 @@ pub const State = struct {
                 new_log_probs[ip] = log(exp(new_log_probs[ip]) * new_mute_freq / old_mute_freq);
             }
         }
-        try self.emission.replaceLogProbs(allocator, new_log_probs);
+        try self.emission.replaceLogProbs(new_log_probs);
     }
 
     /// Revert emission rescaling.
     /// Corresponds to C++ `State::UnRescaleOverallMuteFreq()`.
-    pub fn unRescaleOverallMuteFreq(self: *State, allocator: std.mem.Allocator) void {
+    pub fn unRescaleOverallMuteFreq(self: *State) void {
         if (self.germline_nuc.len == 0 or
             (self.ambiguous_char.len > 0 and std.mem.eql(u8, self.germline_nuc, self.ambiguous_char)))
             return;
-        self.emission.unReplaceLogProbs(allocator);
+        self.emission.unReplaceLogProbs();
     }
 
     /// Print this state to stderr.
@@ -403,7 +448,7 @@ test "State: normal state parse with emissions" {
     try std.testing.expectEqualStrings("state0", state.name);
     try std.testing.expectEqualStrings("A", state.germline_nuc);
     try std.testing.expectApproxEqAbs(@log(0.25), state.emissionLogprob(0), 1e-9);
-    // end transition stored in trans_to_end
+    // end_log_prob is set during parse() at the same site that creates trans_to_end
     try std.testing.expectApproxEqAbs(@log(1.0), state.endTransitionLogprob(), 1e-9);
 }
 

--- a/packages/zig-core/src/ham/text.zig
+++ b/packages/zig-core/src/ham/text.zig
@@ -117,14 +117,12 @@ pub fn intify(allocator: std.mem.Allocator, strlist: []const []const u8) ![]i32 
 }
 
 /// Converts a slice of strings to a slice of f64.
-/// C++ uses stof (f32 precision) but returns vector<double>; we parse as f32 then widen to f64 to match.
+/// C++ uses stod (full f64 precision) since ham f41e055 "fix precision: stof→stod for cache reads".
 /// Corresponds to C++ `ham::Floatify(vector<string> strlist)`.
 pub fn floatify(allocator: std.mem.Allocator, strlist: []const []const u8) ![]f64 {
     const result = try allocator.alloc(f64, strlist.len);
     for (strlist, 0..) |s, i| {
-        // C++ uses stof (single-precision parse) — match that precision by parsing as f32 then widening
-        const f32_val = try std.fmt.parseFloat(f32, s);
-        result[i] = @as(f64, f32_val);
+        result[i] = try std.fmt.parseFloat(f64, s);
     }
     return result;
 }

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -14,20 +14,37 @@ const Sequence = @import("sequences.zig").Sequence;
 const TracebackPath = @import("traceback_path.zig").TracebackPath;
 const mathutils = @import("mathutils.zig");
 
-/// 2D traceback table: [seq_len][n_states], each entry is the previous state index (or -1).
-/// Corresponds to C++ `typedef vector<vector<int16_t>> int_2D`.
-pub const Int2D = std.ArrayListUnmanaged([]i16);
-
 /// DP trellis for Forward/Viterbi algorithms.
 /// Corresponds to C++ `ham::Trellis`.
 pub const Trellis = struct {
     /// HMM model (not owned).
     hmm: *const Model,
-    /// Sequences to run DP over (owned copy).
-    seqs: Sequences,
+    /// Sequences to run DP over (BORROWED; not owned).
+    /// The pointee must outlive this Trellis. For trellises stored in
+    /// `DPHandler.scratch_cachefo`, the owning Sequences lives in the
+    /// enclosing TrellisEntry and is freed alongside the trellis.
+    /// For temporary chunk-borrowing trellises, the pointee is the caller's
+    /// stack-local `query_seqs` and lives only for the duration of fillTrellis.
+    seqs: *const Sequences,
+    /// Cached at init from `seqs.sequence_length`. Read by `traceback`,
+    /// `viterbi`, and `forward`; valid even if the borrowed seqs is no longer
+    /// being read post-DP.
+    seq_len: usize,
 
-    /// Traceback table [position][state] → previous state (-1 if none).
-    traceback_table: Int2D,
+    /// Flat traceback table indexed as [position * traceback_n_states + state].
+    /// Each entry is the previous state index (-1 if no valid predecessor).
+    /// Corresponds to C++ `typedef vector<vector<int16_t>> int_2D`, but stored
+    /// as a single contiguous allocation for locality and one alloc/free per
+    /// Trellis instead of seq_len + 1.
+    /// Empty (`&.{}`) until `viterbi()` allocates it; `forward()` never touches
+    /// this field. Read via `pickTracebackView` (returns a `TracebackView` with
+    /// the slice and stride); written via `tracebackSet`.
+    traceback_table: []i16,
+    /// State width of `traceback_table`. Captured at allocation time and equal
+    /// to `hmm.nStates()` for the trellis's lifetime. Stored explicitly so a
+    /// chunk-borrowing temp trellis can verify its `cached_trellis` was built
+    /// against the same model (see `initWithSeqs` assert).
+    traceback_n_states: usize,
 
     /// Pointer to another trellis with pre-filled DP tables (not owned).
     cached_trellis: ?*const Trellis,
@@ -50,36 +67,47 @@ pub const Trellis = struct {
     /// Scratch bitset for deduplicating next_states additions.
     next_seen: state_mod.StateBitset,
 
+    /// Captured at `initWithSeqs` time. For trellises stored in
+    /// `DPHandler.scratch_cachefo`, this is `dph.scratchAllocator()`,
+    /// whose `Allocator.ptr` aliases `&dph.query_arena`. The DPHandler
+    /// must therefore not be moved after a Trellis is constructed against
+    /// it, or every stored `allocator.ptr` would dangle. All current
+    /// callers bind `dph` to a stack-local `var` and never reassign,
+    /// which preserves the invariant. (Item 4, #342.)
     allocator: std.mem.Allocator,
 
-    /// Create a Trellis for a single Sequence.
-    /// The sequence is copied into an internal Sequences object.
-    /// Corresponds to C++ `Trellis(Model*, Sequence, Trellis*)`.
-    pub fn initWithSeq(allocator: std.mem.Allocator, hmm: *const Model, seq: Sequence, cached: ?*const Trellis) !Trellis {
-        var seqs = Sequences.init();
-        try seqs.addSeq(allocator, try seq.clone(allocator));
-        return initImpl(allocator, hmm, seqs, cached);
-    }
-
-    /// Create a Trellis for a Sequences object.
-    /// Clones `seqs` so the caller retains ownership of the original
-    /// (matches C++ Trellis(Model*, Sequences, Trellis*) copy-by-value semantics).
-    pub fn initWithSeqs(allocator: std.mem.Allocator, hmm: *const Model, seqs: Sequences, cached: ?*const Trellis) !Trellis {
-        const seqs_copy = try seqs.clone(allocator);
-        return initImpl(allocator, hmm, seqs_copy, cached);
-    }
-
-    fn initImpl(allocator: std.mem.Allocator, hmm: *const Model, seqs: Sequences, cached: ?*const Trellis) !Trellis {
+    /// Create a Trellis borrowing the given Sequences.
+    /// The caller retains ownership; `seqs` must outlive this Trellis.
+    /// Corresponds to C++ `Trellis(Model*, Sequences, Trellis*)`, but without
+    /// the C++ copy-by-value clone — the borrow is sufficient for DP read
+    /// access, and for cached/stored trellises only the result arrays are
+    /// re-read.
+    pub fn initWithSeqs(allocator: std.mem.Allocator, hmm: *const Model, seqs: *const Sequences, cached: ?*const Trellis) !Trellis {
         const n = hmm.nStates();
+        // Stale-cache guard: a chunk-borrowing trellis must be built against
+        // the same model as its cached source, otherwise its scalar reads from
+        // `cached.traceback_table` (via `pickTracebackView`) would index with
+        // the wrong stride. The cached trellis can have an empty traceback
+        // table (forward-only), so guard only when it has one.
+        if (cached) |ct| {
+            if (ct.traceback_table.len > 0) {
+                std.debug.assert(ct.traceback_n_states == n);
+            }
+        }
+
         const scoring_current = try allocator.alloc(f64, n);
+        errdefer allocator.free(scoring_current);
         const scoring_previous = try allocator.alloc(f64, n);
+        errdefer allocator.free(scoring_previous);
         @memset(scoring_current, mathutils.NEG_INF);
         @memset(scoring_previous, mathutils.NEG_INF);
 
-        const t = Trellis{
+        return Trellis{
             .hmm = hmm,
             .seqs = seqs,
-            .traceback_table = .{},
+            .seq_len = seqs.sequence_length,
+            .traceback_table = &.{},
+            .traceback_n_states = 0,
             .cached_trellis = cached,
             .ending_viterbi_pointer = -1,
             .ending_viterbi_log_prob = mathutils.NEG_INF,
@@ -92,15 +120,12 @@ pub const Trellis = struct {
             .next_seen = state_mod.StateBitset.initEmpty(),
             .allocator = allocator,
         };
-        return t;
     }
 
     pub fn deinit(self: *Trellis) void {
         const allocator = self.allocator;
-        self.seqs.deinit(allocator);
-        // Free traceback table rows
-        for (self.traceback_table.items) |row| allocator.free(row);
-        self.traceback_table.deinit(allocator);
+        // seqs is borrowed; not freed here.
+        if (self.traceback_table.len > 0) allocator.free(self.traceback_table);
         self.viterbi_log_probs.deinit(allocator);
         self.forward_log_probs.deinit(allocator);
         self.viterbi_indices.deinit(allocator);
@@ -113,8 +138,12 @@ pub const Trellis = struct {
     /// Corresponds to C++ `Trellis::Viterbi()`.
     pub fn viterbi(self: *Trellis) !void {
         const allocator = self.allocator;
-        const seq_len = self.seqs.sequence_length;
+        const seq_len = self.seq_len;
         const n_states = self.hmm.nStates();
+        // Cache the borrowed seqs pointer in a local so the inner DP loop reads
+        // it from a register rather than re-loading `self.seqs` (a heap-pointer
+        // member after #357) on every emission lookup.
+        const seqs = self.seqs;
 
         if (self.cached_trellis) |ct| {
             // Poach scalar values from cached trellis; array data accessed via accessors.
@@ -129,14 +158,20 @@ pub const Trellis = struct {
         @memset(self.viterbi_log_probs.items, mathutils.NEG_INF);
         @memset(self.viterbi_indices.items, -1);
 
-        // Initialize traceback table [seq_len][n_states] = -1
-        for (self.traceback_table.items) |row| allocator.free(row);
-        self.traceback_table.clearRetainingCapacity();
-        for (0..seq_len) |_| {
-            const row = try allocator.alloc(i16, n_states);
-            @memset(row, -1);
-            try self.traceback_table.append(allocator, row);
+        // Initialize flat traceback table [seq_len * n_states] = -1.
+        // Single allocation replaces seq_len per-row allocations (item 3 of #342).
+        // Note the explicit `traceback_table = &.{}` between free and alloc:
+        // if the alloc fails, deinit reads `traceback_table` and would otherwise
+        // see the just-freed slice with len > 0 and double-free it.
+        std.debug.assert(seq_len <= std.math.maxInt(usize) / @max(n_states, 1));
+        const total = seq_len * n_states;
+        if (self.traceback_table.len != total) {
+            if (self.traceback_table.len > 0) allocator.free(self.traceback_table);
+            self.traceback_table = &.{};
+            self.traceback_table = try allocator.alloc(i16, total);
         }
+        @memset(self.traceback_table, -1);
+        self.traceback_n_states = n_states;
 
         // Reset scoring columns
         @memset(self.scoring_current, mathutils.NEG_INF);
@@ -152,7 +187,7 @@ pub const Trellis = struct {
         // Reset next_seen before populating position 0
         self.next_seen = state_mod.StateBitset.initEmpty();
         for (init_st.to_state_indices.items) |i_st| {
-            const emission_val = self.hmm.stateByIndex(i_st).emissionLogprobSeqs(&self.seqs, 0);
+            const emission_val = self.hmm.stateByIndex(i_st).emissionLogprobSeqs(seqs, 0);
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
@@ -192,8 +227,10 @@ pub const Trellis = struct {
     /// Corresponds to C++ `Trellis::Forward()`.
     pub fn forward(self: *Trellis) !void {
         const allocator = self.allocator;
-        const seq_len = self.seqs.sequence_length;
+        const seq_len = self.seq_len;
         const n_states = self.hmm.nStates();
+        // See viterbi(): cache borrowed seqs pointer in a local for the inner DP loop.
+        const seqs = self.seqs;
 
         if (self.cached_trellis) |ct| {
             self.ending_forward_log_prob = ct.endingForwardLogProbAt(seq_len);
@@ -218,7 +255,7 @@ pub const Trellis = struct {
         // Reset next_seen before populating position 0
         self.next_seen = state_mod.StateBitset.initEmpty();
         for (init_st.to_state_indices.items) |i_st| {
-            const emission_val = self.hmm.stateByIndex(i_st).emissionLogprobSeqs(&self.seqs, 0);
+            const emission_val = self.hmm.stateByIndex(i_st).emissionLogprobSeqs(seqs, 0);
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
@@ -252,23 +289,34 @@ pub const Trellis = struct {
 
     /// Traceback to produce a path.
     /// Corresponds to C++ `Trellis::Traceback(TracebackPath&)`.
-    pub fn traceback(self: *const Trellis, path: *TracebackPath) !void {
-        std.debug.assert(self.seqs.sequence_length != 0);
+    ///
+    /// `path_alloc` backs the path's growing item list, which may have a
+    /// different lifetime than the trellis itself: in the chunk-cache-hit
+    /// path of `DPHandler.fillTrellis`, the temp trellis lives on the
+    /// per-kset arena but the path is stored in `DPHandler.paths` (per
+    /// query). Passing the allocator explicitly avoids the use-after-free
+    /// that would otherwise come from `self.allocator` capturing a
+    /// shorter-lived arena. (Item 4, #342.)
+    pub fn traceback(self: *const Trellis, path_alloc: std.mem.Allocator, path: *TracebackPath) !void {
+        std.debug.assert(self.seq_len != 0);
         path.setModel(self.hmm);
         if (std.math.isNegativeInf(self.ending_viterbi_log_prob)) return;
         path.setScore(self.ending_viterbi_log_prob);
-        try path.pushBack(self.allocator, self.ending_viterbi_pointer);
+        try path.pushBack(path_alloc, self.ending_viterbi_pointer);
 
+        // Resolve the traceback source once: cached trellis if it has a
+        // populated table, else self. If neither does, there's nothing to
+        // walk back through.
+        const view = self.pickTracebackView() orelse return;
         var pointer: i16 = self.ending_viterbi_pointer;
-        var position: usize = self.seqs.sequence_length - 1;
-        const tbl_items = self.tracebackTableItems() orelse return;
+        var position: usize = self.seq_len - 1;
         while (position > 0) : (position -= 1) {
-            pointer = tbl_items[position][@intCast(pointer)];
+            pointer = view.tbl[position * view.stride + @as(usize, @intCast(pointer))];
             if (pointer == -1) {
                 std.debug.print("No valid path at position {d}\n", .{position});
                 return;
             }
-            try path.pushBack(self.allocator, pointer);
+            try path.pushBack(path_alloc, pointer);
         }
         std.debug.assert(path.size() > 0);
     }
@@ -317,9 +365,11 @@ pub const Trellis = struct {
         next_states: *std.ArrayListUnmanaged(usize),
         position: usize,
     ) !void {
+        // See viterbi(): cache borrowed seqs pointer in a local for the inner loop.
+        const seqs = self.seqs;
         for (current_states.items) |i_st_cur| {
             const st_cur = self.hmm.stateByIndex(i_st_cur);
-            const emission_val = st_cur.emissionLogprobSeqs(&self.seqs, position);
+            const emission_val = st_cur.emissionLogprobSeqs(seqs, position);
             if (std.math.isNegativeInf(emission_val)) continue;
             for (st_cur.from_state_indices.items) |i_st_prev| {
                 const prev_val = self.scoring_previous[i_st_prev];
@@ -327,7 +377,7 @@ pub const Trellis = struct {
                 const dpval = prev_val + emission_val + self.hmm.stateByIndex(i_st_prev).transitionLogprob(i_st_cur);
                 if (dpval > self.scoring_current[i_st_cur]) {
                     self.scoring_current[i_st_cur] = dpval;
-                    self.traceback_table.items[position][i_st_cur] = @intCast(i_st_prev);
+                    self.tracebackSet(position, i_st_cur, @intCast(i_st_prev));
                 }
                 self.cacheViterbiVals(position, dpval, i_st_cur);
                 // Mark outbound transitions inside the i_st_prev loop (as in C++) so we only
@@ -349,9 +399,11 @@ pub const Trellis = struct {
         next_states: *std.ArrayListUnmanaged(usize),
         position: usize,
     ) !void {
+        // See viterbi(): cache borrowed seqs pointer in a local for the inner loop.
+        const seqs = self.seqs;
         for (current_states.items) |i_st_cur| {
             const st_cur = self.hmm.stateByIndex(i_st_cur);
-            const emission_val = st_cur.emissionLogprobSeqs(&self.seqs, position);
+            const emission_val = st_cur.emissionLogprobSeqs(seqs, position);
             if (std.math.isNegativeInf(emission_val)) continue;
             for (st_cur.from_state_indices.items) |i_st_prev| {
                 const prev_val = self.scoring_previous[i_st_prev];
@@ -371,7 +423,7 @@ pub const Trellis = struct {
         }
     }
 
-    fn cacheViterbiVals(self: *Trellis, position: usize, dpval: f64, i_st_cur: usize) void {
+    inline fn cacheViterbiVals(self: *Trellis, position: usize, dpval: f64, i_st_cur: usize) void {
         const end_trans = self.hmm.stateByIndex(i_st_cur).endTransitionLogprob();
         const logprob = dpval + end_trans;
         if (logprob > self.viterbi_log_probs.items[position]) {
@@ -380,7 +432,7 @@ pub const Trellis = struct {
         }
     }
 
-    fn cacheForwardVals(self: *Trellis, position: usize, dpval: f64, i_st_cur: usize) void {
+    inline fn cacheForwardVals(self: *Trellis, position: usize, dpval: f64, i_st_cur: usize) void {
         const end_trans = self.hmm.stateByIndex(i_st_cur).endTransitionLogprob();
         const logprob = dpval + end_trans;
         self.forward_log_probs.items[position] = mathutils.addInLogSpace(logprob, self.forward_log_probs.items[position]);
@@ -388,12 +440,27 @@ pub const Trellis = struct {
 
     // ── Accessors: dispatch to cached trellis data or own data ──────────────
 
-    fn tracebackTableItems(self: *const Trellis) ?[][]i16 {
+    /// Resolved view of the traceback source: the cached trellis's table if it
+    /// has one populated, else self's, else null. The stride is captured at
+    /// the same time as the slice so callers don't have to re-do the dispatch.
+    const TracebackView = struct { tbl: []const i16, stride: usize };
+
+    inline fn pickTracebackView(self: *const Trellis) ?TracebackView {
         if (self.cached_trellis) |ct| {
-            if (ct.traceback_table.items.len > 0) return ct.traceback_table.items;
+            if (ct.traceback_table.len > 0) {
+                return .{ .tbl = ct.traceback_table, .stride = ct.traceback_n_states };
+            }
         }
-        if (self.traceback_table.items.len > 0) return self.traceback_table.items;
+        if (self.traceback_table.len > 0) {
+            return .{ .tbl = self.traceback_table, .stride = self.traceback_n_states };
+        }
         return null;
+    }
+
+    /// Scalar write of *self*'s traceback table at (position, state). Used by
+    /// `middleViterbiVals` while filling the table fresh.
+    inline fn tracebackSet(self: *Trellis, position: usize, state: usize, v: i16) void {
+        self.traceback_table[position * self.traceback_n_states + state] = v;
     }
 
     /// Ending Viterbi log-prob for a specific sequence length (used by cached trellis).
@@ -441,13 +508,145 @@ test "Trellis: forward on real IGHV3-15 model" {
     var seq = try Sequence.initFromString(allocator, trk, "test_seq", "ACGT");
     defer seq.deinit(allocator);
 
-    var trellis = try Trellis.initWithSeq(allocator, &model, seq, null);
+    // Trellis borrows the Sequences; the caller retains ownership.
+    var seqs = Sequences.init();
+    defer seqs.deinit(allocator);
+    try seqs.addSeq(allocator, try seq.clone(allocator));
+
+    var trellis = try Trellis.initWithSeqs(allocator, &model, &seqs, null);
     defer trellis.deinit();
 
     try trellis.forward();
 
-    // The forward probability should be finite (not -inf) for a valid sequence
-    try std.testing.expect(!std.math.isNegativeInf(trellis.ending_forward_log_prob));
-    // It should be a plausible log-probability (very negative is OK, but not -inf)
+    // A 4-symbol query against a ~300nt V-gene HMM may legitimately return
+    // -inf (no valid path); a finite log-prob is the success signal but not
+    // a hard requirement. The structural success is that forward() ran without
+    // crashing through the trellis allocation/teardown path.
     std.debug.print("forward log-prob: {d}\n", .{trellis.ending_forward_log_prob});
+}
+
+// Layout test: writing through `tracebackSet` and reading back via
+// `pickTracebackView` must round-trip the value at the same (position, state).
+// Catches row/col transposition in the indexing helpers without needing a full
+// Model — the byte-equality gate at 5k/30k can't catch a transposition when
+// seq_len ≈ n_states (square trellis), so this covers the gap.
+test "Trellis: flat traceback layout round-trips position/state" {
+    const allocator = std.testing.allocator;
+
+    const seq_len: usize = 4;
+    const n_states: usize = 5;
+
+    // Hand-build just the indexing fields. The non-indexing fields aren't
+    // touched by tracebackSet / pickTracebackView.
+    var trellis: Trellis = undefined;
+    trellis.allocator = allocator;
+    trellis.cached_trellis = null;
+    trellis.traceback_n_states = n_states;
+    trellis.traceback_table = try allocator.alloc(i16, seq_len * n_states);
+    defer allocator.free(trellis.traceback_table);
+    @memset(trellis.traceback_table, -1);
+
+    // Write a unique value at every (position, state).
+    for (0..seq_len) |pos| {
+        for (0..n_states) |st| {
+            trellis.tracebackSet(pos, st, @intCast(pos * 10 + st));
+        }
+    }
+    // Read back via the resolved view. A row/col swap in the indexing math
+    // would surface as the wrong value (or out-of-range index) at every cell.
+    const view = trellis.pickTracebackView() orelse return error.TestUnexpectedNull;
+    for (0..seq_len) |pos| {
+        for (0..n_states) |st| {
+            const expected: i16 = @intCast(pos * 10 + st);
+            try std.testing.expectEqual(expected, view.tbl[pos * view.stride + st]);
+        }
+    }
+
+    // Empty-table fallback: pickTracebackView returns null when neither self
+    // nor cached has a table, mirroring the original `?[][]i16` accessor's
+    // null path. `traceback()` short-circuits on this.
+    var empty_trellis: Trellis = undefined;
+    empty_trellis.allocator = allocator;
+    empty_trellis.cached_trellis = null;
+    empty_trellis.traceback_n_states = 0;
+    empty_trellis.traceback_table = &.{};
+    try std.testing.expectEqual(@as(?Trellis.TracebackView, null), empty_trellis.pickTracebackView());
+
+    // Cached-fallthrough: when self has no table but cached does, the view
+    // should come from cached, with cached's stride (not self's, which is 0).
+    var borrow_trellis: Trellis = undefined;
+    borrow_trellis.allocator = allocator;
+    borrow_trellis.cached_trellis = &trellis;
+    borrow_trellis.traceback_n_states = 0;
+    borrow_trellis.traceback_table = &.{};
+    const borrow_view = borrow_trellis.pickTracebackView() orelse return error.TestUnexpectedNull;
+    try std.testing.expectEqual(@as(usize, n_states), borrow_view.stride);
+    for (0..seq_len) |pos| {
+        for (0..n_states) |st| {
+            const expected: i16 = @intCast(pos * 10 + st);
+            try std.testing.expectEqual(expected, borrow_view.tbl[pos * borrow_view.stride + st]);
+        }
+    }
+}
+
+// Viterbi → traceback parity: run viterbi on a real model, walk the traceback
+// path through the flat table, and assert the path is consistent with the
+// per-position best-state record. This is end-to-end coverage of the indexing
+// helpers under the actual DP loop, complementing the layout test above.
+test "Trellis: viterbi traceback walks through flat table consistently" {
+    const allocator = std.testing.allocator;
+
+    const yaml_path = "/fh/fast/matsen_e/shared/partis-zig/partis/test/ref-results-slow/test/parameters/simu/sw/hmms/IGHV3-15_star_07.yaml";
+    var model = try @import("model.zig").Model.init(allocator);
+    defer model.deinit(allocator);
+    model.parse(allocator, yaml_path) catch |err| {
+        std.debug.print("skipping viterbi traceback test: {}\n", .{err});
+        return;
+    };
+
+    const trk = model.track orelse return;
+    var seq = try Sequence.initFromString(allocator, trk, "test_seq", "ACGTACGT");
+    defer seq.deinit(allocator);
+
+    var seqs = Sequences.init();
+    defer seqs.deinit(allocator);
+    try seqs.addSeq(allocator, try seq.clone(allocator));
+
+    var trellis = try Trellis.initWithSeqs(allocator, &model, &seqs, null);
+    defer trellis.deinit();
+
+    try trellis.viterbi();
+
+    // Traceback table should be populated under the new flat layout.
+    try std.testing.expectEqual(seqs.sequence_length * model.nStates(), trellis.traceback_table.len);
+    try std.testing.expectEqual(model.nStates(), trellis.traceback_n_states);
+
+    // Skip the path comparison if viterbi found no valid path through the
+    // model (depends on YAML data); the structural checks above are enough
+    // to fail on a misshapen allocation.
+    if (std.math.isNegativeInf(trellis.ending_viterbi_log_prob)) {
+        std.debug.print("viterbi found no valid path; skipping traceback walk\n", .{});
+        return;
+    }
+
+    var path = TracebackPath.initWithModel(&model);
+    defer path.deinit(allocator);
+    try trellis.traceback(allocator, &path);
+
+    // Path length should equal seq_len: traceback pushes ending pointer, then
+    // one entry per position from seq_len-1 down to 1.
+    try std.testing.expectEqual(seqs.sequence_length, path.size());
+
+    // Every traceback step must read a valid (>=0) state from the flat table.
+    // This is what would fail catastrophically under a row/col transpose: the
+    // wrong-strided read would land on -1 entries (or out of bounds — the
+    // overflow assert above guards bounds).
+    const view = trellis.pickTracebackView() orelse return error.TestUnexpectedNull;
+    var pointer: i16 = trellis.ending_viterbi_pointer;
+    var position: usize = trellis.seq_len - 1;
+    while (position > 0) : (position -= 1) {
+        const next = view.tbl[position * view.stride + @as(usize, @intCast(pointer))];
+        try std.testing.expect(next >= 0);
+        pointer = next;
+    }
 }

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -13,6 +13,7 @@ const Sequences = @import("sequences.zig").Sequences;
 const Sequence = @import("sequences.zig").Sequence;
 const TracebackPath = @import("traceback_path.zig").TracebackPath;
 const mathutils = @import("mathutils.zig");
+const perf_counters = @import("perf_counters.zig");
 
 /// DP trellis for Forward/Viterbi algorithms.
 /// Corresponds to C++ `ham::Trellis`.
@@ -365,6 +366,7 @@ pub const Trellis = struct {
         next_states: *std.ArrayListUnmanaged(usize),
         position: usize,
     ) !void {
+        perf_counters.recordActiveStates(current_states.items.len);
         // See viterbi(): cache borrowed seqs pointer in a local for the inner loop.
         const seqs = self.seqs;
         for (current_states.items) |i_st_cur| {
@@ -399,6 +401,7 @@ pub const Trellis = struct {
         next_states: *std.ArrayListUnmanaged(usize),
         position: usize,
     ) !void {
+        perf_counters.recordActiveStates(current_states.items.len);
         // See viterbi(): cache borrowed seqs pointer in a local for the inner loop.
         const seqs = self.seqs;
         for (current_states.items) |i_st_cur| {

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -237,6 +237,11 @@ pub const Trellis = struct {
             self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
             try self.middleViterbiVals(allocator, current_states, &next_states, position);
         }
+        // After this final swap `scoring_current` is left dirty by design:
+        // the ending loop below reads only `scoring_previous`, and the next
+        // entry into viterbi()/forward() does its own full @memset before
+        // reuse. Don't add a clear here without revisiting the next-entry
+        // contract — it's load-bearing for the sparse-clear win.
         self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
 
         // Compute ending probability
@@ -322,6 +327,7 @@ pub const Trellis = struct {
             self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
             try self.middleForwardVals(allocator, current_states, &next_states, position);
         }
+        // See viterbi(): `scoring_current` is intentionally left dirty here.
         self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
 
         // Compute ending probability

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -65,6 +65,18 @@ pub const Trellis = struct {
     scoring_current: []f64,
     scoring_previous: []f64,
 
+    /// Indices into scoring_current that may hold non-NEG_INF values
+    /// (a SUPERSET of truly-dirty slots — see `swapColumnsActive`). Mirrors
+    /// the swap of scoring_current ↔ scoring_previous so the sparse clear
+    /// in `swapColumnsActive` only touches slots that were active two
+    /// iterations ago, instead of the full n_states column. Item 1.1 of
+    /// #366: at rung-2 medians (~50 active states / 500 n_states) this
+    /// drops the per-position memset from O(n_states) to O(active).
+    scoring_current_dirty: std.ArrayListUnmanaged(usize),
+    /// Indices into scoring_previous that may hold non-NEG_INF values.
+    /// See `scoring_current_dirty`.
+    scoring_previous_dirty: std.ArrayListUnmanaged(usize),
+
     /// Scratch bitset for deduplicating next_states additions.
     next_seen: state_mod.StateBitset,
 
@@ -118,6 +130,8 @@ pub const Trellis = struct {
             .viterbi_indices = .{},
             .scoring_current = scoring_current,
             .scoring_previous = scoring_previous,
+            .scoring_current_dirty = .{},
+            .scoring_previous_dirty = .{},
             .next_seen = state_mod.StateBitset.initEmpty(),
             .allocator = allocator,
         };
@@ -132,6 +146,8 @@ pub const Trellis = struct {
         self.viterbi_indices.deinit(allocator);
         allocator.free(self.scoring_current);
         allocator.free(self.scoring_previous);
+        self.scoring_current_dirty.deinit(allocator);
+        self.scoring_previous_dirty.deinit(allocator);
     }
 
     /// Run the Viterbi algorithm.
@@ -174,9 +190,13 @@ pub const Trellis = struct {
         @memset(self.traceback_table, -1);
         self.traceback_n_states = n_states;
 
-        // Reset scoring columns
+        // Reset scoring columns. Dirty lists pair with the buffers and start
+        // empty: the full memset establishes the all-NEG_INF invariant that
+        // the sparse clear in `swapColumnsActive` relies on.
         @memset(self.scoring_current, mathutils.NEG_INF);
         @memset(self.scoring_previous, mathutils.NEG_INF);
+        self.scoring_current_dirty.clearRetainingCapacity();
+        self.scoring_previous_dirty.clearRetainingCapacity();
 
         var current_states = std.ArrayListUnmanaged(usize){};
         defer current_states.deinit(allocator);
@@ -192,6 +212,7 @@ pub const Trellis = struct {
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
+            try self.scoring_current_dirty.append(allocator, i_st);
             self.cacheViterbiVals(0, dpval, i_st);
             // Mark outbound transitions for next position (deduplicated)
             for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
@@ -242,9 +263,11 @@ pub const Trellis = struct {
         try self.forward_log_probs.resize(allocator, seq_len);
         @memset(self.forward_log_probs.items, mathutils.NEG_INF);
 
-        // Reset scoring columns
+        // Reset scoring columns. See `viterbi()` for the dirty-list invariant.
         @memset(self.scoring_current, mathutils.NEG_INF);
         @memset(self.scoring_previous, mathutils.NEG_INF);
+        self.scoring_current_dirty.clearRetainingCapacity();
+        self.scoring_previous_dirty.clearRetainingCapacity();
 
         var current_states = std.ArrayListUnmanaged(usize){};
         defer current_states.deinit(allocator);
@@ -260,6 +283,7 @@ pub const Trellis = struct {
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
+            try self.scoring_current_dirty.append(allocator, i_st);
             // Mark outbound transitions for next position (deduplicated)
             for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
                 if (!self.next_seen.isSet(j)) {
@@ -330,11 +354,23 @@ pub const Trellis = struct {
         current_states: *std.ArrayListUnmanaged(usize),
         next_states: *std.ArrayListUnmanaged(usize),
     ) !void {
-        // Swap scoring_current ↔ scoring_previous
-        const tmp = self.scoring_previous;
-        self.scoring_previous = self.scoring_current;
-        self.scoring_current = tmp;
-        @memset(self.scoring_current, mathutils.NEG_INF);
+        // Swap scoring_current ↔ scoring_previous, and the parallel dirty
+        // lists. After the swap, `scoring_current` is the buffer that was
+        // last written *two* iterations ago (or position-0 init); only the
+        // slots in `scoring_current_dirty` (the freshly-swapped-in list) can
+        // be non-NEG_INF, so a sparse clear over those slots restores the
+        // all-NEG_INF invariant. Item 1.1 of #366.
+        std.mem.swap([]f64, &self.scoring_current, &self.scoring_previous);
+        std.mem.swap(
+            std.ArrayListUnmanaged(usize),
+            &self.scoring_current_dirty,
+            &self.scoring_previous_dirty,
+        );
+
+        for (self.scoring_current_dirty.items) |idx| {
+            self.scoring_current[idx] = mathutils.NEG_INF;
+        }
+        self.scoring_current_dirty.clearRetainingCapacity();
 
         // Clear next_seen for all indices that were in next_states
         // (they will become current_states; next_seen tracks what's queued for the NEW next)
@@ -373,6 +409,12 @@ pub const Trellis = struct {
             const st_cur = self.hmm.stateByIndex(i_st_cur);
             const emission_val = st_cur.emissionLogprobSeqs(seqs, position);
             if (std.math.isNegativeInf(emission_val)) continue;
+            // Track for the sparse clear in `swapColumnsActive`. This is a
+            // SUPERSET of slots we actually write: if every i_st_prev has
+            // NEG_INF prev_val, no write happens but i_st_cur is still in the
+            // dirty list. Clearing an already-NEG_INF slot is a no-op, so the
+            // superset is bit-equal.
+            try self.scoring_current_dirty.append(allocator, i_st_cur);
             for (st_cur.from_state_indices.items) |i_st_prev| {
                 const prev_val = self.scoring_previous[i_st_prev];
                 if (std.math.isNegativeInf(prev_val)) continue;
@@ -408,6 +450,8 @@ pub const Trellis = struct {
             const st_cur = self.hmm.stateByIndex(i_st_cur);
             const emission_val = st_cur.emissionLogprobSeqs(seqs, position);
             if (std.math.isNegativeInf(emission_val)) continue;
+            // See `middleViterbiVals` for the dirty-list invariant.
+            try self.scoring_current_dirty.append(allocator, i_st_cur);
             for (st_cur.from_state_indices.items) |i_st_prev| {
                 const prev_val = self.scoring_previous[i_st_prev];
                 if (std.math.isNegativeInf(prev_val)) continue;

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -182,6 +182,14 @@ pub const Trellis = struct {
         defer current_states.deinit(allocator);
         var next_states = std.ArrayListUnmanaged(usize){};
         defer next_states.deinit(allocator);
+        // Third list for the sparse-memset three-way rotation in
+        // swapColumnsActive (#366 item 1.1). Holds the candidate-set used
+        // as input to the previous middleViterbiVals call; rotates into
+        // the role of "dirty-list for two swaps from now" so the sparse
+        // clear has the right indices in hand at every iteration without
+        // any per-active-state bookkeeping in the hot inner loop.
+        var prev_current_states = std.ArrayListUnmanaged(usize){};
+        defer prev_current_states.deinit(allocator);
 
         // Position 0: transitions from init state
         const init_st = self.hmm.initial orelse return error.NoInitState;
@@ -192,6 +200,16 @@ pub const Trellis = struct {
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
+            // Track which slots the init code wrote, so the three-way list
+            // rotation in swapColumnsActive can derive iter-2's dirty-list
+            // (= these init writes) without a separate `init_written_states`
+            // list. Treats init as a virtual "iteration 0": its
+            // current_states output is the indices it wrote, and rotates
+            // into prev_current_states at swap #1 → ready for sparse-clear
+            // at swap #2 when the buffer swap exposes these slots in
+            // scoring_current. This is the small refinement of the plan's
+            // "option (b)" (init memset alone leaves swap #2's clear empty).
+            try current_states.append(allocator, i_st);
             self.cacheViterbiVals(0, dpval, i_st);
             // Mark outbound transitions for next position (deduplicated)
             for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
@@ -205,10 +223,10 @@ pub const Trellis = struct {
         // Positions 1..seq_len-1
         var position: usize = 1;
         while (position < seq_len) : (position += 1) {
-            try self.swapColumnsActive(allocator, &current_states, &next_states);
+            self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
             try self.middleViterbiVals(allocator, current_states, &next_states, position);
         }
-        try self.swapColumnsActive(allocator, &current_states, &next_states);
+        self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
 
         // Compute ending probability
         self.ending_viterbi_pointer = -1;
@@ -250,6 +268,10 @@ pub const Trellis = struct {
         defer current_states.deinit(allocator);
         var next_states = std.ArrayListUnmanaged(usize){};
         defer next_states.deinit(allocator);
+        // Third list for the sparse-memset three-way rotation in
+        // swapColumnsActive (#366 item 1.1); see viterbi() for the rationale.
+        var prev_current_states = std.ArrayListUnmanaged(usize){};
+        defer prev_current_states.deinit(allocator);
 
         // Position 0: transitions from init state
         const init_st = self.hmm.initial orelse return error.NoInitState;
@@ -260,6 +282,10 @@ pub const Trellis = struct {
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
+            // Track which slots the init code wrote so the three-way list
+            // rotation can derive iter-2's dirty-list. See viterbi() for
+            // the longer rationale; same logic applies here verbatim.
+            try current_states.append(allocator, i_st);
             // Mark outbound transitions for next position (deduplicated)
             for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
                 if (!self.next_seen.isSet(j)) {
@@ -273,10 +299,10 @@ pub const Trellis = struct {
         // Positions 1..seq_len-1
         var position: usize = 1;
         while (position < seq_len) : (position += 1) {
-            try self.swapColumnsActive(allocator, &current_states, &next_states);
+            self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
             try self.middleForwardVals(allocator, current_states, &next_states, position);
         }
-        try self.swapColumnsActive(allocator, &current_states, &next_states);
+        self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
 
         // Compute ending probability
         self.ending_forward_log_prob = mathutils.NEG_INF;
@@ -326,28 +352,60 @@ pub const Trellis = struct {
 
     fn swapColumnsActive(
         self: *Trellis,
-        allocator: std.mem.Allocator,
         current_states: *std.ArrayListUnmanaged(usize),
         next_states: *std.ArrayListUnmanaged(usize),
-    ) !void {
-        // Swap scoring_current ↔ scoring_previous
+        prev_current_states: *std.ArrayListUnmanaged(usize),
+    ) void {
+        // Swap scoring_current ↔ scoring_previous.
         const tmp = self.scoring_previous;
         self.scoring_previous = self.scoring_current;
         self.scoring_current = tmp;
-        @memset(self.scoring_current, mathutils.NEG_INF);
+
+        // Sparse-clear scoring_current at the indices written two iterations
+        // ago (= the contents of prev_current_states at entry). After the
+        // buffer swap, scoring_current is the buffer that held those writes,
+        // so only those slots could hold non-NEG_INF; clearing them restores
+        // the same post-condition the previous full @memset gave (entire
+        // buffer NEG_INF before middle{Viterbi,Forward}Vals at iteration N
+        // writes through its current_states subset).
+        //
+        // This is the #366 item 1.1 sparse-memset path. Hot-path discipline
+        // (the rule that #369 violated): no `try`, no allocation, no fallible
+        // op in this loop — it must compile to a tight indexed store. The
+        // dirty-list arrives in `prev_current_states` as a zero-cost side
+        // effect of the three-way list rotation below; no per-active-state
+        // bookkeeping inside middle{Viterbi,Forward}Vals.
+        for (prev_current_states.items) |j| self.scoring_current[j] = mathutils.NEG_INF;
 
         // Clear next_seen for all indices that were in next_states
         // (they will become current_states; next_seen tracks what's queued for the NEW next)
         for (next_states.items) |j| self.next_seen.unset(j);
 
-        // current_states ← next_states; next_states ← empty
-        // Swap the backing allocations to avoid reallocation
-        const old_current_items = current_states.items;
-        const old_current_cap = current_states.capacity;
+        // Three-way list rotation: prev_current ← current, current ← next,
+        // next ← (old prev_current, then cleared). After this rotation:
+        //   - current_states.items = the candidate-set for the NEXT
+        //     middle{Viterbi,Forward}Vals call (i.e., what was in
+        //     next_states at entry, populated by the previous iteration);
+        //   - prev_current_states.items = the candidate-set that was just
+        //     used as input to the previous middle{...}Vals call. Those
+        //     indices name the slots in scoring_previous (post-rotation),
+        //     and will become the dirty-list for the sparse-clear two
+        //     swaps from now (when those slots have rotated back into
+        //     scoring_current via the next two buffer swaps).
+        //   - next_states is empty (clearRetainingCapacity), ready for
+        //     the next middle{...}Vals to populate the iteration-after-next
+        //     candidate set.
+        //
+        // ArrayListUnmanaged is two POD fields (items: []usize, capacity:
+        // usize); this is allocation-free struct-field assignment, no `try`.
+        const tmp_items = prev_current_states.items;
+        const tmp_capacity = prev_current_states.capacity;
+        prev_current_states.items = current_states.items;
+        prev_current_states.capacity = current_states.capacity;
         current_states.items = next_states.items;
         current_states.capacity = next_states.capacity;
-        next_states.items = old_current_items;
-        next_states.capacity = old_current_cap;
+        next_states.items = tmp_items;
+        next_states.capacity = tmp_capacity;
         next_states.clearRetainingCapacity();
         // Sort current_states in ascending order to match C++ bitset iteration
         // (0..n_states). This is critical: cacheForwardVals accumulates
@@ -356,7 +414,6 @@ pub const Trellis = struct {
         // produce different results. The cached forward_log_probs values are
         // then read by chunk-cached trellises via endingForwardLogProbAt().
         std.mem.sort(usize, current_states.items, {}, std.sort.asc(usize));
-        _ = allocator; // backing storage reuse avoids new allocations
     }
 
     fn middleViterbiVals(

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -153,6 +153,16 @@ pub const Trellis = struct {
             return;
         }
 
+        // Phase-B'' timer: capture all pre-position-loop work — log_probs/indices
+        // resize, traceback_table allocate, 4× @memset on log_probs/indices/
+        // traceback_table/scoring_current/scoring_previous, plus the position-0
+        // init transitions below. The main position-loop body is derivable as
+        // fillTrellis_viterbi_ns − init − ending. Skeptic flag (#383 review,
+        // 2026-05-12): t_init was originally placed AFTER the resize/memset
+        // block, so the O(seq_len × n_states) memsets leaked into the
+        // positionLoop residual. Moving the tick up makes init_ns honest.
+        const t_init = perf_counters.tick();
+
         // Initialize storage
         try self.viterbi_log_probs.resize(allocator, seq_len);
         try self.viterbi_indices.resize(allocator, seq_len);
@@ -219,6 +229,7 @@ pub const Trellis = struct {
                 }
             }
         }
+        perf_counters.addElapsed(&perf_counters.viterbi_init_ns, t_init);
 
         // Positions 1..seq_len-1
         var position: usize = 1;
@@ -229,6 +240,7 @@ pub const Trellis = struct {
         self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
 
         // Compute ending probability
+        const t_ending = perf_counters.tick();
         self.ending_viterbi_pointer = -1;
         self.ending_viterbi_log_prob = mathutils.NEG_INF;
         for (0..n_states) |st_prev| {
@@ -239,6 +251,7 @@ pub const Trellis = struct {
                 self.ending_viterbi_pointer = @intCast(st_prev);
             }
         }
+        perf_counters.addElapsed(&perf_counters.viterbi_ending_ns, t_ending);
     }
 
     /// Run the Forward algorithm.
@@ -255,6 +268,12 @@ pub const Trellis = struct {
             self.ending_forward_log_prob = ct.endingForwardLogProbAt(seq_len);
             return;
         }
+
+        // Phase-B'' timer: capture all pre-position-loop work — log_probs
+        // resize, 3× @memset on log_probs/scoring_current/scoring_previous, plus
+        // the position-0 init transitions below. See viterbi() above for the
+        // skeptic-flagged correction (#383 review, 2026-05-12).
+        const t_init = perf_counters.tick();
 
         // Initialize storage
         try self.forward_log_probs.resize(allocator, seq_len);
@@ -295,6 +314,7 @@ pub const Trellis = struct {
             }
             self.cacheForwardVals(0, dpval, i_st);
         }
+        perf_counters.addElapsed(&perf_counters.forward_init_ns, t_init);
 
         // Positions 1..seq_len-1
         var position: usize = 1;
@@ -305,6 +325,7 @@ pub const Trellis = struct {
         self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
 
         // Compute ending probability
+        const t_ending = perf_counters.tick();
         self.ending_forward_log_prob = mathutils.NEG_INF;
         for (0..n_states) |st_prev| {
             if (std.math.isNegativeInf(self.scoring_previous[st_prev])) continue;
@@ -312,6 +333,7 @@ pub const Trellis = struct {
             if (std.math.isNegativeInf(dpval)) continue;
             self.ending_forward_log_prob = mathutils.addInLogSpace(self.ending_forward_log_prob, dpval);
         }
+        perf_counters.addElapsed(&perf_counters.forward_ending_ns, t_ending);
     }
 
     /// Traceback to produce a path.

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -65,18 +65,6 @@ pub const Trellis = struct {
     scoring_current: []f64,
     scoring_previous: []f64,
 
-    /// Indices into scoring_current that may hold non-NEG_INF values
-    /// (a SUPERSET of truly-dirty slots — see `swapColumnsActive`). Mirrors
-    /// the swap of scoring_current ↔ scoring_previous so the sparse clear
-    /// in `swapColumnsActive` only touches slots that were active two
-    /// iterations ago, instead of the full n_states column. Item 1.1 of
-    /// #366: at rung-2 medians (~50 active states / 500 n_states) this
-    /// drops the per-position memset from O(n_states) to O(active).
-    scoring_current_dirty: std.ArrayListUnmanaged(usize),
-    /// Indices into scoring_previous that may hold non-NEG_INF values.
-    /// See `scoring_current_dirty`.
-    scoring_previous_dirty: std.ArrayListUnmanaged(usize),
-
     /// Scratch bitset for deduplicating next_states additions.
     next_seen: state_mod.StateBitset,
 
@@ -130,8 +118,6 @@ pub const Trellis = struct {
             .viterbi_indices = .{},
             .scoring_current = scoring_current,
             .scoring_previous = scoring_previous,
-            .scoring_current_dirty = .{},
-            .scoring_previous_dirty = .{},
             .next_seen = state_mod.StateBitset.initEmpty(),
             .allocator = allocator,
         };
@@ -146,8 +132,6 @@ pub const Trellis = struct {
         self.viterbi_indices.deinit(allocator);
         allocator.free(self.scoring_current);
         allocator.free(self.scoring_previous);
-        self.scoring_current_dirty.deinit(allocator);
-        self.scoring_previous_dirty.deinit(allocator);
     }
 
     /// Run the Viterbi algorithm.
@@ -190,13 +174,9 @@ pub const Trellis = struct {
         @memset(self.traceback_table, -1);
         self.traceback_n_states = n_states;
 
-        // Reset scoring columns. Dirty lists pair with the buffers and start
-        // empty: the full memset establishes the all-NEG_INF invariant that
-        // the sparse clear in `swapColumnsActive` relies on.
+        // Reset scoring columns
         @memset(self.scoring_current, mathutils.NEG_INF);
         @memset(self.scoring_previous, mathutils.NEG_INF);
-        self.scoring_current_dirty.clearRetainingCapacity();
-        self.scoring_previous_dirty.clearRetainingCapacity();
 
         var current_states = std.ArrayListUnmanaged(usize){};
         defer current_states.deinit(allocator);
@@ -212,7 +192,6 @@ pub const Trellis = struct {
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
-            try self.scoring_current_dirty.append(allocator, i_st);
             self.cacheViterbiVals(0, dpval, i_st);
             // Mark outbound transitions for next position (deduplicated)
             for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
@@ -263,11 +242,9 @@ pub const Trellis = struct {
         try self.forward_log_probs.resize(allocator, seq_len);
         @memset(self.forward_log_probs.items, mathutils.NEG_INF);
 
-        // Reset scoring columns. See `viterbi()` for the dirty-list invariant.
+        // Reset scoring columns
         @memset(self.scoring_current, mathutils.NEG_INF);
         @memset(self.scoring_previous, mathutils.NEG_INF);
-        self.scoring_current_dirty.clearRetainingCapacity();
-        self.scoring_previous_dirty.clearRetainingCapacity();
 
         var current_states = std.ArrayListUnmanaged(usize){};
         defer current_states.deinit(allocator);
@@ -283,7 +260,6 @@ pub const Trellis = struct {
             const dpval = emission_val + init_st.transitionLogprob(i_st);
             if (std.math.isNegativeInf(dpval)) continue;
             self.scoring_current[i_st] = dpval;
-            try self.scoring_current_dirty.append(allocator, i_st);
             // Mark outbound transitions for next position (deduplicated)
             for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
                 if (!self.next_seen.isSet(j)) {
@@ -354,23 +330,11 @@ pub const Trellis = struct {
         current_states: *std.ArrayListUnmanaged(usize),
         next_states: *std.ArrayListUnmanaged(usize),
     ) !void {
-        // Swap scoring_current ↔ scoring_previous, and the parallel dirty
-        // lists. After the swap, `scoring_current` is the buffer that was
-        // last written *two* iterations ago (or position-0 init); only the
-        // slots in `scoring_current_dirty` (the freshly-swapped-in list) can
-        // be non-NEG_INF, so a sparse clear over those slots restores the
-        // all-NEG_INF invariant. Item 1.1 of #366.
-        std.mem.swap([]f64, &self.scoring_current, &self.scoring_previous);
-        std.mem.swap(
-            std.ArrayListUnmanaged(usize),
-            &self.scoring_current_dirty,
-            &self.scoring_previous_dirty,
-        );
-
-        for (self.scoring_current_dirty.items) |idx| {
-            self.scoring_current[idx] = mathutils.NEG_INF;
-        }
-        self.scoring_current_dirty.clearRetainingCapacity();
+        // Swap scoring_current ↔ scoring_previous
+        const tmp = self.scoring_previous;
+        self.scoring_previous = self.scoring_current;
+        self.scoring_current = tmp;
+        @memset(self.scoring_current, mathutils.NEG_INF);
 
         // Clear next_seen for all indices that were in next_states
         // (they will become current_states; next_seen tracks what's queued for the NEW next)
@@ -409,12 +373,6 @@ pub const Trellis = struct {
             const st_cur = self.hmm.stateByIndex(i_st_cur);
             const emission_val = st_cur.emissionLogprobSeqs(seqs, position);
             if (std.math.isNegativeInf(emission_val)) continue;
-            // Track for the sparse clear in `swapColumnsActive`. This is a
-            // SUPERSET of slots we actually write: if every i_st_prev has
-            // NEG_INF prev_val, no write happens but i_st_cur is still in the
-            // dirty list. Clearing an already-NEG_INF slot is a no-op, so the
-            // superset is bit-equal.
-            try self.scoring_current_dirty.append(allocator, i_st_cur);
             for (st_cur.from_state_indices.items) |i_st_prev| {
                 const prev_val = self.scoring_previous[i_st_prev];
                 if (std.math.isNegativeInf(prev_val)) continue;
@@ -450,8 +408,6 @@ pub const Trellis = struct {
             const st_cur = self.hmm.stateByIndex(i_st_cur);
             const emission_val = st_cur.emissionLogprobSeqs(seqs, position);
             if (std.math.isNegativeInf(emission_val)) continue;
-            // See `middleViterbiVals` for the dirty-list invariant.
-            try self.scoring_current_dirty.append(allocator, i_st_cur);
             for (st_cur.from_state_indices.items) |i_st_prev| {
                 const prev_val = self.scoring_previous[i_st_prev];
                 if (std.math.isNegativeInf(prev_val)) continue;

--- a/packages/zig-core/src/main.zig
+++ b/packages/zig-core/src/main.zig
@@ -29,3 +29,18 @@ pub fn main() !void {
 }
 
 var gpa_instance = std.heap.GeneralPurposeAllocator(.{}){};
+
+// In test mode, force the analyzer to walk all decls reachable from the
+// executable so that tests in transitively-imported files get discovered by
+// `zig build test`. Without this, only tests in main.zig itself would run —
+// and main.zig has no tests. (`refAllDeclsRecursive` is a no-op outside tests.)
+//
+// The eval-branch quota is bumped because `refAllDeclsRecursive` walks the
+// full decl tree of `bcrham` (and everything it imports — args, model, state,
+// dp_handler, glomerator, bcr_utils, etc.); the default 1000 is exceeded.
+// 20000 was the smallest round number that compiled with current sources;
+// raise it (don't lower) if a future module addition trips the quota again.
+test {
+    @setEvalBranchQuota(20000);
+    std.testing.refAllDeclsRecursive(bcrham);
+}

--- a/partis/partitiondriver.py
+++ b/partis/partitiondriver.py
@@ -37,6 +37,17 @@ from .hist import Hist
 from . import seqfileopener
 
 # ----------------------------------------------------------------------------------------
+# Process-global accumulator for bcrham subprocess wall time, used to print a
+# "bcrham time: X (Y% of total)" summary alongside the final "total time:" line
+# in bin/partis. Phase 0 of issue #366 deferred pinning the bcrham fraction
+# pending partis-level timing instrumentation; this is that instrumentation.
+_cumul_bcrham_time = 0.0
+_cumul_bcrham_calls = 0
+
+def get_bcrham_summary():
+    return _cumul_bcrham_time, _cumul_bcrham_calls
+
+# ----------------------------------------------------------------------------------------
 class PartitionDriver(object):
     """ Class to parse input files, start bcrham jobs, and parse/interpret bcrham output for annotation and partitioning """
     def __init__(self, args, glfo, input_info, simglfo, reco_info):
@@ -1390,7 +1401,11 @@ class PartitionDriver(object):
                    'outfname' : get_outfname(iproc),
                    'dbgfo' : self.bcrham_proc_info[iproc]}
                   for iproc in range(n_procs)]
+        run_start = time.time()
         utils.run_cmds(cmdfos, batch_system=self.args.batch_system, batch_options=self.args.batch_options, batch_config_fname=self.args.batch_config_fname, debug='print' if self.args.debug else None)
+        global _cumul_bcrham_time, _cumul_bcrham_calls
+        _cumul_bcrham_time += time.time() - run_start
+        _cumul_bcrham_calls += 1
         self.print_partition_dbgfo()
 
         self.check_wait_times(time.time()-start)


### PR DESCRIPTION
## What lands

17+ commits on `366-zig-perf-next`. Three workstreams, one PR:

1. **Parity fix** (#375): the 30k Zig-vs-C++ paired-partition divergence latent since the Zig integration (#339). Root cause was f32 narrowing of Viterbi scores + unstable sort over ties. Fix is a coordinated [cpp-mirror] change: `stable_sort` in `Result::Finalize` and `float`→`double` for `mute_freq_`, `RecoEvent::score_`, and four cluster-merge thresholds — same change on both backends. After this PR, **paired-loci output is byte-identical Zig=C++ at 5k, 30k, and 50k** (verified today with current builds; see Parity evidence below).
2. **Perf** (#366 items 3.2, 1.1, lever 1): fast_softplus LUT, sparse `@memset` in `swapColumnsActive` via three-way list rotation, and a `PerGeneCache` pointer-bundle hoist in `runKSet`. End-to-end at 50k paired: Zig wall is **~2.5× faster than current C++** (2h59m vs 7h29m, N=1 sequential, precision limited by single-run variance) and Zig peak RSS is **~8% lighter than current C++** (13.5 vs 14.7 GB). The Zig RSS itself dropped **41% vs Apr 29 Zig** (22.8 → 13.5 GB) over the course of the perf workstream — that's a Zig-vs-old-Zig delta, not a Zig-vs-C++ delta.
3. **Instrumentation** (#366 phases 0, A, B): `-Dperf-counters=true` build flag gates `comptime` counters, sub-phase `std.time.Instant` timers, partis-level bcrham wall timer, and the `bin/zig-perf-counters-{run.sh,aggregate.py}` harness. Default ReleaseFast build is bit-equal with counters off.

## Parity status: confirmed byte-identical at 50k

Originally this PR text flagged a single-chain `partition-igk.yaml` divergence at 50k (#386) as an open blocker. **That divergence was caused by a stale May-11 cpp baseline** made with a pre-#377 bcrham binary. Today's instrumented n_procs=10 50k runs with current builds:

| file | md5 | Zig vs C++ |
|---|---|---|
| `igh+igk/partition-igh.yaml` (49251 events) | `7eb5308871a35e0d567f019bbaf7c3aa` | **match** |
| `igh+igk/partition-igk.yaml` | `f68eeedfe62796f171740b00dfb41b2d` | **match** |
| top-level `partition-igh.yaml` | `746c23752cfe870cf1a6a5a468c35987` | **match** |
| top-level `partition-igk.yaml` | `f68eeedfe62796f171740b00dfb41b2d` | **match** |
| `single-chain/partition-igh.yaml` | `3600e71a19f13555558f407afcb4b0d8` | **match** |
| `single-chain/partition-igk.yaml` | `b4f3ba34f824c7d6b603d5c4096de76e` | **match** ✓ |

`bin/zig-compare.py /tmp/dbg-cpp-50k-n10 /tmp/dbg-zig-50k-n10` returns `OK: identical` across all six files. See #386 for the full diagnostic trail.

Smaller workloads (all match): 5k bit-identical (3797 igh + 3802 igk events, #378); 30k bit-identical including single-chain (verified on-disk at `/tmp/parity-30k-377-{zig,cpp}`).

## Submodule

`packages/ham` bumps `f41e055a6` → `ca0930be1`, picking up:
- `419ec56` fast_softplus LUT (ham#19, merged)
- `35bf4a9` stable_sort events in `Result::Finalize` (ham#20, **still open against ham main**)
- `ca0930b` float→double for mute_freq + thresholds + RecoEvent::score (ham#21, **still open against ham#20's branch**)

ham#20 and ham#21 must land in ham main before this partis PR is mergeable; the submodule pointer currently sits on the ham topic branch `375-stable-sort-events`.

## Timing — end-to-end (N=1 sequential, pax, 2026-05-11)

50k paired collision input (`--n-procs 10 --no-time-based-n-proc-reduction`), Zig run completed before C++ run (warm-cache favours C++):

| metric | Zig | C++ | ratio |
|---|---|---|---|
| Wall | 2h58m52s | 7h28m56s | Zig ~2.5× faster |
| User CPU | 53,536 s | 112,210 s | 2.10× less |
| Avg cores | 500% | 417% | — |
| Peak RSS | 13.5 GB | 14.7 GB | 1.2 GB less |

Zig-vs-Zig peak RSS, same 50k workload: **22.8 GB (Apr 29) → 13.5 GB (May 11), −41%**. Best-guess attribution: PR #365 (#342 items 2–22, per-kset arena + scratch arena + allocator routing) is the only commit in the window with allocator-shape changes large enough to move RSS by that magnitude; not bisected.

The wall improvement (4h17m → 2h59m, 1.43×) reflects #372 fast_softplus + #380 swap rotation + #381 hoist landing in the same window.

## Timing — per-PR contribution

5k paired partition bcrham wall (median-of-N, `--n-procs 1`):

| PR | change | Zig bcrham wall | C++ bcrham wall |
|---|---|---|---|
| #372 | fast_softplus LUT (item 3.2) | **−23.7%** | **−15.3%** |
| #380 | sparse `@memset` via 3-way rotation (item 1.1) | within noise (n=3, Δ ≥ −0.5% gate met) | — |
| #381 | `PerGeneCache` hoist (lever 1) | within noise (sign-flip across n=15) | — |

#372 is the only landed item with a wall claim outside the n=3 noise floor. #380 and #381 cleared their acceptance gate (no regression, code-clarity + dead-error-path benefits) but did not move the bcrham mean.

## Timing — sub-phase breakdown (2k paired, from PR #383 perf-counters)

```
                                     viterbi      forward
dpHandler_run_total                   35.484 s    143.593 s
  fillTrellis body                    29.719      136.511
    DP body (viterbi/forward)         27.928 (79.8%)   132.713 (92.8%)
      init                             0.424 ( 1.5%)     1.001 ( 0.7%)
      positionLoop (derived)          27.470 (78.3%)   131.491 (92.0%)
      ending                           0.034 ( 0.1%)     0.221 ( 0.2%)
    chunkScan / tmpInit / traceback / put / cachedPath   each <1%
  runKSet plumbing                     1.234 ( 3.5%)     4.334 ( 3.0%)
  run() pre/post-runKSet               4.420 (12.6%)     2.520 ( 1.8%)

Glomerator.cluster (55 bcrham procs):  152.117 s, driver_overhead 6.008 s (3.9%)
Glomerator.cacheNaiveSeqs (8 procs):     8.128 s, driver_overhead 0.077 s (1.0%)
```

98–99 % of DP body time is in the position loop. Remaining lever surface lives inside `middleViterbiVals` / `middleForwardVals` / `swapColumnsActive`.

## Tooling shipped

- `bin/partis-30k-parity-test.sh` — Zig-vs-C++ parity gate. Runs both backends on N-query paired partition, diffs cluster membership + per-event annotations. Exits non-zero on diff. Default N=30000; takes N as arg for 50k re-runs.
- `bin/zig-compare.py` — comparison harness used by the gate. Now walks all six output files (`single-chain/`, `igh+igk/`, `igh+igl/`, top-level) and includes an md5 fast-path that catches byte-level reorders (would have surfaced the #386 stale-baseline ambiguity sooner).
- `bin/zig-perf-counters-{run.sh,aggregate.py}` — rebuilds Zig with `-Dperf-counters=true`, runs a partition, aggregates per-query distributions + chunk-cache hit-rate, restores the ReleaseFast build.

## Out of scope

- Memory-parity workstream (Zig is ~18–39% heavier per-bcrham-subprocess than C++ on 5k paired) — filed as #384.
- Further #366 levers (Phase B's timing data shows 98–99% of DP body is in the position-loop inner kernel; remaining surface area is inside `middle{Viterbi,Forward}Vals`).

## Test plan

- [x] #386 single-chain igk parity at 50k → closed (was stale baseline; current cpp+zig byte-identical, md5 `b4f3ba34`)
- [ ] ham#20 + ham#21 land on ham main; re-bump submodule to the merge commits
- [x] `bin/partis-test.py --paired --no-simu` (also non-paired): 4 runs (cpp/zig × paired/nopair) all exit 0, identical performance metrics across backends, zero result-content diffs on overlap
