### PR TITLE
size disjoint and hfrac stages from the --n-procs budget

### DIFF
--- a/bin/partis
+++ b/bin/partis
@@ -532,7 +532,11 @@ def subset_partition(args):
             utils.remove_from_arglist(clist, '--is-simu')  # don't want to deal with subsetting input simulation file (and dual-use of --paired-indir), so just ignore --is-simu until merged run
         else:  # merged run
             utils.remove_from_arglist(clist, '--infname', has_arg=True)
-            utils.remove_from_arglist(clist, '--disjoint-groups')  # merged re-partition should not use disjoint grouping (it runs continue-from-input-partition)
+            # merged re-partition runs continue-from-input-partition, so the disjoint-only args do not apply (and --hfrac/--ha-repartition/--partition-refine are rejected without --disjoint-groups)
+            for targ in ['--disjoint-groups', '--hfrac', '--ha-repartition', '--partition-refine']:
+                utils.remove_from_arglist(clist, targ)
+            for targ in ['--hfrac-merge-factor', '--hfrac-max-bin-size', '--hfrac-min-seqs']:
+                utils.remove_from_arglist(clist, targ, has_arg=True)
             if args.paired_indir is None:  # if --paired-indir wasn't set (i.e. --infname *was* set), we want to use the extract-pairing-info/split-loci output in --paired-outdir
                 clist += ['--paired-indir', merged_odir]
             utils.replace_in_arglist(clist, '--parameter-dir', '%s/parameters'%merged_odir)

--- a/bin/partis
+++ b/bin/partis
@@ -74,7 +74,23 @@ def strip_paired_args(clist, args):
     return clist
 
 # ----------------------------------------------------------------------------------------
