### PR TITLE
read_airr_output: O(N^2 log N) -> O(N log N)

### DIFF
--- a/partis/utils.py
+++ b/partis/utils.py
@@ -2320,14 +2320,15 @@ def read_airr_output(fname, glfo=None, locus=None, glfo_dir=None, skip_other_loc
     if len(plines) > 0:
         sorted_ids = [l['unique_ids'][0] for l in plines]
         sorted_id_set = set(sorted_ids)
+        sorted_id_idx = {u : i for i, u in enumerate(sorted_ids)}  # avoid sorted_ids.index() inside the sort key (used to make read_airr_output O(N^2 log N) — observed ~10 hr on 432k-row AIRR TSVs)
         partition = [[u for u in c if u in sorted_id_set] for c in partition]
         partition = [c for c in partition if len(c) > 0]
-        partition = sorted(partition, key=lambda c: min(sorted_ids.index(u) for u in c))  # sort by min index in <sorted_ids> of any uid in each cluster
+        partition = sorted(partition, key=lambda c: min(sorted_id_idx[u] for u in c))  # sort by min index in <sorted_ids> of any uid in each cluster
     antn_list = []
     if len(plines) > 0:
         antn_dict = get_annotation_dict(plines)
         for iclust, cluster in enumerate(partition):  # may as well sort by length, otherwise order is just random
-            cluster = [u for u in sorted_ids if u in cluster]  # it's nice to try to keep them in the same order, and if partis wrote the single-seq lines this'll put them back in the same order
+            cluster = sorted(cluster, key=lambda u: sorted_id_idx[u])  # nice to keep cluster members in input order; was previously `[u for u in sorted_ids if u in cluster]` which is O(N) per cluster -> O(N^2) overall on big AIRR TSVs
             partition[iclust] = cluster
             multi_line = synthesize_multi_seq_line_from_reco_info(cluster, antn_dict)
             # print_reco_event(multi_line, extra_str='  ')


### PR DESCRIPTION
## Summary

Two list-scan-in-loop spots inside `read_airr_output` made it quadratic on AIRR TSVs with one cluster per sequence (the common case when there's no `clone_id` column):

1. `sorted(partition, key=lambda c: min(sorted_ids.index(u) for u in c))` — `list.index()` is O(N), called once per cluster during sort, so the sort was O(N² log N).

2. `cluster = [u for u in sorted_ids if u in cluster]` inside the per-cluster `antn_list` loop — O(N) per cluster, O(N²) overall.

Both replaced with a precomputed `sorted_id_idx` dict so lookup is O(1). The final cluster ordering is identical to before — clusters are still in input order, members inside each cluster are still in input order.

## Measured impact

Same partis API, same input, on a 432k-row IGL AIRR TSV from IgBLAST `-outfmt 19`:

| N (rows) | before     | after    |
|----------|-----------:|---------:|
| 10k      | 12 s       | 12 s     |
| 100k     | >11 min    | 68 s     |
| 432k     | 10.3 hr    | ~5 min   |

Linear scaling confirmed across the range.

## Context

Caught while running IgBLAST as an independent annotator for issue matsengrp/loris-experiments#254 thread 3 — needed to drive `ParameterCounter` from IgBLAST AIRR output across full-size training sets (~1M sequences per locus).

## Test plan

- No behavior change: same partition ordering, same `antn_list` contents.
- Verified on a 100k IGL TSV that the result matches input order (each `cluster = sorted(cluster, key=lambda u: sorted_id_idx[u])` is a deterministic re-sort by input position).

🤖 Generated with [Claude Code](https://claude.com/claude-code)