### PR TITLE
AIRR tsv I/O only: consistent light-chain N-region field (#389)

### DIFF
--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -26,10 +26,11 @@ To have partis write to an AIRR-format tsv file, set the partis option `--airr-o
 To convert existing partis output to AIRR tsv, pass the same option to `bin/parse-output.py`.
 Both `bin/partis` and `bin/parse-output.py` also take AIRR files as input with the flag `--airr-input`.
 
-One subtlety of these AIRR files concerns light chain (igk/igl) N regions.
-Light chain has no D gene, so there is a single VJ N region, which partis always keeps internally in `dj_insertion` (with `vd_insertion` empty).
-In the tsv, though, it goes in the `np1` column (with `np2` empty), following the AIRR spec, where `np1` is the N region between V and D, or between V and J when there is no D.
-When reading, partis takes `np1` + `np2` (one is always empty) back into `dj_insertion`, so files written by either partis or an external tool such as IgBLAST are handled the same way.
+One subtlety of these AIRR files concerns the light chain (igk/igl) N region.
+Light chain has no D gene, so there is a single VJ N region, which partis stores internally in `dj_insertion` (with `vd_insertion` empty).
+In the tsv, partis writes it to the `np1` column (with `np2` empty), following the AIRR spec, where `np1` is the N region between V and D, or between V and J when there is no D.
+This is also where external tools such as IgBLAST write it, so their files read back correctly.
+(For back-compatibility the reader also accepts the N region in `np2`, which is where partis versions before this change wrote it.)
 
 For more information on all options, run `partis <action> --help`.
 

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -27,7 +27,7 @@ To convert existing partis output to AIRR tsv, pass the same option to `bin/pars
 Both `bin/partis` and `bin/parse-output.py` also take AIRR files as input with the flag `--airr-input`.
 
 Note on light chain (igk/igl) N regions: since light chain has no D gene, there is a single VJ N region.
-Partis stores this internally in `dj_insertion` (matching the convention used by `cache-parameters`), but writes it to the AIRR `np1` field (and leaves `np2` empty), following the AIRR spec, in which `np1` is the N region between V and D *or between V and J* when there is no D.
+Partis always stores this internally in `dj_insertion` (`vd_insertion` is left empty for light chain), but writes it to the AIRR `np1` field (and leaves `np2` empty), following the AIRR spec, in which `np1` is the N region between V and D *or between V and J* when there is no D.
 On input, partis reads the light-chain N region from `np1` + `np2` (one is always empty) back into `dj_insertion`, so files from either partis or external tools (e.g. IgBLAST, which also uses `np1`) are handled correctly.
 
 For more information on all options, run `partis <action> --help`.

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -26,6 +26,10 @@ To have partis write to an AIRR-format tsv file, set the partis option `--airr-o
 To convert existing partis output to AIRR tsv, pass the same option to `bin/parse-output.py`.
 Both `bin/partis` and `bin/parse-output.py` also take AIRR files as input with the flag `--airr-input`.
 
+Note on light chain (igk/igl) N regions: since light chain has no D gene, there is a single VJ N region.
+Partis stores this internally in `dj_insertion` (matching the convention used by `cache-parameters`), but writes it to the AIRR `np1` field (and leaves `np2` empty), following the AIRR spec, in which `np1` is the N region between V and D *or between V and J* when there is no D.
+On input, partis reads the light-chain N region from `np1` + `np2` (one is always empty) back into `dj_insertion`, so files from either partis or external tools (e.g. IgBLAST, which also uses `np1`) are handled correctly.
+
 For more information on all options, run `partis <action> --help`.
 
 #### output file overview

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -26,9 +26,10 @@ To have partis write to an AIRR-format tsv file, set the partis option `--airr-o
 To convert existing partis output to AIRR tsv, pass the same option to `bin/parse-output.py`.
 Both `bin/partis` and `bin/parse-output.py` also take AIRR files as input with the flag `--airr-input`.
 
-Note on light chain (igk/igl) N regions: since light chain has no D gene, there is a single VJ N region.
-Partis always stores this internally in `dj_insertion` (`vd_insertion` is left empty for light chain), but writes it to the AIRR `np1` field (and leaves `np2` empty), following the AIRR spec, in which `np1` is the N region between V and D *or between V and J* when there is no D.
-On input, partis reads the light-chain N region from `np1` + `np2` (one is always empty) back into `dj_insertion`, so files from either partis or external tools (e.g. IgBLAST, which also uses `np1`) are handled correctly.
+One subtlety of these AIRR files concerns light chain (igk/igl) N regions.
+Light chain has no D gene, so there is a single VJ N region, which partis always keeps internally in `dj_insertion` (with `vd_insertion` empty).
+In the tsv, though, it goes in the `np1` column (with `np2` empty), following the AIRR spec, where `np1` is the N region between V and D, or between V and J when there is no D.
+When reading, partis takes `np1` + `np2` (one is always empty) back into `dj_insertion`, so files written by either partis or an external tool such as IgBLAST are handled the same way.
 
 For more information on all options, run `partis <action> --help`.
 

--- a/partis/utils.py
+++ b/partis/utils.py
@@ -2138,8 +2138,9 @@ def convert_airr_line(aline, glfo):
             pline[pky] = [aline[aky]] if pky in linekeys['per_seq'] else aline[aky]  # NOTE/TODO all end up as single-sequence annotations
     pline['duplicates'] = [[]]
 
-    if not has_d_gene(glfo['locus']):  # light chain (igk/igl) has a single VJ N region, which partis always keeps in dj_insertion (vd_insertion stays empty for light chain). External AIRR tools (e.g. igblast), and partis's own airr writer, put it in np1 -> vd_insertion; older/other files may have it in np2 -> dj_insertion. Concatenate (one is always empty for light chain) so we land in dj_insertion regardless of source. See issue #389.
-        pline['dj_insertion'] = pline['vd_insertion'] + pline['dj_insertion']
+    if not has_d_gene(glfo['locus']):  # light chain (igk/igl) has a single VJ N region, which partis always keeps in dj_insertion (vd_insertion stays empty for light chain). External AIRR tools (e.g. igblast), and partis's own airr writer, put it in np1 -> vd_insertion; older/other files may have it in np2 -> dj_insertion. Move it to dj_insertion regardless of source. See issue #389.
+        assert pline['vd_insertion'] == '' or pline['dj_insertion'] == ''  # at most one is populated (light chain has a single N region); if both were set we'd be silently merging two distinct insertions, which would mean the file doesn't follow either convention
+        pline['dj_insertion'] = pline['vd_insertion'] + pline['dj_insertion']  # one is always empty, so this just moves whichever is set into dj_insertion
         pline['vd_insertion'] = ''
 
     # print aline['v_call'], aline['d_call'], aline['j_call']

--- a/partis/utils.py
+++ b/partis/utils.py
@@ -2132,6 +2132,10 @@ def convert_airr_line(aline, glfo):
             pline[pky] = [aline[aky]] if pky in linekeys['per_seq'] else aline[aky]  # NOTE/TODO all end up as single-sequence annotations
     pline['duplicates'] = [[]]
 
+    if not has_d_gene(glfo['locus']):  # light chain (igk/igl) has a single VJ N region. partis's convention (matching cache-parameters) keeps it in dj_insertion, but external AIRR tools (e.g. igblast) put it in np1 -> vd_insertion, while partis writes it to np2 -> dj_insertion. Concatenate (one is always empty for light chain) so we land in dj_insertion regardless of source, and partis-written files still round-trip. See issue #389.
+        pline['dj_insertion'] = pline['vd_insertion'] + pline['dj_insertion']
+        pline['vd_insertion'] = ''
+
     # print aline['v_call'], aline['d_call'], aline['j_call']
     if aline['d_germline_start'] == '':  # igblast leaves this blank for light chain (and sometimes for heavy)
         d_start, d_end = [int(float(aline['v_germline_end'])) + 1 for _ in range(2)]

--- a/partis/utils.py
+++ b/partis/utils.py
@@ -2138,7 +2138,7 @@ def convert_airr_line(aline, glfo):
             pline[pky] = [aline[aky]] if pky in linekeys['per_seq'] else aline[aky]  # NOTE/TODO all end up as single-sequence annotations
     pline['duplicates'] = [[]]
 
-    if not has_d_gene(glfo['locus']):  # light chain (igk/igl) has a single VJ N region. partis's convention (matching cache-parameters) keeps it in dj_insertion, but external AIRR tools (e.g. igblast) put it in np1 -> vd_insertion, while partis writes it to np2 -> dj_insertion. Concatenate (one is always empty for light chain) so we land in dj_insertion regardless of source, and partis-written files still round-trip. See issue #389.
+    if not has_d_gene(glfo['locus']):  # light chain (igk/igl) has a single VJ N region, which partis always keeps in dj_insertion (vd_insertion stays empty for light chain). External AIRR tools (e.g. igblast), and partis's own airr writer, put it in np1 -> vd_insertion; older/other files may have it in np2 -> dj_insertion. Concatenate (one is always empty for light chain) so we land in dj_insertion regardless of source. See issue #389.
         pline['dj_insertion'] = pline['vd_insertion'] + pline['dj_insertion']
         pline['vd_insertion'] = ''
 

--- a/partis/utils.py
+++ b/partis/utils.py
@@ -2111,6 +2111,12 @@ def get_airr_line(pline, iseq, extra_columns=None, skip_columns=None, args=None,
         else:
             raise Exception('unhandled airr key / partis key \'%s\' / \'%s\'' % (akey, pkey))
 
+    if not has_d_gene(get_locus(pline['v_gene'])):  # light chain (igk/igl): single VJ N region, which partis keeps in dj_insertion. AIRR's convention (and external tools like igblast) put it in np1 (the V-J junction, since there's no D), with np2 empty -- so emit it there. The reader (convert_airr_line) reverses this. See issue #389.
+        if 'np1' in aline:
+            aline['np1'] = pline['vd_insertion'] + pline['dj_insertion']  # vd_insertion is always empty for light chain, but concatenate to mirror the reader and be robust
+        if 'np2' in aline:
+            aline['np2'] = ''
+
     if extra_columns is not None:
         for key in extra_columns:
             if key in pline:


### PR DESCRIPTION
## Scope

**This PR changes only how partis reads and writes AIRR-format tsv files** (`--airr-input` / `--airr-output`, i.e. `read_airr_output`/`convert_airr_line` and `write_airr_output`/`get_airr_line`). Partis's native yaml output, its in-memory annotation representation, and every internal engine (SW, HMM, simulation, cache-parameters) are **unchanged**: partis still always stores the light-chain N region in `dj_insertion` internally. The only thing that changes is the mapping between that internal `dj_insertion` field and the AIRR `np1`/`np2` columns on the way in and out of AIRR tsv files.

## Summary

Fixes #389. Makes partis's **AIRR tsv** read and write consistent with each other, with partis's internal convention, and with the AIRR spec, for the light-chain (igk/igl) VJ N region.

Light chain has no D gene, so there is a single VJ N region. The conventions involved:

- **partis internal (unchanged by this PR)**: partis always stores the light-chain N region in `dj_insertion` (`vd_insertion` is left empty for light chain). This is partis's universal internal layout — annotate, partition, simulate, and cache-parameters all use it — so it's what `ParameterCounter` histograms and any HMM-vs-AIRR parameter comparison expect.
- **AIRR spec**: `np1` is the N region between V and D *or between V and J* when there is no D; `np2` is strictly the D–J region. So in an AIRR file the light-chain N region belongs in `np1`.
- **external tools** (e.g. IgBLAST): follow the AIRR spec — light-chain N region in `np1`.

Before this PR, partis's AIRR tsv I/O disagreed with all of the above:
- **read**: `convert_airr_line` mapped `np1` → `vd_insertion` unconditionally, so reading an external AIRR file put the light-chain N region in `vd_insertion`, while partis's own pipeline keeps it in `dj_insertion`. Anything mixing the two paths then read two different fields for the same quantity and silently produced wrong results (the symptom in #389 was a light-chain `dj_insertion` TVD of exactly 0.0 — the real N-region distribution was sitting in `vd_insertion.csv` on both sides).
- **write**: `get_airr_line` emitted the light-chain N region in the AIRR `np2` column (from `dj_insertion`), matching neither the AIRR spec nor external tools.

## Changes (both AIRR-tsv-only)

**AIRR read** (`convert_airr_line`): for light chain, `dj_insertion = np1 + np2` (one is always empty), `vd_insertion = ''`. Handles igblast (`np1`), AIRR-standard partis output (`np1`), and legacy partis output (`np2`) — all normalize to partis's canonical internal `dj_insertion`.

**AIRR write** (`get_airr_line`): for light chain, emit the N region in the AIRR `np1` column with `np2` empty, following the AIRR spec.

**Docs**: documented the AIRR-tsv convention in `docs/output-formats.md`.

Heavy chain AIRR I/O is untouched (guarded by `not has_d_gene`) — partis `vd_insertion`/`dj_insertion` already correspond to AIRR `np1`/`np2` for loci with a D.

## Verification

Round-trip on `test/paired/ref-results/partition-new-simu/partition-igk.yaml` (igk) and `partition-igh.yaml` (igh) — native yaml in, AIRR tsv out, AIRR tsv back in:

- **Light-chain AIRR write**: N region now emitted in `np1` (AIRR-standard), `np2` empty.
- **Light-chain round-trip** (yaml→AIRR→read): N region lands back in `dj_insertion`, `vd_insertion` empty, `naive_seq` unchanged — 0 mismatches.
- **IgBLAST-style AIRR read** (N in `np1`, synthesized): N region → `dj_insertion`, `naive_seq` matches source. (Before: went to `vd_insertion` — the bug.)
- **Legacy partis AIRR read** (N in `np2`): still normalizes to `dj_insertion`.
- **Heavy chain (igh)**: 0 round-trip mismatches across 15 annotations.
- `partis-test.py --quick`: passes (the standard suite does not exercise the AIRR path; there are no AIRR reference files to update).

Safe geometrically because the light-chain dummy D is zero-length (`d_gl_seq=''`, regional bound `d=(N,N)`), so `vd_insertion` and `dj_insertion` sit at the same V/J junction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)