### PR TITLE
size simulation UID hash length by event count to avoid collisions at scale

### DIFF
--- a/bin/partis
+++ b/bin/partis
@@ -42,6 +42,7 @@ import partis.disjointgrouper as disjointgrouper
 from partis.parametercounter import ParameterCounter
 from partis.corrcounter import CorrCounter
 from partis.waterer import Waterer
+import partis.event as event
 
 # ----------------------------------------------------------------------------------------
 def strip_paired_args(clist, args):
@@ -137,6 +138,8 @@ def assemble_groups_action(args):
 
 # ----------------------------------------------------------------------------------------
 def run_simulation(args):
+    if args.uid_hash_len is None:  # single-locus: resolve from n-sim-events (paired resolves globally in run_all_loci)
+        args.uid_hash_len = event.UID_HASH_LEN_LONG if args.n_sim_events >= event.UID_HASH_LEN_THRESHOLD else event.UID_HASH_LEN_SHORT
     # ----------------------------------------------------------------------------------------
     def run_sub_cmds(working_gldir):
         # ----------------------------------------------------------------------------------------
@@ -189,6 +192,7 @@ def run_simulation(args):
             utils.replace_in_arglist(clist, '--workdir', get_workdir(iproc))
             utils.replace_in_arglist(clist, '--outfname', get_outfname(iproc))
             utils.replace_in_arglist(clist, '--n-sim-events', str(n_sub_events))
+            utils.replace_in_arglist(clist, '--uid-hash-len', str(args.uid_hash_len))  # forward resolved (global) hash len
             if working_gldir is not None:
                 utils.replace_in_arglist(clist, '--initial-germline-dir', working_gldir)
             if args.allele_prevalence_fname is not None:
@@ -815,6 +819,7 @@ def run_all_loci(args, ig_or_tr='ig'):
                 clist.append('--crash-on-duplicate-uids')  # single-chain subprocesses in paired mode should crash on duplicates
                 if args.action == 'simulate':
                     clist += ['--choose-trees-in-order', '--outfname', getofn(ltmp, lpair=lpair)]
+                    utils.replace_in_arglist(clist, '--uid-hash-len', str(args.uid_hash_len))  # forward resolved (global) hash len
                     if args.input_simulation_treefname is None:
                         clist += ['--input-simulation-treefname', getofn(ltmp, trees=True, lpair=lpair)]
                     if args.paired_correlation_values is not None and not utils.has_d_gene(ltmp):
@@ -1062,7 +1067,7 @@ def run_all_loci(args, ig_or_tr='ig'):
             print('%s: synchronizing heavy and light chain simulation trees and rewriting output files in %s/' % (utils.color('blue', '+'.join(lpair)), getodir(lpair=lpair)))
             antns_to_remove = []
             for hline, lline in paircluster.get_antn_pairs(lpair, lpfos):
-                treeutils.merge_heavy_light_trees(hline, lline, use_identical_uids=False)
+                treeutils.merge_heavy_light_trees(hline, lline, use_identical_uids=False, uid_hash_len=args.uid_hash_len)
                 if args.remove_nonfunctional_seqs:
                     rm_nonfunc_seqs(antns_to_remove, hline, lline)
             if len(antns_to_remove) > 0:
@@ -1503,6 +1508,8 @@ def run_all_loci(args, ig_or_tr='ig'):
 
     # ----------------------------------------------------------------------------------------
     if args.action == 'simulate':
+        if args.uid_hash_len is None:  # resolve from total (global) n-sim-events, forward to per-locus subprocs
+            args.uid_hash_len = event.UID_HASH_LEN_LONG if args.n_sim_events >= event.UID_HASH_LEN_THRESHOLD else event.UID_HASH_LEN_SHORT
         if not args.dry_run:
             paircluster.prep_paired_dir(getodir(), clean=True, suffix='.yaml', extra_files=[getofn(None, trees=True, lpair=lp) for lp in utils.locus_pairs[ig_or_tr]])
         for lpair in utils.locus_pairs[ig_or_tr]:
