### PR TITLE
docs: document the optional zig backend (--zig)

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -4,6 +4,7 @@
 
 Partis can be installed via:
   - [pip and pipx](#installation-with-pip-or-pipx): recommended
+  - [the optional zig backend](#zig-backend): faster, lower-memory, almost nothing to install
   - [additional steps for simulation installation](#simulation)
   - [with Docker](#installation-with-docker)
   - [plotting dependencies](#plotting)
@@ -53,15 +54,17 @@ partis-test.py --no-simu
 partis-test.py --paired --no-simu
 ```
 
-##### Zig backend (optional)
+#### Zig backend
 
 Partis includes an optional alternative backend, written in [Zig](https://ziglang.org), that replaces the default C++ `bcrham` and C `ig-sw` binaries.
-It is much faster, uses substantially less memory, and has far fewer dependencies, but has not yet been tested as thoroughly, so it is opt-in (see [`--zig`](subcommands.md#the-zig-backend---zig)).
-To build it (no extra system dependencies beyond a C toolchain; the script fetches a pinned Zig compiler into the tree):
+It is much faster, uses less memory, and has far fewer dependencies, but has not yet been tested as thoroughly, so it is opt-in (see [`--zig`](subcommands.md#the-zig-backend---zig)).
+
+There is essentially nothing extra to install: it needs no new system packages (one of its advantages), and `bin/zig-build.sh` downloads its own pinned Zig compiler into the source tree (`packages/zig-core/.zig-install/`), so it doesn't touch your system or environment.
+Just run, from the partis directory:
 ```bash
 bin/zig-build.sh
 ```
-Then add `--zig` to any partis command to use it instead of the default backend.
+This compiles the in-tree backend (a minute or two). Then add `--zig` to any partis command to use it instead of the default backend.
 
 #### Simulation
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -53,6 +53,16 @@ partis-test.py --no-simu
 partis-test.py --paired --no-simu
 ```
 
+##### Zig backend (optional)
+
+Partis includes an optional alternative backend, written in [Zig](https://ziglang.org), that replaces the default C++ `bcrham` and C `ig-sw` binaries.
+It is much faster, uses substantially less memory, and has far fewer dependencies, but has not yet been tested as thoroughly, so it is opt-in (see [`--zig`](subcommands.md#the-zig-backend---zig)).
+To build it (no extra system dependencies beyond a C toolchain; the script fetches a pinned Zig compiler into the tree):
+```bash
+bin/zig-build.sh
+```
+Then add `--zig` to any partis command to use it instead of the default backend.
+
 #### Simulation
 
 A variety of partis simulation options will work using the base install described above; however for full functionality you'll need to install R and some R packages, as well as potentially compile bio++.

--- a/docs/subcommands.md
+++ b/docs/subcommands.md
@@ -19,6 +19,7 @@
     - [germline sets](#germline-sets)
   - [simulate](#simulate) make simulated sequences
   - [other topics](#other-topics)
+    - [the zig backend (--zig)](#the-zig-backend---zig) faster, lower-memory, fewer-dependency backend (opt-in)
     - [restricting to certain partitions or clusters](#restricting-to-certain-partitions-or-clusters)
     - [subcluster annotation](#subcluster-annotation)
 	- [annotation uncertainties (alternative annotations)](#annotation-uncertainties-alternative-annotations)
@@ -465,6 +466,17 @@ You can then add novel alleles to the germline set by telling it how many novel 
 
 
 ### other topics
+
+##### the zig backend (`--zig`)
+
+Partis ships an alternative backend, written in [Zig](https://ziglang.org), that replaces the default C++ `bcrham` and C `ig-sw` binaries.
+It is much faster, uses substantially less memory, and has far fewer dependencies than the default backend, but has not yet been tested as thoroughly, so for now it remains opt-in.
+Output is intended to be identical to the default backend (the two are checked for byte-identical results on paired clustering).
+
+Build it once with `bin/zig-build.sh` (this fetches a pinned Zig compiler and compiles the in-tree backend; see [install](install.md#zig-backend-optional)), then add `--zig` to any partis command, e.g.:
+```
+partis --zig annotate --infname <input> --outfname <output>
+```
 
 ##### restricting to certain partitions or clusters
 

--- a/docs/subcommands.md
+++ b/docs/subcommands.md
@@ -470,10 +470,10 @@ You can then add novel alleles to the germline set by telling it how many novel 
 ##### the zig backend (`--zig`)
 
 Partis ships an alternative backend, written in [Zig](https://ziglang.org), that replaces the default C++ `bcrham` and C `ig-sw` binaries.
-It is much faster, uses substantially less memory, and has far fewer dependencies than the default backend, but has not yet been tested as thoroughly, so for now it remains opt-in.
+It is much faster, uses less memory, and has far fewer dependencies than the default backend, but has not yet been tested as thoroughly, so for now it remains opt-in.
 Output is intended to be identical to the default backend (the two are checked for byte-identical results on paired clustering).
 
-Build it once with `bin/zig-build.sh` (this fetches a pinned Zig compiler and compiles the in-tree backend; see [install](install.md#zig-backend-optional)), then add `--zig` to any partis command, e.g.:
+Build it once with `bin/zig-build.sh` (this fetches a pinned Zig compiler and compiles the in-tree backend; see [install](install.md#zig-backend)), then add `--zig` to any partis command, e.g.:
 ```
 partis --zig annotate --infname <input> --outfname <output>
 ```


### PR DESCRIPTION
Documents the zig backend that lands in `dev` via #385, per the agreed framing: faster, less memory, far fewer dependencies, but not yet as thoroughly tested — so it stays opt-in via `--zig`.

- `docs/subcommands.md`: new "the zig backend (`--zig`)" subsection under *other topics*, plus a TOC entry. Covers what it is, the opt-in rationale, and usage (`partis --zig ...`).
- `docs/install.md`: new "Zig backend (optional)" subsection with the `bin/zig-build.sh` build step (notes it fetches a pinned Zig compiler into the tree, no extra system deps).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)