-def build_single_locus_cmd(tmpaction, ltmp, args, infname=None, outfname=None, parameter_dir=None, input_metafnames=None, extra_args=None):
+def proc_budget(args):
+    # procs each stage may use: the --n-procs ceiling, bounded by available cpus
+    return max(1, min(args.n_procs, utils.n_available_cpus()))
+
+# ----------------------------------------------------------------------------------------
+def disjoint_group_allocation(args):
+    # --n-procs is a ceiling, so split it into (jobs at once) x (procs per job) rather than multiplying by it
+    n_cpus = utils.n_available_cpus()
+    budget = proc_budget(args)
+    n_jobs = max(1, min(args.n_max_subprocs, budget))
+    n_procs = args.n_sub_procs if args.n_sub_procs is not None else max(1, budget // n_jobs)
+    if n_jobs * n_procs > n_cpus:
+        print('    %s group stage would use %d x %d = %d procs, but only %d cpus are available' % (utils.color('yellow', 'warning'), n_jobs, n_procs, n_jobs * n_procs, n_cpus))
+    return n_jobs, n_procs
+
+# ----------------------------------------------------------------------------------------
+def build_single_locus_cmd(tmpaction, ltmp, args, infname=None, outfname=None, parameter_dir=None, input_metafnames=None, n_procs=None, extra_args=None):
     # Build a single-locus subprocess command from sys.argv with full arg forwarding.
     # Uses strip_paired_args() for core arg stripping, then adds locus-specific overrides.
     clist = strip_paired_args(copy.deepcopy(sys.argv), args)
@@ -101,6 +117,8 @@ def build_single_locus_cmd(tmpaction, ltmp, args, infname=None, outfname=None, p
         utils.replace_in_arglist(clist, '--parameter-dir', parameter_dir)
     if input_metafnames is not None:
         utils.replace_in_arglist(clist, '--input-metafnames', ':'.join(input_metafnames))
+    if n_procs is not None:  # set rather than append, to avoid a duplicate --n-procs in the sub-command
+        utils.replace_in_arglist(clist, '--n-procs', str(n_procs))
     # remove --is-simu: per-group FASTAs lack simulation metadata; CCFs are calculated post-merge
     utils.remove_from_arglist(clist, '--is-simu')
     if extra_args is not None:
@@ -123,7 +141,7 @@ def disjoint_group_action(args):
     if outdir is None:
         raise Exception('--paired-outdir or --workdir must be set')
     disjoint_dir = '%s/disjoint-groups/%s' % (outdir, args.locus)
-    disjointgrouper.create_cdr3_groups(args.locus, sw_cache_paths, disjoint_dir, parameter_dir=args.parameter_dir, hfrac=args.hfrac, hfrac_merge_factor=args.hfrac_merge_factor, hfrac_max_bin_size=args.hfrac_max_bin_size, min_group_size=args.hfrac_min_seqs)
+    disjointgrouper.create_cdr3_groups(args.locus, sw_cache_paths, disjoint_dir, parameter_dir=args.parameter_dir, hfrac=args.hfrac, hfrac_merge_factor=args.hfrac_merge_factor, hfrac_max_bin_size=args.hfrac_max_bin_size, min_group_size=args.hfrac_min_seqs, n_procs=proc_budget(args))
 
 # ----------------------------------------------------------------------------------------
 def assemble_groups_action(args):
@@ -1558,13 +1576,13 @@ def run_all_loci(args, ig_or_tr='ig'):
             print('%s %s: manifest exists, skipping grouping: %s' % (utils.color('blue_bkg', 'create-disjoint-groups'), ltmp, manifest_path))
             manifest = disjointgrouper.read_manifest(manifest_path)
         else:
-            manifest = disjointgrouper.create_cdr3_groups(ltmp, sw_cache_path(getpdir(ltmp)), disjoint_dir, parameter_dir=getpdir(ltmp), hfrac=args.hfrac, hfrac_merge_factor=args.hfrac_merge_factor, hfrac_max_bin_size=args.hfrac_max_bin_size, min_group_size=args.hfrac_min_seqs)
+            manifest = disjointgrouper.create_cdr3_groups(ltmp, sw_cache_path(getpdir(ltmp)), disjoint_dir, parameter_dir=getpdir(ltmp), hfrac=args.hfrac, hfrac_merge_factor=args.hfrac_merge_factor, hfrac_max_bin_size=args.hfrac_max_bin_size, min_group_size=args.hfrac_min_seqs, n_procs=proc_budget(args))
 
         # step 2: partition each group (or sub-group if hfrac)
         if len(manifest['groups']) == 0:
             raise Exception('manifest contains no groups (all sequences may have failed CDR3 annotation): %s' % manifest_path)
         cmdfos = []
-        n_max_jobs = args.n_max_subprocs
+        n_max_jobs, n_group_procs = disjoint_group_allocation(args)
         for ginfo in manifest['groups']:
             # derive partition and sw-cache paths from the fasta_path in the manifest
             fasta_rel = ginfo['fasta_path']
@@ -1579,20 +1597,18 @@ def run_all_loci(args, ig_or_tr='ig'):
             fasta_path = '%s/%s' % (disjoint_dir, fasta_rel)
             sw_cache_path_full = '%s/%s' % (disjoint_dir, sw_cache_rel)
             extra_args = ['--sw-cachefname', sw_cache_path_full]
-            if args.n_sub_procs is not None:
-                extra_args += ['--n-procs', str(args.n_sub_procs)]
             if args.ha_repartition and '--naive-vsearch' not in extra_args:  # ha-repartition base is always vsearch
                 extra_args += ['--naive-vsearch']
             cmd = build_single_locus_cmd('partition', ltmp, args,
                                          infname=fasta_path, outfname=partition_path, parameter_dir=getpdir(ltmp),
-                                         extra_args=extra_args)
+                                         n_procs=n_group_procs, extra_args=extra_args)
             workdir = '%s/%s' % (disjoint_dir, fasta_dir)
             cmdfos.append({'cmd_str' : cmd, 'outfname' : partition_path, 'workdir' : workdir})
         if len(cmdfos) > 0:
             if args.dry_run:
-                print('    --dry-run: would run %d group partition jobs (%d concurrent)' % (len(cmdfos), n_max_jobs))
+                print('    --dry-run: would run %d group partition jobs (%d concurrent x %d procs)' % (len(cmdfos), n_max_jobs, n_group_procs))
             else:
-                print('    running %d group partition jobs (%d concurrent, logs in %s/groups/cdr3-*/out):' % (len(cmdfos), n_max_jobs, disjoint_dir), end=' ')
+                print('    running %d group partition jobs (%d concurrent x %d procs, logs in %s/groups/cdr3-*/out):' % (len(cmdfos), n_max_jobs, n_group_procs, disjoint_dir), end=' ')
                 utils.run_cmds(cmdfos, n_max_procs=n_max_jobs, debug='write', progress=True)
 
         # step 2.4: HA re-partition (optional). Per group: HA on every vsearch cluster >= 3
@@ -2055,8 +2071,8 @@ subargs['partition'].append({'name' : '--ha-repartition', 'kwargs' : {'action' :
 subargs['partition'].append({'name' : '--hfrac-merge-factor', 'kwargs' : {'type' : float, 'default' : disjointgrouper.HFRAC_MERGE_FACTOR_DEFAULT, 'help' : argparse.SUPPRESS}})  # dev/testing: hfrac round 2 threshold = factor * hi_bound; 0 disables round 2
 subargs['partition'].append({'name' : '--hfrac-max-bin-size', 'kwargs' : {'type' : int, 'default' : disjointgrouper.HFRAC_MAX_BIN_SIZE_DEFAULT, 'help' : 'Target maximum sequences per hfrac sub-group. A soft target: bin-packing only fires past %.1fx this value, and a single indivisible component larger than that is emitted whole with a warning. Set to 0 to disable.' % disjointgrouper.BIN_PACK_TOLERANCE}})
 subargs['partition'].append({'name' : '--hfrac-min-seqs', 'kwargs' : {'type' : int, 'default' : disjointgrouper.HFRAC_MIN_SEQS_DEFAULT, 'help' : 'CDR3 groups smaller than this skip hfrac sub-grouping entirely.'}})
-subargs['partition'].append({'name' : '--n-max-subprocs', 'kwargs' : {'type' : int, 'default' : 2, 'help' : 'Maximum number of concurrent subprocess jobs (disjoint CDR3 groups or subset-partition subsets). Each job uses --n-procs processes internally. The HA re-partition and partition-refine stages are single-proc and scale to the job cpu allocation instead (capped at --n-procs).'}})
-subargs['partition'].append({'name' : '--n-sub-procs', 'kwargs' : {'type' : int, 'help' : 'Number of processes for each disjoint group partition job. If not set, each job inherits --n-procs from the parent.'}})
+subargs['partition'].append({'name' : '--n-max-subprocs', 'kwargs' : {'type' : int, 'default' : 2, 'help' : 'Maximum number of concurrent subprocess jobs (disjoint CDR3 groups or subset-partition subsets). Disjoint group jobs split --n-procs among themselves so the total stays within it (override the per-job count with --n-sub-procs); subset-partition subsets each get the full --n-procs. The HA re-partition and partition-refine stages are single-proc and scale to the job cpu allocation instead (capped at --n-procs).'}})
+subargs['partition'].append({'name' : '--n-sub-procs', 'kwargs' : {'type' : int, 'help' : 'Number of processes for each disjoint group partition job, overriding the default split of --n-procs among --n-max-subprocs concurrent jobs. Setting this above the split can oversubscribe the available cpus (you get a warning, not an error).'}})
 
 subargs['create-disjoint-groups'] = []
 subargs['create-disjoint-groups'].append({'name' : '--hfrac', 'kwargs' : {'action' : 'store_true', 'help' : 'Further split CDR3 groups by naive hamming fraction into sub-groups.'}})

--- a/bin/partis
+++ b/bin/partis
@@ -90,7 +90,7 @@ def disjoint_group_allocation(args):
     budget = proc_budget(args)
     if args.n_procs > n_cpus:
         print('    note: --n-procs %d exceeds the %d available cpus, so using %d' % (args.n_procs, n_cpus, budget))
-    n_jobs = max(1, min(args.n_max_subprocs, budget))
+    n_jobs = max(1, min(args.n_max_procs, budget))
     n_procs = args.n_sub_procs if args.n_sub_procs is not None else max(1, budget // n_jobs)
     if n_jobs * n_procs > n_cpus:
         print('    %s group stage would use %d x %d = %d procs, but only %d cpus are available' % (utils.color('yellow', 'warning'), n_jobs, n_procs, n_jobs * n_procs, n_cpus))
@@ -106,7 +106,7 @@ def build_single_locus_cmd(tmpaction, ltmp, args, infname=None, outfname=None, p
                     '--disjoint-groups', '--hfrac', '--partition-refine', '--ha-repartition', '--prepend-coverage-command',
                     '--plot-annotation-performance']:  # requires --is-simu which is also stripped
         utils.remove_from_arglist(clist, argname)
-    for argname in ['--n-subsets', '--n-max-subprocs', '--n-sub-procs', '--hfrac-merge-factor', '--hfrac-max-bin-size', '--hfrac-min-seqs']:
+    for argname in ['--n-subsets', '--n-max-procs', '--n-max-subprocs', '--n-sub-procs', '--hfrac-merge-factor', '--hfrac-max-bin-size', '--hfrac-min-seqs']:
         utils.remove_from_arglist(clist, argname, has_arg=True)
     # set action and locus
     clist[clist.index(args.action)] = tmpaction
@@ -602,8 +602,8 @@ def subset_partition(args):
             if args.dry_run:
                 print('    --dry-run: would run %d subset jobs' % len(cmdfos))
             else:
-                print('    running %d subset jobs (%d concurrent):' % (len(cmdfos), min(len(cmdfos), args.n_max_subprocs)))
-                utils.run_cmds(cmdfos, n_max_procs=args.n_max_subprocs, debug='write')
+                print('    running %d subset jobs (%d concurrent):' % (len(cmdfos), min(len(cmdfos), args.n_max_procs)))
+                utils.run_cmds(cmdfos, n_max_procs=args.n_max_procs, debug='write')
     # ----------------------------------------------------------------------------------------
     def merge_subset_files():
         # NOTE it would be nice to merge duplicates in here (from --collapse-duplicate-sequences, but jeez it seems like it'll be a bit fiddly to implement it
@@ -2078,8 +2078,9 @@ subargs['partition'].append({'name' : '--ha-repartition', 'kwargs' : {'action' :
 subargs['partition'].append({'name' : '--hfrac-merge-factor', 'kwargs' : {'type' : float, 'default' : disjointgrouper.HFRAC_MERGE_FACTOR_DEFAULT, 'help' : argparse.SUPPRESS}})  # dev/testing: hfrac round 2 threshold = factor * hi_bound; 0 disables round 2
 subargs['partition'].append({'name' : '--hfrac-max-bin-size', 'kwargs' : {'type' : int, 'default' : disjointgrouper.HFRAC_MAX_BIN_SIZE_DEFAULT, 'help' : 'Target maximum sequences per hfrac sub-group. A soft target: bin-packing only fires past %.1fx this value, and a single indivisible component larger than that is emitted whole with a warning. Set to 0 to disable.' % disjointgrouper.BIN_PACK_TOLERANCE}})
 subargs['partition'].append({'name' : '--hfrac-min-seqs', 'kwargs' : {'type' : int, 'default' : disjointgrouper.HFRAC_MIN_SEQS_DEFAULT, 'help' : 'CDR3 groups smaller than this skip hfrac sub-grouping entirely.'}})
-subargs['partition'].append({'name' : '--n-max-subprocs', 'kwargs' : {'type' : int, 'default' : 2, 'help' : 'Maximum number of concurrent subprocess jobs (disjoint CDR3 groups or subset-partition subsets). Disjoint group jobs split --n-procs among themselves so the total stays within it (override the per-job count with --n-sub-procs); subset-partition subsets each get the full --n-procs. The HA re-partition and partition-refine stages are single-proc and scale to the job cpu allocation instead (capped at --n-procs).'}})
-subargs['partition'].append({'name' : '--n-sub-procs', 'kwargs' : {'type' : int, 'help' : 'Number of processes for each disjoint group partition job, overriding the default split of --n-procs among --n-max-subprocs concurrent jobs. Setting this above the split can oversubscribe the available cpus (you get a warning, not an error).'}})
+subargs['partition'].append({'name' : '--n-max-procs', 'kwargs' : {'type' : int, 'default' : 2, 'help' : 'Maximum number of concurrent subprocess jobs (disjoint CDR3 groups or subset-partition subsets). Disjoint group jobs split --n-procs among themselves so the total stays within it (override the per-job count with --n-sub-procs); subset-partition subsets each get the full --n-procs. The HA re-partition and partition-refine stages are single-proc and scale to the job cpu allocation instead (capped at --n-procs).'}})
+subargs['partition'].append({'name' : '--n-max-subprocs', 'kwargs' : {'type' : int, 'dest' : 'n_max_procs', 'default' : argparse.SUPPRESS, 'help' : argparse.SUPPRESS}})  # old name for --n-max-procs
+subargs['partition'].append({'name' : '--n-sub-procs', 'kwargs' : {'type' : int, 'help' : 'Number of processes for each disjoint group partition job, overriding the default split of --n-procs among --n-max-procs concurrent jobs. Setting this above the split can oversubscribe the available cpus (you get a warning, not an error).'}})
 
 subargs['create-disjoint-groups'] = []
 subargs['create-disjoint-groups'].append({'name' : '--hfrac', 'kwargs' : {'action' : 'store_true', 'help' : 'Further split CDR3 groups by naive hamming fraction into sub-groups.'}})

--- a/bin/partis
+++ b/bin/partis
@@ -79,10 +79,17 @@ def proc_budget(args):
     return max(1, min(args.n_procs, utils.n_available_cpus()))
 
 # ----------------------------------------------------------------------------------------
+def single_proc_concurrency(args):
+    # single-proc bundles: fill job cpus, capped at --n-procs
+    return max(1, min(utils.n_available_cpus() - 1, args.n_procs))
+
+# ----------------------------------------------------------------------------------------
 def disjoint_group_allocation(args):
-    # --n-procs is a ceiling, so split it into (jobs at once) x (procs per job) rather than multiplying by it
+    # split the --n-procs ceiling into (jobs at once) x (procs per job), rather than multiplying by it
     n_cpus = utils.n_available_cpus()
     budget = proc_budget(args)
+    if args.n_procs > n_cpus:
+        print('    note: --n-procs %d exceeds the %d available cpus, so using %d' % (args.n_procs, n_cpus, budget))
     n_jobs = max(1, min(args.n_max_subprocs, budget))
     n_procs = args.n_sub_procs if args.n_sub_procs is not None else max(1, budget // n_jobs)
     if n_jobs * n_procs > n_cpus:
@@ -550,7 +557,7 @@ def subset_partition(args):
             utils.remove_from_arglist(clist, '--is-simu')  # don't want to deal with subsetting input simulation file (and dual-use of --paired-indir), so just ignore --is-simu until merged run
         else:  # merged run
             utils.remove_from_arglist(clist, '--infname', has_arg=True)
-            # merged re-partition runs continue-from-input-partition, so the disjoint-only args do not apply (and --hfrac/--ha-repartition/--partition-refine are rejected without --disjoint-groups)
+            # merged re-partition runs continue-from-input-partition, so the disjoint-only args do not apply
             for targ in ['--disjoint-groups', '--hfrac', '--ha-repartition', '--partition-refine']:
                 utils.remove_from_arglist(clist, targ)
             for targ in ['--hfrac-merge-factor', '--hfrac-max-bin-size', '--hfrac-min-seqs']:
@@ -1616,7 +1623,7 @@ def run_all_loci(args, ig_or_tr='ig'):
         # Repoints partition_path to the re-partitioned partition.
         if args.ha_repartition:
             harep_bundles_per_proc = 8  # bundles per concurrency slot
-            ha_concurrency = max(1, min(utils.n_available_cpus() - 1, args.n_procs))  # single-proc bundles: fill job cpus, capped at --n-procs
+            ha_concurrency = single_proc_concurrency(args)
             harep_specs, harep_jobs = ha_repartition.prepare_all(disjoint_dir, manifest['groups'], ltmp)
             n_todo = sum(1 for j in harep_jobs if not os.path.exists(j['outfname']))  # existence is each cluster's completion signal
             # bundle per-cluster HA jobs so glfo loads once per bundle, not per cluster; more bundles than slots for load balance
@@ -1649,7 +1656,7 @@ def run_all_loci(args, ig_or_tr='ig'):
         if args.partition_refine:
             import partis.partition_refinement as partition_refinement
             refine_bundles_per_proc = 8  # bundles per concurrency slot
-            ha_concurrency = max(1, min(utils.n_available_cpus() - 1, args.n_procs))  # single-proc bundles: fill job cpus, capped at --n-procs
+            ha_concurrency = single_proc_concurrency(args)
             rspecs = partition_refinement.group_specs(disjoint_dir, manifest['groups'], ltmp)
             n_todo = len(rspecs) if args.overwrite else sum(1 for spec in rspecs if not os.path.exists(spec['refined_out']))  # existence is each group's refine completion signal
             total = len(rspecs)

--- a/docs/subcommands.md
+++ b/docs/subcommands.md
@@ -106,7 +106,7 @@ See section [below](#subset-partition) on the `subset-partition` action, which f
 Setting `--disjoint-groups` splits sequences by CDR3 length, partitions each group independently, and concatenates the results.
 Since no clonal family can span two CDR3 lengths, the groups are guaranteed disjoint and the concatenation needs no further reconciliation.
 This can substantially speed up partitioning on large samples, since partitioning many smaller groups is much faster than one large partition.
-The number of concurrent per-group jobs is set with `--n-max-subprocs <n>` (default 2), and each job uses `--n-procs` processes unless overridden with `--n-sub-procs <n>`.
+The number of concurrent per-group jobs is set with `--n-max-procs <n>` (default 2), and those jobs split `--n-procs` among themselves (so the total stays within it) unless the per-job count is overridden with `--n-sub-procs <n>`.
 It can also be combined with `subset-partition` (i.e. `partis subset-partition --disjoint-groups`), in which case it speeds up the single-chain partition step within each subset.
 Adding `--hfrac` further splits CDR3 groups by naive hamming fraction into smaller sub-groups, controlled by `--hfrac-max-bin-size` (default 100000).
 Note that each sub-group is partitioned independently, and the clustering method depends on sub-group size: groups larger than `--max-n-seqs-to-likelihood-cluster` (default 50000) automatically use vsearch, while smaller groups use full likelihood clustering.

--- a/partis/disjointgrouper.py
+++ b/partis/disjointgrouper.py
@@ -18,7 +18,6 @@ HFRAC_MIN_SEQS_DEFAULT = 50000   # CDR3 groups smaller than this skip hfrac enti
 
 # hfrac internal tuning (named to avoid magic numbers)
 BIN_PACK_TOLERANCE = 1.2               # bin-packing only fires past this multiple of the cap
-MAX_VSEARCH_PROCS = 8                  # cap on concurrent vsearch jobs (round 1 and round 2)
 MAX_TCM_THRESHOLD = 0.49               # safety clamp on round-2 threshold; vsearch --id requires <= 1.0 and high-SHM regimes can otherwise drive merge_factor*hi_bound past sensible bounds
 
 # ----------------------------------------------------------------------------------------
@@ -258,7 +257,7 @@ def _build_round1_vsearch_cmds(groups, hi_bound, outdir, min_group_size):
     return cmdfos, vsearch_groups, small_groups
 
 # ----------------------------------------------------------------------------------------
-def _run_round2_tcm(groups, r1_by_c3len, merge_factor, hi_bound, outdir):
+def _run_round2_tcm(groups, r1_by_c3len, merge_factor, hi_bound, outdir, n_procs):
     # run round 2 TCM (transitive closure merge) on round 1 centroids
     # returns comps_by_c3len (c3len -> components), r2_workdirs (c3len -> workdir)
     comps_by_c3len = {}
@@ -286,7 +285,7 @@ def _run_round2_tcm(groups, r1_by_c3len, merge_factor, hi_bound, outdir):
         r2_workdirs[c3len] = r2_workdir
         r2_pairs_files[c3len] = pairs_fname
     if len(r2_cmdfos) > 0:
-        n_procs2 = min(MAX_VSEARCH_PROCS, len(r2_cmdfos))
+        n_procs2 = min(n_procs, len(r2_cmdfos))
         print('        running %d round 2 TCM jobs (%d concurrent, %.2fx hi_bound = %.4f threshold)' % (
             len(r2_cmdfos), n_procs2, merge_factor, round2_threshold))
         utils.run_cmds(r2_cmdfos, n_max_procs=n_procs2)
@@ -324,7 +323,7 @@ def _write_subgroup_outputs(sub_groups_list, c3len, outdir, locus, uid_to_antn, 
         print('        cdr3-%d: %d seqs -> %d sub-groups (sizes: %s)' % (c3len, seqcount, len(sub_groups_list), ' '.join(str(len(sg)) for sg in sub_groups_list)))
 
 # ----------------------------------------------------------------------------------------
-def _apply_hfrac_and_write(groups, hi_bound, outdir, locus, glfo, annotation_list, merge_factor=HFRAC_MERGE_FACTOR_DEFAULT, max_bin_size=HFRAC_MAX_BIN_SIZE_DEFAULT, min_group_size=HFRAC_MIN_SEQS_DEFAULT):
+def _apply_hfrac_and_write(groups, hi_bound, outdir, locus, glfo, annotation_list, merge_factor=HFRAC_MERGE_FACTOR_DEFAULT, max_bin_size=HFRAC_MAX_BIN_SIZE_DEFAULT, min_group_size=HFRAC_MIN_SEQS_DEFAULT, n_procs=1):
     # apply hfrac sub-grouping within each CDR3 group, write per-sub-group outputs
     # single-cache in-memory path: annotation_list is fully loaded
     # min_group_size: CDR3 groups smaller than this skip hfrac and are written as single groups
@@ -337,9 +336,9 @@ def _apply_hfrac_and_write(groups, hi_bound, outdir, locus, glfo, annotation_lis
     # round 1: vsearch greedy clustering
     cmdfos, vsearch_groups, small_groups = _build_round1_vsearch_cmds(groups, hi_bound, outdir, min_group_size)
     if len(cmdfos) > 0:
-        n_procs = min(MAX_VSEARCH_PROCS, len(cmdfos))
-        print('        running %d vsearch hfrac jobs (%d concurrent)' % (len(cmdfos), n_procs))
-        utils.run_cmds(cmdfos, n_max_procs=n_procs)
+        n_r1_procs = min(n_procs, len(cmdfos))
+        print('        running %d vsearch hfrac jobs (%d concurrent)' % (len(cmdfos), n_r1_procs))
+        utils.run_cmds(cmdfos, n_max_procs=n_r1_procs)
 
     # parse round 1 results
     r1_by_c3len = {}
@@ -352,7 +351,7 @@ def _apply_hfrac_and_write(groups, hi_bound, outdir, locus, glfo, annotation_lis
     # round 2 (optional): TCM on centroids
     comps_by_c3len, r2_workdirs = {}, {}
     if merge_factor > 0:
-        comps_by_c3len, r2_workdirs = _run_round2_tcm(groups, r1_by_c3len, merge_factor, hi_bound, outdir)
+        comps_by_c3len, r2_workdirs = _run_round2_tcm(groups, r1_by_c3len, merge_factor, hi_bound, outdir, n_procs)
 
     # build and write sub-groups per CDR3 group
     all_group_infos = []
@@ -391,16 +390,16 @@ def _apply_hfrac_and_write(groups, hi_bound, outdir, locus, glfo, annotation_lis
     return flattened_groups, all_group_infos
 
 # ----------------------------------------------------------------------------------------
-def _apply_hfrac_two_pass(groups, hi_bound, outdir, locus, glfo, merge_factor=HFRAC_MERGE_FACTOR_DEFAULT, max_bin_size=HFRAC_MAX_BIN_SIZE_DEFAULT, min_group_size=HFRAC_MIN_SEQS_DEFAULT):
+def _apply_hfrac_two_pass(groups, hi_bound, outdir, locus, glfo, merge_factor=HFRAC_MERGE_FACTOR_DEFAULT, max_bin_size=HFRAC_MAX_BIN_SIZE_DEFAULT, min_group_size=HFRAC_MIN_SEQS_DEFAULT, n_procs=1):
     # memory-efficient hfrac for multi-cache path: reads one CDR3 group SW cache at a time
     # min_group_size: CDR3 groups smaller than this skip hfrac and are written as single groups
 
     # round 1: vsearch greedy clustering
     cmdfos, vsearch_groups, small_groups = _build_round1_vsearch_cmds(groups, hi_bound, outdir, min_group_size)
     if len(cmdfos) > 0:
-        n_procs = min(MAX_VSEARCH_PROCS, len(cmdfos))
-        print('        running %d vsearch hfrac jobs (%d concurrent)' % (len(cmdfos), n_procs))
-        utils.run_cmds(cmdfos, n_max_procs=n_procs)
+        n_r1_procs = min(n_procs, len(cmdfos))
+        print('        running %d vsearch hfrac jobs (%d concurrent)' % (len(cmdfos), n_r1_procs))
+        utils.run_cmds(cmdfos, n_max_procs=n_r1_procs)
 
     # parse round 1 results
     r1_by_c3len = {}
@@ -413,7 +412,7 @@ def _apply_hfrac_two_pass(groups, hi_bound, outdir, locus, glfo, merge_factor=HF
     # round 2 (optional): TCM on centroids
     comps_by_c3len, r2_workdirs = {}, {}
     if merge_factor > 0:
-        comps_by_c3len, r2_workdirs = _run_round2_tcm(groups, r1_by_c3len, merge_factor, hi_bound, outdir)
+        comps_by_c3len, r2_workdirs = _run_round2_tcm(groups, r1_by_c3len, merge_factor, hi_bound, outdir, n_procs)
 
     # pass 2: re-read SW caches, build sub-groups, write outputs
     all_group_infos = []
@@ -686,16 +685,18 @@ def resolve_sw_cache_paths(sw_cache_paths, locus):
     return [sw_cache_paths]
 
 # ----------------------------------------------------------------------------------------
-def create_cdr3_groups(locus, sw_cache_paths, outdir, parameter_dir, hfrac=False, hfrac_merge_factor=HFRAC_MERGE_FACTOR_DEFAULT, hfrac_max_bin_size=HFRAC_MAX_BIN_SIZE_DEFAULT, min_group_size=HFRAC_MIN_SEQS_DEFAULT):
+def create_cdr3_groups(locus, sw_cache_paths, outdir, parameter_dir, hfrac=False, hfrac_merge_factor=HFRAC_MERGE_FACTOR_DEFAULT, hfrac_max_bin_size=HFRAC_MAX_BIN_SIZE_DEFAULT, min_group_size=HFRAC_MIN_SEQS_DEFAULT, n_procs=None):
     # read sw cache(s) for a single locus, group sequences by CDR3 length,
     # optionally sub-group by naive hamming fraction (--hfrac),
     # write per-group (or per-sub-group) fastas and sw-cache subsets, write manifest.
     # <sw_cache_paths>: single path string or list of paths.
+    # <n_procs>: concurrent single-threaded vsearch jobs; defaults to available cpus.
     # For multiple caches, processes one chunk at a time to limit peak memory:
     #   - per-group FASTAs are written after all chunks are grouped (seqfos are lightweight)
     #   - per-group sw-cache fragments are written per chunk, then merged and cleaned up
     sw_cache_paths = resolve_sw_cache_paths(sw_cache_paths, locus)
     multi_cache = len(sw_cache_paths) > 1
+    n_procs = utils.n_available_cpus() if n_procs is None else max(1, n_procs)
 
     # compute hi hamming bound for hfrac sub-grouping
     hi_bound = None
@@ -720,7 +721,7 @@ def create_cdr3_groups(locus, sw_cache_paths, outdir, parameter_dir, hfrac=False
         groups, n_failed = group_sequences_by_cdr3_length(annotation_list)
         n_seqs = sum(len(seqfos) for seqfos in groups.values()) + n_failed
         if hfrac:
-            groups, group_infos = _apply_hfrac_and_write(groups, hi_bound, outdir, locus, glfo, annotation_list, merge_factor=hfrac_merge_factor, max_bin_size=hfrac_max_bin_size, min_group_size=min_group_size)
+            groups, group_infos = _apply_hfrac_and_write(groups, hi_bound, outdir, locus, glfo, annotation_list, merge_factor=hfrac_merge_factor, max_bin_size=hfrac_max_bin_size, min_group_size=min_group_size, n_procs=n_procs)
         else:
             group_infos = write_group_fastas(groups, outdir, locus)
             write_group_sw_caches(groups, glfo, annotation_list, outdir, locus)
@@ -777,7 +778,7 @@ def create_cdr3_groups(locus, sw_cache_paths, outdir, parameter_dir, hfrac=False
         # then dispatch all vsearch jobs in parallel
         # pass 2: read each CDR3 sw cache again, parse vsearch results, write sub-group outputs
         if hfrac:
-            _, group_infos = _apply_hfrac_two_pass(groups, hi_bound, outdir, locus, glfo, merge_factor=hfrac_merge_factor, max_bin_size=hfrac_max_bin_size, min_group_size=min_group_size)
+            _, group_infos = _apply_hfrac_two_pass(groups, hi_bound, outdir, locus, glfo, merge_factor=hfrac_merge_factor, max_bin_size=hfrac_max_bin_size, min_group_size=min_group_size, n_procs=n_procs)
 
     n_cdr3_groups = len(set(g['cdr3_length'] for g in group_infos)) if len(group_infos) > 0 else 0
     print('      %s: %d sequences in %d cdr3 length groups (%d failed)' % (locus, n_seqs - n_failed, n_cdr3_groups, n_failed))

--- a/partis/partition_refinement.py
+++ b/partis/partition_refinement.py
@@ -4,8 +4,9 @@ Pipeline-agnostic module: operates on a partition (list of clusters, each a list
 of uids) plus per-sequence annotations and SW naives, and returns a refined
 partition. Usable after any partis partition (standard or disjoint grouping).
 
-Which operators run is decided by D-gene presence, resolved before any of them,
-because each operator is built on a signal only its locus carries:
+Which operators run is decided by the locus, resolved before any of them, because
+each operator is built on a signal only its locus carries. D-gene presence is the
+fallback when no locus is supplied, and a disagreement between the two only warns:
 
   HEAVY  split_on_naive_identity    exact sw naive proposes, shared mutations veto
          merge_on_naive_similarity  naive hamming proposes, mutation fingerprint
@@ -202,7 +203,9 @@ def fingerprint_agreement(fp1, n1, fp2, n2, min_fp_positions=0):
 
     For each mutation position in fp1, check if fp2 has the same position
     with the same dominant base. Score = fraction of fp1's positions that
-    agree with fp2 (symmetric: take the average of both directions).
+    agree with fp2, symmetrised by taking the max of the two directions, so an
+    asymmetric pair passes when the small fragment's positions appear in the
+    large one.
 
     Returns (score, n_strong_max) where score is in [0, 1] and n_strong_max
     is the number of strong positions in the larger fingerprint.
@@ -658,7 +661,9 @@ def repertoire_mutation_freqs(uid_muts, n_seqs=None):
 
 def _weight_bins(muts, freqs, n_seqs, grid):
     """{(pos, base): (frequency, surprisal in whole grid bins)} for one sequence's mutations.
-    Each weight is binned, not the sums, which keeps the tail below exact."""
+    Each weight is binned rather than the sums, which is not a bound in either direction: the
+    dp returns the exact tail of the rounded statistic, which can sit above or below the tail
+    of the unrounded one."""
     floor = FREQ_SMOOTH_COUNT / n_seqs
     out = {}
     for pos, base in muts.items():

--- a/partis/processargs.py
+++ b/partis/processargs.py
@@ -114,6 +114,8 @@ def process(args):
         raise Exception('--hfrac requires --disjoint-groups')
     if (getattr(args, 'ha_repartition', False) or getattr(args, 'partition_refine', False)) and not getattr(args, 'disjoint_groups', False):
         raise Exception('--ha-repartition/--partition-refine require --disjoint-groups')
+    if (getattr(args, 'ha_repartition', False) or getattr(args, 'partition_refine', False)) and args.action.startswith('subset-'):
+        raise Exception('--ha-repartition/--partition-refine do not work with %s (refinement needs disjoint grouping over the whole sample): use \'partition --disjoint-groups\'' % args.action)
 
     if args.outfname is None and args.paired_outdir is None and args.action in utils.existing_output_actions:
         raise Exception('--outfname (or --paired-outdir, if using --paired-loci) required for %s' % args.action)


### PR DESCRIPTION
#### Discussed changes

Options 1, 3 and 4 from #337 (5095231885), in the vocabulary of option 2. No argument changes meaning: `--n-procs` already documents itself as a ceiling and the non-disjoint path honours it, so this makes the disjoint path obey the ceiling it already claims.

Every stage now sizes itself from one budget, `min(--n-procs, available cpus)`, and spends it as (jobs at once) x (procs per job):

| stage | jobs at once | procs per job |
|---|---|---|
| grouping (hfrac vsearch rounds 1 and 2) | budget | 1 (jobs are built `--threads 1`) |
| group partition | `--n-max-procs`, capped by budget | budget // jobs, or `--n-sub-procs` |
| ha-repartition, partition-refine | budget less one for the orchestrator | 1 |
| subset-partition subsets | `--n-max-procs` | full `--n-procs` each, unchanged |

So `--n-procs 16` fills every stage without oversubscribing, and lowering it throttles the pipeline uniformly. `--n-sub-procs` stays the per-group override and is now the only way to oversubscribe, which warns rather than errors. When `--n-procs` exceeds the cpus the process can see, it is reduced and says so rather than silently.

Nothing relied on the old behaviour: the doubling came from `build_single_locus_cmd` copying the command line without stripping `--n-procs`, and the group jobs run vsearch or bcrham, both CPU-bound.

Grouping previously used a hardcoded cap of 8 concurrent vsearch jobs (`MAX_VSEARCH_PROCS`, from #349), wrong in both directions: it oversubscribes a 4-core box and idles 24 of 32 cores on a large node. It now comes from the budget.

This also closes the scan-driver gap you raised. `test/cf-paired-loci.py:232` builds the child command as `--n-procs` from its own `--n-sub-procs`, and the drivers expose no knob for the inner split, so a scan-driven disjoint run used to get 2 x 15 = 30 procs with no CLI way to fix it. It now derives 2 jobs of 7 from the 15 it was given.

`--n-max-subprocs` becomes `--n-max-procs`, matching the drivers' name for "how many jobs at once", with the old spelling kept as a hidden alias. You suggested this as its own PR; I folded it in because most of its sites are lines the other commits already touch.

#### Changes the code path forced

The merged re-partition in `subset-partition` stripped `--disjoint-groups` but not `--hfrac`, `--ha-repartition` or `--partition-refine`, all three of which are rejected without `--disjoint-groups`. So `subset-partition --disjoint-groups --hfrac` always crashed at the final merge, after every per-subset job had finished. It now strips them, plus the three hfrac tuning args, which mean nothing on a run that does no grouping.

Refinement needs disjoint grouping over the whole sample. Under `subset-partition` the sample is split first and the merged re-partition runs without `--disjoint-groups`, so refinement cannot apply there, and its single-chain output also does not match the paired per-subset file `run_subsets` waits for (the subset finished correctly and was then reported as `exceeded max number of tries`). The combination now raises up front, pointing at `partition --disjoint-groups`.

#### Identified, not fixed here

The paired `subset-partition` reference is now stale: it records a 2 x 10 = 20 procs run on 8 cpus, where the correct allocation is 8. Concretely `partis-test.py --paired` shows subset completeness 0.677 to 0.635, which is the proc count rather than the logic, since re-running with `--n-sub-procs 10` restores the old per-group count and returns completeness to the unmodified baseline of 0.682. I have not regenerated it here.