@@ -1894,6 +1901,7 @@ subargs['subset-annotate'].append({'name' : '--n-subsets', 'kwargs' : {'type' : 
 # basic simulation:
 subargs['simulate'].append({'name' : '--mutation-multiplier', 'kwargs' : {'type' : float, 'help' : 'Multiply observed branch lengths by some factor when simulating, e.g. if in data it was 0.05, but you want closer to ten percent in your simulation, set this to 2'}})
 subargs['simulate'].append({'name' : '--n-sim-events', 'kwargs' : {'type' : int, 'default' : 1, 'help' : 'Number of rearrangement events to simulate'}})
+subargs['simulate'].append({'name' : '--uid-hash-len', 'kwargs' : {'type' : int, 'help' : 'simulation uid hash length; unset = auto (%d at/above %d total events, else %d)' % (event.UID_HASH_LEN_LONG, event.UID_HASH_LEN_THRESHOLD, event.UID_HASH_LEN_SHORT)}})
 subargs['simulate'].append({'name' : '--n-trees', 'kwargs' : {'type' : int, 'help' : 'Number of phylogenetic trees from which to choose during simulation (we pre-generate this many trees before starting a simulation run, then for each rearrangement event choose one at random -- so this should be at least of order the number of simulated events, so your clonal families don\'t all have the same tree).'}})
 subargs['simulate'].append({'name' : '--n-leaf-distribution', 'kwargs' : {'default' : None, 'choices' : ['geometric', 'box', 'zipf', 'hist'], 'help' : 'Distribution from which to draw the number of leaves for each tree. Except for \'hist\' (which is a histogram inferred from data) the distribution\'s parameter comes from --n-leaves. If not set, defaults to --default-scratch-n-leaf-distribution (if rearranging from scratch), or \'hist\' (if rearranging with inferred parameters). Note that in the latter case if the hist file doesn\'t exist, it\'ll fall back to one of the others (with warning). If planning to use \'hist\', you\'ll need to run \'partition\' with --count-parameters set; otherwise the only parameters available will have been inferred from the singleton partition (before partitioning), so the cluster size hist will only have entries in the 1-bin (it will also warn about this).'}})
 subargs['simulate'].append({'name' : '--n-leaf-hist-fname', 'kwargs' : {'help' : 'file with histogram of cluster sizes (i.e. from a parameter dir) from which to sample simulation family sizes'}})

--- a/bin/partis
+++ b/bin/partis
@@ -42,7 +42,6 @@ import partis.disjointgrouper as disjointgrouper
 from partis.parametercounter import ParameterCounter
 from partis.corrcounter import CorrCounter
 from partis.waterer import Waterer
-import partis.event as event
 
 # ----------------------------------------------------------------------------------------
 def strip_paired_args(clist, args):
@@ -139,7 +138,7 @@ def assemble_groups_action(args):
 # ----------------------------------------------------------------------------------------
 def run_simulation(args):
     if args.uid_hash_len is None:  # single-locus: resolve from n-sim-events (paired resolves globally in run_all_loci)
-        args.uid_hash_len = event.UID_HASH_LEN_LONG if args.n_sim_events >= event.UID_HASH_LEN_THRESHOLD else event.UID_HASH_LEN_SHORT
+        args.uid_hash_len = utils.resolve_uid_hash_len(args.n_sim_events)
     # ----------------------------------------------------------------------------------------
     def run_sub_cmds(working_gldir):
         # ----------------------------------------------------------------------------------------
@@ -819,7 +818,7 @@ def run_all_loci(args, ig_or_tr='ig'):
                 clist.append('--crash-on-duplicate-uids')  # single-chain subprocesses in paired mode should crash on duplicates
                 if args.action == 'simulate':
                     clist += ['--choose-trees-in-order', '--outfname', getofn(ltmp, lpair=lpair)]
-                    utils.replace_in_arglist(clist, '--uid-hash-len', str(args.uid_hash_len))  # forward resolved (global) hash len
+                    utils.replace_in_arglist(clist, '--uid-hash-len', str(args.uid_hash_len), insert_after='--choose-trees-in-order')  # forward resolved (global) hash len
                     if args.input_simulation_treefname is None:
                         clist += ['--input-simulation-treefname', getofn(ltmp, trees=True, lpair=lpair)]
                     if args.paired_correlation_values is not None and not utils.has_d_gene(ltmp):
@@ -1509,7 +1508,7 @@ def run_all_loci(args, ig_or_tr='ig'):
     # ----------------------------------------------------------------------------------------
     if args.action == 'simulate':
         if args.uid_hash_len is None:  # resolve from total (global) n-sim-events, forward to per-locus subprocs
-            args.uid_hash_len = event.UID_HASH_LEN_LONG if args.n_sim_events >= event.UID_HASH_LEN_THRESHOLD else event.UID_HASH_LEN_SHORT
+            args.uid_hash_len = utils.resolve_uid_hash_len(args.n_sim_events)
         if not args.dry_run:
             paircluster.prep_paired_dir(getodir(), clean=True, suffix='.yaml', extra_files=[getofn(None, trees=True, lpair=lp) for lp in utils.locus_pairs[ig_or_tr]])
         for lpair in utils.locus_pairs[ig_or_tr]:
@@ -1901,7 +1900,7 @@ subargs['subset-annotate'].append({'name' : '--n-subsets', 'kwargs' : {'type' : 
 # basic simulation:
 subargs['simulate'].append({'name' : '--mutation-multiplier', 'kwargs' : {'type' : float, 'help' : 'Multiply observed branch lengths by some factor when simulating, e.g. if in data it was 0.05, but you want closer to ten percent in your simulation, set this to 2'}})
 subargs['simulate'].append({'name' : '--n-sim-events', 'kwargs' : {'type' : int, 'default' : 1, 'help' : 'Number of rearrangement events to simulate'}})
-subargs['simulate'].append({'name' : '--uid-hash-len', 'kwargs' : {'type' : int, 'help' : 'simulation uid hash length; unset = auto (%d at/above %d total events, else %d)' % (event.UID_HASH_LEN_LONG, event.UID_HASH_LEN_THRESHOLD, event.UID_HASH_LEN_SHORT)}})
+subargs['simulate'].append({'name' : '--uid-hash-len', 'kwargs' : {'type' : int, 'help' : 'simulation uid/reco id hash length; unset = auto (%d at/above %d total events, else %d). Note the auto threshold is on events, which is exact for reco ids but assumes modest family sizes for uids (whose collision risk scales with total seqs), so set this by hand if simulating very large families.' % (utils.UID_HASH_LEN_LONG, utils.UID_HASH_LEN_THRESHOLD, utils.UID_HASH_LEN_SHORT)}})
 subargs['simulate'].append({'name' : '--n-trees', 'kwargs' : {'type' : int, 'help' : 'Number of phylogenetic trees from which to choose during simulation (we pre-generate this many trees before starting a simulation run, then for each rearrangement event choose one at random -- so this should be at least of order the number of simulated events, so your clonal families don\'t all have the same tree).'}})
 subargs['simulate'].append({'name' : '--n-leaf-distribution', 'kwargs' : {'default' : None, 'choices' : ['geometric', 'box', 'zipf', 'hist'], 'help' : 'Distribution from which to draw the number of leaves for each tree. Except for \'hist\' (which is a histogram inferred from data) the distribution\'s parameter comes from --n-leaves. If not set, defaults to --default-scratch-n-leaf-distribution (if rearranging from scratch), or \'hist\' (if rearranging with inferred parameters). Note that in the latter case if the hist file doesn\'t exist, it\'ll fall back to one of the others (with warning). If planning to use \'hist\', you\'ll need to run \'partition\' with --count-parameters set; otherwise the only parameters available will have been inferred from the singleton partition (before partitioning), so the cluster size hist will only have entries in the 1-bin (it will also warn about this).'}})
 subargs['simulate'].append({'name' : '--n-leaf-hist-fname', 'kwargs' : {'help' : 'file with histogram of cluster sizes (i.e. from a parameter dir) from which to sample simulation family sizes'}})

--- a/partis/event.py
+++ b/partis/event.py
@@ -12,11 +12,15 @@ from . import utils
 from . import indelutils
 from . import treeutils
 
+UID_HASH_LEN_SHORT, UID_HASH_LEN_LONG = 10, 20  # short is readable, long avoids collisions at scale
+UID_HASH_LEN_THRESHOLD = 100000  # use long hash at/above this many total --n-sim-events
+
 #----------------------------------------------------------------------------------------
 class RecombinationEvent(object):
     """ Container to hold the information for a single recombination event. """
-    def __init__(self, glfo):
+    def __init__(self, glfo, uid_hash_len=UID_HASH_LEN_SHORT):
         self.glfo = glfo
+        self.uid_hash_len = uid_hash_len or UID_HASH_LEN_SHORT
         self.vdj_combo_label = ()  # A tuple with the names of the chosen versions (v_gene, d_gene, j_gene, cdr3_length, <erosion lengths>)
                                    # NOTE I leave the lengths in here as strings
         self.genes = {}
@@ -96,7 +100,7 @@ class RecombinationEvent(object):
     def set_reco_id(self, line, irandom=None):
         reco_id_columns = [r + '_gene' for r in utils.regions] + [b + '_insertion' for b in utils.boundaries] + [e + '_del' for e in utils.all_erosions]
         reco_id_str = ''.join([str(line[c]) for c in reco_id_columns]) + self.randstr(irandom)  # NOTE this used to give the same reco id for the same rearrangement parameters, even if they come from a separate rearrangement event (until we added the randstr() call)
-        line['reco_id'] = utils.uidhashstr(reco_id_str)
+        line['reco_id'] = utils.uidhashstr(reco_id_str, max_len=self.uid_hash_len)
         return reco_id_str
 
     # ----------------------------------------------------------------------------------------
@@ -104,7 +108,7 @@ class RecombinationEvent(object):
         unique_id_columns = ['seqs', 'input_seqs']
         uidstrs = [''.join([str(line[c][iseq]) for c in unique_id_columns]) for iseq in range(len(line['input_seqs']))]
         uidstrs = [reco_id_str + uidstrs[iseq] + self.randstr(irandom) + str(iseq) for iseq in range(len(uidstrs))]  # NOTE i'm not sure I really like having the str(iseq), but it mimics the way things used to be by accident/bug (i.e. identical sequences in the same simulated rearrangement event get different uids), so I'm leaving it in for the moment to ease transition after a rewrite
-        line['unique_ids'] = [utils.uidhashstr(ustr) for ustr in uidstrs]
+        line['unique_ids'] = [utils.uidhashstr(ustr, max_len=self.uid_hash_len) for ustr in uidstrs]
 
     # ----------------------------------------------------------------------------------------
     def set_ids(self, line, irandom=None):

--- a/partis/event.py
+++ b/partis/event.py
@@ -12,15 +12,12 @@ from . import utils
 from . import indelutils
 from . import treeutils
 
-UID_HASH_LEN_SHORT, UID_HASH_LEN_LONG = 10, 20  # short is readable, long avoids collisions at scale
-UID_HASH_LEN_THRESHOLD = 100000  # use long hash at/above this many total --n-sim-events
-
 #----------------------------------------------------------------------------------------
 class RecombinationEvent(object):
     """ Container to hold the information for a single recombination event. """
-    def __init__(self, glfo, uid_hash_len=UID_HASH_LEN_SHORT):
+    def __init__(self, glfo, uid_hash_len=utils.UID_HASH_LEN_SHORT):
         self.glfo = glfo
-        self.uid_hash_len = uid_hash_len or UID_HASH_LEN_SHORT
+        self.uid_hash_len = uid_hash_len
         self.vdj_combo_label = ()  # A tuple with the names of the chosen versions (v_gene, d_gene, j_gene, cdr3_length, <erosion lengths>)
                                    # NOTE I leave the lengths in here as strings
         self.genes = {}

--- a/partis/recombinator.py
+++ b/partis/recombinator.py
@@ -191,7 +191,7 @@ class Recombinator(object):
         if self.args.debug:
             print('combine (seed %d)' % irandom)
 
-        reco_event = RecombinationEvent(self.glfo)
+        reco_event = RecombinationEvent(self.glfo, uid_hash_len=getattr(self.args, 'uid_hash_len', None))
         try:
             self.choose_vdj_combo(reco_event, i_heavy_event=i_heavy_event)  # it's kind of ugly to raise an exception here, rather than having the fcn[s] return None as below, but the control flow gets complicated that way. Maybe would be better to switch all of them to exceptions
         except SimuGiveUpError as err:

--- a/partis/recombinator.py
+++ b/partis/recombinator.py
@@ -191,7 +191,7 @@ class Recombinator(object):
         if self.args.debug:
             print('combine (seed %d)' % irandom)
 
-        reco_event = RecombinationEvent(self.glfo, uid_hash_len=getattr(self.args, 'uid_hash_len', None))
+        reco_event = RecombinationEvent(self.glfo, uid_hash_len=self.args.uid_hash_len)
         try:
             self.choose_vdj_combo(reco_event, i_heavy_event=i_heavy_event)  # it's kind of ugly to raise an exception here, rather than having the fcn[s] return None as below, but the control flow gets complicated that way. Maybe would be better to switch all of them to exceptions
         except SimuGiveUpError as err:

--- a/partis/treeutils.py
+++ b/partis/treeutils.py
@@ -947,7 +947,7 @@ def mrca_dist(dtree_t, dtree_i, denom_type='mut', debug=False):
 
 # ----------------------------------------------------------------------------------------
 # loops over uids in <hline> and <lline> (which, in order, must correspond to each other), chooses a new joint uid and applies it to both h and l trees, then checks to make sure the trees are identical
-def merge_heavy_light_trees(hline, lline, use_identical_uids=False, check_trees=True, debug=False):
+def merge_heavy_light_trees(hline, lline, use_identical_uids=False, check_trees=True, debug=False, uid_hash_len=10):
     def ladd(uid, locus):
         return '%s-%s' % (uid, locus)
     def lrm(uid, locus):
@@ -964,13 +964,13 @@ def merge_heavy_light_trees(hline, lline, use_identical_uids=False, check_trees=
         assert hline['unique_ids'] == lline['heavy-chain-correlation-info']['heavy-chain-uids']
     assert len(hline['unique_ids']) == len(lline['unique_ids'])
     lpair = [hline, lline]
-    joint_reco_id = utils.uidhashstr(hline['reco_id'] + lline['reco_id'])
+    joint_reco_id = utils.uidhashstr(hline['reco_id'] + lline['reco_id'], max_len=uid_hash_len)
     for ltmp in lpair:
         ltmp['reco_id'] = joint_reco_id
         ltmp['paired-uids'] = []
     dtrees = [get_dendro_tree(treestr=l['tree']) for l in lpair]
     for iuid, (huid, luid) in enumerate(zip(hline['unique_ids'], lline['unique_ids'])):
-        joint_uid = utils.uidhashstr(huid + luid)
+        joint_uid = utils.uidhashstr(huid + luid, max_len=uid_hash_len)
         for ltmp in lpair:
             ltmp['unique_ids'][iuid] = joint_uid
             if not use_identical_uids:

--- a/partis/treeutils.py
+++ b/partis/treeutils.py
@@ -947,7 +947,7 @@ def mrca_dist(dtree_t, dtree_i, denom_type='mut', debug=False):
 
 # ----------------------------------------------------------------------------------------
 # loops over uids in <hline> and <lline> (which, in order, must correspond to each other), chooses a new joint uid and applies it to both h and l trees, then checks to make sure the trees are identical
-def merge_heavy_light_trees(hline, lline, use_identical_uids=False, check_trees=True, debug=False, uid_hash_len=10):
+def merge_heavy_light_trees(hline, lline, uid_hash_len, use_identical_uids=False, check_trees=True, debug=False):
     def ladd(uid, locus):
         return '%s-%s' % (uid, locus)
     def lrm(uid, locus):

--- a/partis/utils.py
+++ b/partis/utils.py
@@ -1742,8 +1742,16 @@ def get_hash(instr):
     return hashlib.md5(instr.encode()).hexdigest()  # , usedforsecurity=False (can't use this arg til python 3.9)
 
 # ----------------------------------------------------------------------------------------
-def uidhashstr(instr, max_len=10):
+def uidhashstr(instr, max_len=10):  # NOTE default deliberately not UID_HASH_LEN_SHORT (most callers aren't simulation uids)
     return get_hash(instr)[:max_len]
+
+# ----------------------------------------------------------------------------------------
+UID_HASH_LEN_SHORT, UID_HASH_LEN_LONG = 10, 20  # short is readable, long avoids collisions at scale
+UID_HASH_LEN_THRESHOLD = 100000  # use long hash at/above this many total --n-sim-events
+
+# ----------------------------------------------------------------------------------------
+def resolve_uid_hash_len(n_sim_events):  # NOTE exact for reco ids, but uid collisions scale with total seqs, so assumes modest family sizes
+    return UID_HASH_LEN_LONG if n_sim_events >= UID_HASH_LEN_THRESHOLD else UID_HASH_LEN_SHORT
 
 # ----------------------------------------------------------------------------------------
 def hashint(instr, max_int=2**31):  # max random seed val is 32, so reduce by 1 to get some leeway


### PR DESCRIPTION
Simulation UIDs use a 10-char (40-bit) hash. The deterministic per-event seeds from #367 removed same-input collisions, but the 10-char hash still birthday-collides at roughly 1M or more sequences (about 1-2 duplicate UIDs per dataset), which crashes the paired combine (`check_for_cross_locus_duplicates`).

This adds `--uid-hash-len` (auto by default):

- Unset resolves from the total `--n-sim-events`: 20-char at or above 100000 events, else 10-char.
- The resolved value is forwarded through the per-locus and per-proc subprocesses into `event.py` UID generation, and through the paired combine (`merge_heavy_light_trees` joint uid and reco_id).
- Small simulations keep readable 10-char UIDs; large simulations get collision-free 20-char UIDs.
- Builds on #367 and does not change the seed fix.
- `merge_heavy_light_trees` is simulation-only (single caller), so inference is unaffected.

#### Validation

- Auto-resolution: 100000 events gives 20-char, small gives 10-char.
- Single-locus and paired: default 10-char; `--uid-hash-len 20` gives 20-char UIDs and reco_ids through the combine.
- `partis-test.py --quick` passes with no regression.
