### PR TITLE
Add zig backend selection (--zig) and validate against C++ at 200k/1M

### DIFF
--- a/bin/partis
+++ b/bin/partis
@@ -2249,4 +2249,10 @@ random.seed(args.random_seed)
 numpy.random.seed(args.random_seed)
 start = time.time()
 args.func(args)
-print('      total time: %.1f' % (time.time()-start))
+total_time = time.time() - start
+print('      total time: %.1f' % total_time)
+from partis import partitiondriver
+bcrham_t, bcrham_n = partitiondriver.get_bcrham_summary()
+if bcrham_n > 0:
+    pct = 100.0 * bcrham_t / total_time if total_time > 0 else 0.0
+    print('      bcrham time: %.1f (%.1f%% of total, %d calls)' % (bcrham_t, pct, bcrham_n))

--- a/bin/partis
+++ b/bin/partis
@@ -17,6 +17,7 @@ import traceback
 from io import open
 import colored_traceback.always
 import os
+import platform
 import json
 import yaml
 import csv
@@ -1834,6 +1835,7 @@ parent_args.append({'name' : '--extra-print-keys', 'kwargs' : {'help' : 'add the
 parent_args.append({'name' : '--n-procs', 'kwargs' : {'type' : int, 'default' : utils.auto_n_procs(), 'help' : 'Number of processes over which to parallelize (defaults to the number of cpus on the machine). This is usually the maximum that will be initialized at any given time, but for internal reasons, certain steps (e.g. smith waterman) sometimes use slightly more.'}})
 parent_args.append({'name' : '--n-max-to-calc-per-process', 'kwargs' : {'default' : 250, 'help' : 'if a bcrham process calc\'d more than this many fwd + vtb values (and this is the first time with this number of procs), don\'t decrease the number of processes in the next step (default %(default)d)'}})
 parent_args.append({'name' : '--min-hmm-step-time', 'kwargs' : {'default' : 2., 'help' : 'if a clustering step takes fewer than this many seconds, always reduce n_procs'}})
+parent_args.append({'name' : '--no-time-based-n-proc-reduction', 'kwargs' : {'action' : 'store_true', 'help' : 'disable time-based n_procs reduction during partition hieraglom iterations (for testing: ensures C++ and Zig backends use the same number of processes)'}})
 parent_args.append({'name' : '--batch-system', 'kwargs' : {'choices' : ['slurm', 'sge'], 'help' : 'batch system with which to attempt paralellization'}})
 parent_args.append({'name' : '--batch-options', 'kwargs' : {'help' : 'additional options to apply to --batch-system (e.g. --batch-options : "--foo bar")'}})
 parent_args.append({'name' : '--batch-config-fname', 'kwargs' : {'default' : '/etc/slurm-llnl/slurm.conf', 'help' : 'system-wide batch system configuration file name'}})  # for when you're running the whole thing within one slurm allocation, i.e. with  % salloc --nodes N ./bin/partis [...]
@@ -1844,6 +1846,8 @@ parent_args.append({'name' : '--count-correlations', 'kwargs' : {'action' : 'sto
 parent_args.append({'name' : '--dont-write-parameters', 'kwargs' : {'action' : 'store_true', 'help' : 'don\'t write parameters to disk even if you\'ve counted them (mostly for use in conjunction with --only-smith-waterman, so you can avoid cluttering up your file system)'}})
 parent_args.append({'name' : '--partis-dir', 'kwargs' : {'default' : partis_dir, 'help' : 'for internal use only'}})
 parent_args.append({'name' : '--ig-sw-binary', 'kwargs' : {'default' : partis_dir + '/packages/ig-sw/src/ig_align/ig-sw', 'help' : 'Path to ig-sw executable.'}})
+parent_args.append({'name' : '--bcrham-binary', 'kwargs' : {'default' : partis_dir + '/packages/ham/bcrham', 'help' : 'Path to bcrham executable.'}})
+parent_args.append({'name' : '--zig', 'kwargs' : {'action' : 'store_true', 'help' : 'Use Zig backend instead of C++ bcrham and C ig-sw. Requires running bin/zig-build.sh first.'}})
 parent_args.append({'name' : '--vsearch-binary', 'kwargs' : { 'help' : 'Path to vsearch binary (vsearch binaries for linux and darwin are pre-installed in bin/, but for other systems you need to get your own)'}})
 parent_args.append({'name' : '--is-simu', 'kwargs' : {'action' : 'store_true', 'help' : 'Set if running on simulated sequences'}})
 parent_args.append({'name' : '--skip-unproductive', 'kwargs' : {'action' : 'store_true', 'help' : 'Skip sequences which Smith-Waterman determines to be unproductive (i.e. if they have stop codons, out of frame cdr3, or mutated cyst/tryp/phen)'}})
@@ -2221,6 +2225,24 @@ args = parser.parse_args() if len(sys.argv) > 1 else parser.parse_args(['--help'
 # add OR of all arguments to all subparsers to <args>, as None (to avoid having to rewrite a *##!(%ton of other code)
 for missing_arg in get_arg_names('all') - set(args.__dict__):  # NOTE see also remove_action_specific_args() above, which kind of does similar things, at least if i rewrote this all from scratch only one (or neither...) would exist
     args.__dict__[missing_arg] = None
+
+if not getattr(args, 'zig', False) and sys.platform == 'darwin' and platform.machine() == 'arm64':
+    # Apple Silicon can't build/run the SSE2 C++ ig-sw (issue #330), so zig is the only backend here -- default to it. everywhere the C++ backend *does* run (linux, intel mac), --zig stays an explicit opt-in, since the C++ backend is the more-tested default.
+    print('  %s no C++ backend on Apple Silicon (arm64 can\'t run the SSE2 ig-sw, issue #330), so defaulting to the zig backend, which is faster, but newer and less thoroughly tested' % utils.wrnstr())
+    args.zig = True
+
+if getattr(args, 'zig', False):
+    zig_bin = partis_dir + '/packages/zig-core/zig-out/bin'
+    for binary, name in [('bcrham_binary', 'partis-zig-core'), ('ig_sw_binary', 'partis-zig-igsw')]:
+        path = zig_bin + '/' + name
+        if not os.path.exists(path):
+            raise Exception('Zig binary not found: %s (run bin/zig-build.sh first)' % path)
+        setattr(args, binary, path)
+else:  # default (C++) backend: if its binaries aren't built but the zig ones are, point at --zig
+    zig_bin = partis_dir + '/packages/zig-core/zig-out/bin'
+    for binary, zname in [('bcrham_binary', 'partis-zig-core'), ('ig_sw_binary', 'partis-zig-igsw')]:
+        if not os.path.exists(getattr(args, binary)) and os.path.exists(zig_bin + '/' + zname):
+            raise Exception('C++ backend binary not found (%s), but the zig backend is built -- pass --zig to use it (or reinstall the C++ backend with bin/build.sh)' % getattr(args, binary))
 
 processargs.process(args)
 random.seed(args.random_seed)

--- a/bin/partis-30k-parity-test.sh
+++ b/bin/partis-30k-parity-test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# 30k Zig-vs-C++ partition parity gate (issue #375).
+#
+# Runs an unbounded paired-loci partition with the Zig and C++ backends on the
+# same 30k input, then compares cluster membership and per-event annotation
+# fields. Exits 0 if identical, 1 otherwise. The 5k partis-test.py rung doesn't
+# exercise enough cache round-trips to surface tiebreak-density-dependent
+# divergences (#375 was latent until 30k).
+#
+# Usage:
+#   bin/partis-30k-parity-test.sh [INFILE [OUTBASE [N]]]
+#
+# Defaults:
+#   INFILE = /tmp/paired-paper-all-seqs.fa
+#   OUTBASE = /tmp/parity-30k-test
+#   N = 30000
+#
+# Wall budget on pax (32-core Zen 5):
+#   ~50 min Zig + ~100 min C++ + a few min compare = ~2.5 h total when sequential.
+#   Backends run sequentially to keep the host responsive; bump --n-procs in
+#   this script to parallelize within a backend.
+
+set -euo pipefail
+
+INFILE="${1:-/tmp/paired-paper-all-seqs.fa}"
+OUTBASE="${2:-/tmp/parity-30k-test}"
+N="${3:-30000}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Match bin/zig-perf-counters-run.sh: per project CLAUDE.md, activate the venv
+# before invoking partis so an unactivated shell doesn't fall back to system
+# python and fail with an import error.
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/.venv/bin/activate"
+
+COMPARE="${REPO_ROOT}/bin/zig-compare.py"
+if [[ ! -x "${COMPARE}" ]]; then
+  echo "ERROR: cannot find zig-compare.py at ${COMPARE}" >&2
+  exit 2
+fi
+
+if [[ ! -f "${INFILE}" ]]; then
+  echo "ERROR: input file ${INFILE} does not exist" >&2
+  exit 2
+fi
+
+CPP_DIR="${OUTBASE}-cpp"
+ZIG_DIR="${OUTBASE}-zig"
+
+run_backend() {
+  local backend="$1" outdir="$2"
+  shift 2
+  rm -rf "${outdir}"
+  echo ">> running ${backend} backend → ${outdir}"
+  PYTHONHASHSEED=0 python3 "${REPO_ROOT}/bin/partis" partition --paired-loci \
+    --paired-outdir "${outdir}" \
+    --infname "${INFILE}" --n-max-queries "${N}" \
+    --random-seed 1 --n-procs 10 --no-time-based-n-proc-reduction \
+    --dont-write-git-info "$@"
+}
+
+# C++ first (slower), then Zig — sequential keeps the host responsive at the
+# usual 10 procs. Either order works; the partition is deterministic.
+run_backend "C++"  "${CPP_DIR}"
+run_backend "Zig"  "${ZIG_DIR}"  --zig
+
+echo ">> comparing"
+"${COMPARE}" "${CPP_DIR}" "${ZIG_DIR}"

--- a/bin/zig-build.sh
+++ b/bin/zig-build.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Build the in-tree Zig backend (drop-in replacements for bcrham and ig-sw).
+#
+# Usage:
+#   bin/zig-build.sh
+#
+# After building, pass --zig to partis:
+#   partis --zig annotate ...
+set -euo pipefail
+
+ZIG_VERSION="0.15.2"
+PARTIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ZIG_CORE_DIR="$PARTIS_DIR/packages/zig-core"
+ZIG_EXE_FINAL="$ZIG_CORE_DIR/zig-out/bin/partis-zig-core"
+ZIG_IGSW_EXE_FINAL="$ZIG_CORE_DIR/zig-out/bin/partis-zig-igsw"
+
+echo "==> Building Zig backend in: $ZIG_CORE_DIR"
+
+# ── 1. Ensure Zig is available ──────────────────────────────────────────────
+
+find_zig() {
+    # Prefer a zig in PATH that matches the required version
+    if command -v zig &>/dev/null; then
+        local v
+        v=$(zig version 2>/dev/null || echo "")
+        if [[ "$v" == "$ZIG_VERSION" ]]; then
+            echo "zig"
+            return
+        fi
+    fi
+    # Check if we already downloaded it
+    local downloaded="$ZIG_CORE_DIR/.zig-install/zig-$ZIG_VERSION/zig"
+    if [[ -x "$downloaded" ]]; then
+        echo "$downloaded"
+        return
+    fi
+    echo ""
+}
+
+ZIG=$(find_zig)
+if [[ -z "$ZIG" ]]; then
+    echo "==> Downloading Zig $ZIG_VERSION..."
+    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+    ARCH=$(uname -m)
+    case "$ARCH" in
+        x86_64)  ARCH="x86_64" ;;
+        aarch64|arm64) ARCH="aarch64" ;;
+        *) echo "ERROR: Unsupported architecture: $ARCH" >&2; exit 1 ;;
+    esac
+    case "$OS" in
+        linux)  OS_TAG="linux" ;;
+        darwin) OS_TAG="macos" ;;
+        *) echo "ERROR: Unsupported OS: $OS" >&2; exit 1 ;;
+    esac
+    ZIG_TARBALL="zig-${ARCH}-${OS_TAG}-${ZIG_VERSION}.tar.xz"
+    ZIG_URL="https://ziglang.org/download/${ZIG_VERSION}/${ZIG_TARBALL}"
+    ZIG_DIR="$ZIG_CORE_DIR/.zig-install/zig-${ZIG_VERSION}"
+    mkdir -p "$ZIG_DIR"
+    curl -fsSL "$ZIG_URL" | tar -xJ -C "$ZIG_DIR" --strip-components=1
+    ZIG="$ZIG_DIR/zig"
+    echo "    Zig $ZIG_VERSION installed at: $ZIG"
+else
+    echo "==> Using Zig: $ZIG ($($ZIG version))"
+fi
+
+# ── 2. Build ─────────────────────────────────────────────────────────────────
+
+export PARTIS_DIR
+echo "==> Building partis-zig-core (this takes ~30s)..."
+(cd "$ZIG_CORE_DIR" && "$ZIG" build -Doptimize=ReleaseFast)
+
+if [[ ! -x "$ZIG_EXE_FINAL" ]]; then
+    echo "ERROR: build succeeded but executable not found at $ZIG_EXE_FINAL" >&2
+    exit 1
+fi
+
+echo ""
+echo "Build complete:"
+echo "  $ZIG_EXE_FINAL"
+echo "  $ZIG_IGSW_EXE_FINAL"
+echo ""
+echo "To use the Zig backend, pass --zig to partis:"
+echo "  partis --zig annotate ..."

--- a/bin/zig-build.sh
+++ b/bin/zig-build.sh
@@ -2,11 +2,21 @@
 # Build the in-tree Zig backend (drop-in replacements for bcrham and ig-sw).
 #
 # Usage:
-#   bin/zig-build.sh
+#   bin/zig-build.sh [zig-target] [search-prefix]
 #
 # After building, pass --zig to partis:
 #   partis --zig annotate ...
 set -euo pipefail
+
+# drop the active conda-family env's cc, on PATH or in CC, ahead of zig's own toolchain.
+unset -v CC CXX 2>/dev/null || true
+if [[ -n "${CONDA_PREFIX:-}" ]]; then
+    PATH=$(printf '%s' "$PATH" | tr ':' '\n' | grep -Fv "$CONDA_PREFIX" | paste -sd: -)
+    export PATH
+fi
+
+ZIG_TARGET="${1:-}"
+ZIG_SEARCH_PREFIX="${2:-}"
 
 ZIG_VERSION="0.15.2"
 PARTIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -67,7 +77,15 @@ fi
 
 export PARTIS_DIR
 echo "==> Building partis-zig-core (this takes ~30s)..."
-(cd "$ZIG_CORE_DIR" && "$ZIG" build -Doptimize=ReleaseFast)
+BUILD_ARGS=(-Doptimize=ReleaseFast)
+if [[ -n "$ZIG_TARGET" ]]; then
+    echo "==> Targeting: $ZIG_TARGET"
+    BUILD_ARGS+=(-Dtarget="$ZIG_TARGET")
+fi
+if [[ -n "$ZIG_SEARCH_PREFIX" ]]; then
+    BUILD_ARGS+=(--search-prefix "$ZIG_SEARCH_PREFIX")
+fi
+(cd "$ZIG_CORE_DIR" && "$ZIG" build "${BUILD_ARGS[@]}")
 
 if [[ ! -x "$ZIG_EXE_FINAL" ]]; then
     echo "ERROR: build succeeded but executable not found at $ZIG_EXE_FINAL" >&2

--- a/bin/zig-compare.py
+++ b/bin/zig-compare.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Diff two partis paired-loci output dirs for byte-equality on partition + annotations.
+
+Usage: zig-compare.py <baseline_dir> <new_dir>
+
+Companion to bin/partis-30k-parity-test.sh (issue #375 cpp-mirror gate).
+Exit 0 if identical, 1 otherwise.
+"""
+import hashlib
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+from partis import utils
+from partis.clusterpath import ClusterPath
+
+
+def best_partition(path):
+    cpath = ClusterPath()
+    cpath.readfile(path)
+    return sorted(tuple(sorted(c)) for c in cpath.partitions[cpath.i_best])
+
+
+FIELDS = ('naive_seq', 'v_gene', 'd_gene', 'j_gene',
+          'v_3p_del', 'd_5p_del', 'd_3p_del', 'j_5p_del',
+          'vd_insertion', 'dj_insertion', 'cdr3_length')
+
+_MD5_CHUNK_BYTES = 1 << 20
+
+
+# All partition-{locus}.yaml files paired-loci output writes. Subdirs and loci
+# are derived from utils.locus_pairs (plus top-level + single-chain/) so a
+# future paired-loci pair addition picks up automatically. Originally the
+# gate only walked igh+igk/ (or igh+igl/ as fallback) and missed single-chain
+# divergence at 50k — see #386.
+def _partition_relpaths():
+    pairs = utils.locus_pairs['ig']
+    loci = sorted({l for lp in pairs for l in lp})
+    subs = [''] + ['+'.join(lp) for lp in pairs] + ['single-chain']
+    return [(sub, loc, f'{sub}/partition-{loc}.yaml' if sub else f'partition-{loc}.yaml')
+            for sub in subs for loc in loci]
+
+
+PARTITION_RELPATHS = _partition_relpaths()
+
+
+def md5(path):
+    h = hashlib.md5()
+    with open(path, 'rb') as fh:
+        for chunk in iter(lambda: fh.read(_MD5_CHUNK_BYTES), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def diff_one(label, bp, np_):
+    """Compare a single base/new partition-*.yaml pair. Returns 1 on diff, 0 on match, None on skip."""
+    if not os.path.exists(bp) and not os.path.exists(np_):
+        return None  # neither side has this file — not produced by this run
+    if not os.path.exists(bp):
+        print(f'{label}: MISSING in base ({bp})')
+        return 1
+    if not os.path.exists(np_):
+        print(f'{label}: MISSING in new ({np_})')
+        return 1
+    if md5(bp) == md5(np_):
+        print(f'{label}: byte-identical')
+        return 0
+    bpart = best_partition(bp)
+    npart = best_partition(np_)
+    if bpart != npart:
+        print(f'{label}: PARTITION DIFF ({len(bpart)} vs {len(npart)} clusters)')
+        return 1
+    bd = utils.read_json_yaml(bp)
+    nd = utils.read_json_yaml(np_)
+    bk = {tuple(sorted(e['unique_ids'])): e for e in bd['events']}
+    nk = {tuple(sorted(e['unique_ids'])): e for e in nd['events']}
+    if set(bk) != set(nk):
+        only_b = set(bk) - set(nk)
+        only_n = set(nk) - set(bk)
+        print(f'{label}: EVENT-KEY DIFF (only in base: {len(only_b)}, only in new: {len(only_n)})')
+        return 1
+    field_diffs = 0
+    for k in bk:
+        for f in FIELDS:
+            if bk[k].get(f) != nk[k].get(f):
+                field_diffs += 1
+                if field_diffs <= 3:
+                    print(f'{label} {k[0]}...: {f} diff: {bk[k].get(f)} vs {nk[k].get(f)}')
+    if field_diffs:
+        print(f'{label}: {field_diffs} FIELD DIFFS across {len(bk)} events')
+        return 1
+    # Bytes differ but every event keyed by unique_ids has bit-identical content
+    # and partitions match — the diff is event-list ordering only (#386).
+    cpp_order = [tuple(sorted(e['unique_ids'])) for e in bd['events']]
+    zig_order = [tuple(sorted(e['unique_ids'])) for e in nd['events']]
+    n_pos_diff = sum(1 for a, b in zip(cpp_order, zig_order) if a != b)
+    print(f'{label}: BYTE DIFF (md5 mismatch) but events bit-identical by uid; '
+          f'event-list order differs at {n_pos_diff}/{len(bk)} positions')
+    return 1
+
+
+def diff_pair(base, new):
+    n_diffs = 0
+    n_compared = 0
+    for sub, locus, rel in PARTITION_RELPATHS:
+        label = f'{sub or "(top)"}/{locus}'
+        res = diff_one(label, f'{base}/{rel}', f'{new}/{rel}')
+        if res is None:
+            continue
+        n_compared += 1
+        n_diffs += res
+    if n_compared == 0:
+        print('no partition files found in either dir')
+        return 1
+    return n_diffs
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit(__doc__)
+    base, new = sys.argv[1], sys.argv[2]
+    n = diff_pair(base, new)
+    if n:
+        print(f'\nFAILED: {n} loci differ')
+        sys.exit(1)
+    print('\nOK: identical')
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/zig-perf-counters-aggregate.py
+++ b/bin/zig-perf-counters-aggregate.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Aggregate PERFCOUNTER / PERFCOUNTER_CACHE / PERFCOUNTER_TIMING lines.
+
+Per-query summary: median/p95/max of ksets, fillTrellis calls, addInLogSpace
+calls, addInLogSpace+log_exp work calls, active-state distribution stats, and
+chunk-cache hit rate. Plus a chunk-cache prefix-list-length histogram across
+all queries.
+
+For Phase-B (added after the issue #366 lever-5 close, PR
+https://github.com/psathyrella/partis/pull/383), also aggregates
+PERFCOUNTER_TIMING lines: cycle-precise nanosecond accumulators for
+fillTrellis sub-phases (chunkScan / init / tmpInit / viterbi / forward /
+traceback / put) and the runKSet cache-hit branch (cachedPath). The
+timing report is what we should have had before pulling lever 5: it
+divides time spent between cache-hit and cache-miss paths, and within
+the cache-miss path between trellis init, the DP itself, and traceback.
+
+The log file is produced by partis-zig-core when built with
+-Dperf-counters=true and run with PARTIS_ZIG_PERF_LOG=<path> in the env. See
+packages/zig-core/src/ham/perf_counters.zig for the metric definitions.
+
+These counters pin denominators (active-state distribution, n_ksets,
+fillTrellis call counts, addInLogSpace call counts, chunk-cache hit rate)
+for the perf-work cost claims tracked in issue #366
+(https://github.com/psathyrella/partis/issues/366). Originally landed in
+PR #368.
+
+Usage: zig-perf-counters-aggregate.py <log-file>
+"""
+import argparse
+import re
+import sys
+from collections import defaultdict
+
+
+# Histogram bucket labels for the chunk-cache prefix-list-length report,
+# in display order.
+CACHE_BUCKET_ORDER = ("0", "1", "2", "3", "4", "5",
+                      "6_9", "10_19", "20_49", "50_99", "100_199", "200p")
+
+
+def parse_kv(line):
+    return {m.group(1): m.group(2) for m in re.finditer(r"(\w+)=(\S+)", line)}
+
+
+def stats(xs):
+    if not xs:
+        return None
+    xs = sorted(xs)
+    n = len(xs)
+    return {
+        "n": n,
+        "min": xs[0],
+        "median": xs[n // 2],
+        "p95": xs[int(n * 0.95)] if n > 1 else xs[0],
+        "max": xs[-1],
+        "mean": sum(xs) / n,
+        "total": sum(xs),
+    }
+
+
+# Fields on PERFCOUNTER_TIMING line that hold per-query ns accumulators.
+# fillTrellis_total is the parent (sub-phases sum into it modulo work
+# outside the sub-timers, like the model load); cachedPath is a sibling
+# (the runKSet branch that bypasses fillTrellis entirely).
+TIMING_SUBPHASES = (
+    "chunkScan_ns", "init_ns", "tmpInit_ns",
+    "viterbi_ns", "forward_ns", "traceback_ns", "put_ns",
+)
+
+
+def trow(name, ns, denom):
+    pct = (100 * ns / denom) if denom else 0
+    print(f"    {name:<32}  {ns / 1e9:>9.3f}s  ({pct:>5.1f}% of timed)")
+
+
+def main(path):
+    by_alg = defaultdict(lambda: {
+        "ksets": [], "fillTrellis": [], "addInLogSpace": [],
+        "addInLogSpace_log_exp": [], "chunk_hits": [], "chunk_lookups": [],
+        "active_med": [], "active_p95": [], "active_max": [], "active_positions": [],
+        "n_seqs": [],
+    })
+    cache_buckets = defaultdict(lambda: defaultdict(int))
+    # timing[alg][field] = list of per-query ns values
+    timing = defaultdict(lambda: defaultdict(list))
+    # glomerator[kind] = list of {glomerator_total_ns, cumul_dpHandler_run_ns}
+    glomerator = defaultdict(list)
+    n_lines = 0
+    n_cache_lines = 0
+    n_timing_lines = 0
+    n_glom_lines = 0
+
+    try:
+        fh = open(path)
+    except (IOError, OSError) as e:
+        sys.exit(f"error: cannot open {path}: {e}")
+    with fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("PERFCOUNTER_GLOMERATOR"):
+                n_glom_lines += 1
+                kv = parse_kv(line[len("PERFCOUNTER_GLOMERATOR "):])
+                kind = kv.get("kind", "?")
+                glomerator[kind].append({
+                    "glomerator_total_ns": int(kv["glomerator_total_ns"]),
+                    "cumul_dpHandler_run_ns": int(kv["cumul_dpHandler_run_ns"]),
+                })
+                continue
+            if line.startswith("PERFCOUNTER_CACHE"):
+                n_cache_lines += 1
+                kv = parse_kv(line[len("PERFCOUNTER_CACHE "):])
+                alg = kv.get("alg", "?")
+                for k, v in kv.items():
+                    if k in ("alg", "q"):
+                        continue
+                    cache_buckets[alg][k] += int(v)
+                continue
+            if line.startswith("PERFCOUNTER_TIMING"):
+                n_timing_lines += 1
+                kv = parse_kv(line[len("PERFCOUNTER_TIMING "):])
+                alg = kv.get("alg", "?")
+                t = timing[alg]
+                t["fillTrellis_total_ns"].append(int(kv["fillTrellis_total_ns"]))
+                t["cachedPath_ns"].append(int(kv["cachedPath_ns"]))
+                for k in TIMING_SUBPHASES:
+                    t[k].append(int(kv[k]))
+                # Outer-perimeter accumulators (older logs omit these; default 0).
+                t["runKSet_total_ns"].append(int(kv.get("runKSet_total_ns", "0")))
+                t["dpHandler_run_total_ns"].append(int(kv.get("dpHandler_run_total_ns", "0")))
+                # Phase-B'' deeper-DP timers (older logs omit; default 0).
+                for k in ("viterbi_init_ns", "viterbi_ending_ns",
+                          "forward_init_ns", "forward_ending_ns"):
+                    t[k].append(int(kv.get(k, "0")))
+                continue
+            if not line.startswith("PERFCOUNTER"):
+                continue
+            n_lines += 1
+            kv = parse_kv(line[len("PERFCOUNTER "):])
+            alg = kv.get("alg", "?")
+            d = by_alg[alg]
+            d["n_seqs"].append(int(kv["n_seqs"]))
+            d["ksets"].append(int(kv["ksets"]))
+            d["fillTrellis"].append(int(kv["fillTrellis"]))
+            d["addInLogSpace"].append(int(kv["addInLogSpace"]))
+            d["addInLogSpace_log_exp"].append(int(kv["addInLogSpace_log_exp"]))
+            h, l = kv["chunk_hits"].split("/")
+            d["chunk_hits"].append(int(h))
+            d["chunk_lookups"].append(int(l))
+            d["active_med"].append(int(kv["active_states_med"]))
+            d["active_p95"].append(int(kv["active_states_p95"]))
+            d["active_max"].append(int(kv["active_states_max"]))
+            d["active_positions"].append(int(kv["active_states_positions"]))
+
+    print(f"# parsed {n_lines} PERFCOUNTER + {n_cache_lines} PERFCOUNTER_CACHE + {n_timing_lines} PERFCOUNTER_TIMING + {n_glom_lines} PERFCOUNTER_GLOMERATOR lines from {path}")
+    for alg, d in by_alg.items():
+        nq = len(d["ksets"])
+        print(f"\n## algorithm={alg}, n_queries={nq}")
+
+        def row(name, xs, fmt="{:>12,d}"):
+            s = stats(xs)
+            if s is None:
+                return
+            print(f"  {name:<32}  median={fmt.format(s['median'])}  p95={fmt.format(s['p95'])}  max={fmt.format(s['max'])}  mean={s['mean']:>12,.1f}  total={s['total']:>14,d}")
+
+        row("n_seqs (per query)", d["n_seqs"])
+        row("ksets (per query)", d["ksets"])
+        row("fillTrellis calls (per query)", d["fillTrellis"])
+        row("addInLogSpace calls (per query)", d["addInLogSpace"])
+        row("addInLogSpace+log_exp (per query)", d["addInLogSpace_log_exp"])
+
+        # active states are already per-query medians/p95/maxes; aggregate across queries
+        row("active_states median-of-medians", d["active_med"])
+        row("active_states median-of-p95s", d["active_p95"])
+        row("active_states median-of-maxes", d["active_max"])
+        row("active_positions (per query)", d["active_positions"])
+
+        # chunk-cache rate
+        total_hits = sum(d["chunk_hits"])
+        total_lookups = sum(d["chunk_lookups"])
+        if total_lookups:
+            print(f"  {'chunk_cache_rate':<32}  hits/lookups = {total_hits:,} / {total_lookups:,} = {100*total_hits/total_lookups:.1f}%")
+
+    if cache_buckets:
+        print("\n## chunk-cache prefix-list-length histogram (across all queries)")
+        for alg, buckets in cache_buckets.items():
+            print(f"  alg={alg}")
+            total = sum(buckets.values())
+            for k in CACHE_BUCKET_ORDER:
+                v = buckets.get(k, 0)
+                pct = 100 * v / total if total else 0
+                print(f"    {k:>8}: {v:>10,d}  ({pct:>5.1f}%)")
+            print(f"    {'total':>8}: {total:>10,d}")
+
+    # Phase-B timing report: where is bcrham wall actually going inside
+    # the Zig core? Sub-phases sum into fillTrellis_total; cachedPath is
+    # the sibling runKSet branch that bypasses fillTrellis entirely. The
+    # denominator we want for "%" is "all time the Zig core spent doing
+    # DP-ish work for this query," which is fillTrellis_total + cachedPath.
+    # Anything not in that sum is runKSet glue, findPartialCacheMatch,
+    # sorted-gene plumbing, etc. — out of the timed perimeter.
+    if timing:
+        print("\n## sub-phase timing (Phase-B, PERFCOUNTER_TIMING)")
+        # Three concentric perimeters, biggest first:
+        #   dpHandler_run_total ⊇ Σ runKSet_total ⊇ Σ fillTrellis_total + Σ cachedPath
+        # Each "_overhead" row is the residual between a perimeter and the
+        # sum of its inner pieces — i.e. work in the outer that isn't in
+        # any inner sub-bucket. Denominator is dpHandler_run_total when
+        # present (so % adds up over all reported rows); falls back to
+        # fillTrellis_total + cachedPath for older logs without outer
+        # timers.
+        for alg, t in timing.items():
+            tot_run = sum(t.get("dpHandler_run_total_ns", []))
+            tot_rks = sum(t.get("runKSet_total_ns", []))
+            tot_fill = sum(t["fillTrellis_total_ns"])
+            tot_cached = sum(t["cachedPath_ns"])
+            inner_timed = tot_fill + tot_cached
+            denom = tot_run if tot_run > 0 else inner_timed
+            print(f"  alg={alg}, n_queries={len(t['fillTrellis_total_ns'])}, "
+                  f"dpHandler_run_total={tot_run / 1e9:.3f}s "
+                  f"(runKSet={tot_rks / 1e9:.3f}s, "
+                  f"fillTrellis+cachedPath={inner_timed / 1e9:.3f}s)")
+
+            if tot_run > 0:
+                trow("dpHandler_run_total (outer)", tot_run, denom)
+                # Pre/post-runKSet work inside run(): Sequences build,
+                # only_genes map, rescaleOverallMuteFreqs, fillRecoEvent,
+                # Result.finalize, debug summary.
+                trow("  (run()-body pre/post-runKSet)", tot_run - tot_rks, denom)
+                trow("runKSet_total (Σ ksets)", tot_rks, denom)
+            trow("  fillTrellis_total (Σ misses+chunks)", tot_fill, denom)
+            for k in TIMING_SUBPHASES:
+                trow(f"    {k}", sum(t[k]), denom)
+                # Phase-B'' DP-body sub-split (init + ending → position
+                # loop derived as residual). Only meaningful for the
+                # viterbi/forward rows.
+                if k == "viterbi_ns":
+                    vi = sum(t.get("viterbi_init_ns", [0]))
+                    ve = sum(t.get("viterbi_ending_ns", [0]))
+                    vp = sum(t[k]) - vi - ve
+                    trow("      viterbi_init_ns", vi, denom)
+                    trow("      viterbi_positionLoop_ns (derived)", vp, denom)
+                    trow("      viterbi_ending_ns", ve, denom)
+                elif k == "forward_ns":
+                    fi = sum(t.get("forward_init_ns", [0]))
+                    fe = sum(t.get("forward_ending_ns", [0]))
+                    fp = sum(t[k]) - fi - fe
+                    trow("      forward_init_ns", fi, denom)
+                    trow("      forward_positionLoop_ns (derived)", fp, denom)
+                    trow("      forward_ending_ns", fe, denom)
+            sub_sum = sum(sum(t[k]) for k in TIMING_SUBPHASES)
+            unaccounted_fill = tot_fill - sub_sum
+            # The model load (`self.hmms.get(gene)`) sits between the
+            # chunk scan and the init/tmpInit; it's not timed. So
+            # fillTrellis_total − Σ sub-phases is the un-timed remainder,
+            # mostly that lookup plus the addWithMinusInfinities math.
+            trow("    (fillTrellis untimed)", unaccounted_fill, denom)
+            trow("  cachedPath (sibling, Σ hits)", tot_cached, denom)
+            if tot_rks > 0:
+                # runKSet plumbing: sorted_genes alloc/sort, regions loop,
+                # findPartialCacheMatch, regional_total/best updates, the
+                # debug-output and fillRecoEvent assembly. Anything inside
+                # runKSet body but outside fillTrellis() and cachedPath_ns.
+                trow("  (runKSet body, excl. fillTrellis+cachedPath)",
+                     tot_rks - inner_timed, denom)
+
+    # Phase-B' outermost perimeter: one PERFCOUNTER_GLOMERATOR per bcrham
+    # invocation that ran Glomerator.cluster() or cacheNaiveSeqs(). The
+    # `cumul_dpHandler_run_ns` is the sum of every DPHandler.run() body
+    # time during that bcrham process; the residual is Glomerator driver
+    # overhead — merge decisions, partition I/O, hfrac calculations.
+    if glomerator:
+        print("\n## Glomerator wrapper (Phase-B', PERFCOUNTER_GLOMERATOR)")
+        for kind, rows in glomerator.items():
+            tot_glom = sum(r["glomerator_total_ns"] for r in rows)
+            tot_dp = sum(r["cumul_dpHandler_run_ns"] for r in rows)
+            n_proc = len(rows)
+            # `glomerator_total` is summed across bcrham procs, not elapsed
+            # wall — without the mean-per-proc column readers can mis-read
+            # a 152s sum as a single-process wall claim. Both reported.
+            mean_glom = tot_glom / n_proc if n_proc else 0
+            print(f"  kind={kind}, n_bcrham_procs={n_proc}, "
+                  f"mean_glom_per_proc={mean_glom / 1e9:.3f}s, "
+                  f"sum_glomerator_total={tot_glom / 1e9:.3f}s "
+                  f"(cumul_dpHandler_run={tot_dp / 1e9:.3f}s, "
+                  f"driver_overhead={(tot_glom - tot_dp) / 1e9:.3f}s, "
+                  f"driver_overhead_pct={100 * (tot_glom - tot_dp) / tot_glom if tot_glom else 0:.1f}%)")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("log_file", help="PERFCOUNTER log produced by partis-zig-core")
+    main(parser.parse_args().log_file)

--- a/bin/zig-perf-counters-run.sh
+++ b/bin/zig-perf-counters-run.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Build partis-zig-core with -Dperf-counters=true and run a partition workload
+# with PARTIS_ZIG_PERF_LOG set, so each query emits one PERFCOUNTER line plus
+# one PERFCOUNTER_CACHE line (chunk-cache prefix-list-length histogram) into
+# the log. See packages/zig-core/src/ham/perf_counters.zig for the metric set.
+#
+# These counters pin denominators for the perf-work cost claims tracked in
+# issue #366 (https://github.com/psathyrella/partis/issues/366) — the
+# distributions every later perf-item's wall claim depends on:
+# per-query active-state median/p95/max, n_ksets, fillTrellis call counts,
+# addInLogSpace call counts, and chunk-cache hit rate. Originally landed in
+# PR #368.
+#
+# Pair with bin/zig-perf-counters-aggregate.py to compute median/p95/max
+# distributions and chunk-cache hit rate from the resulting log.
+#
+# Usage:
+#   bin/zig-perf-counters-run.sh [INFILE [OUTBASE [N [N_PROCS]]]]
+#
+# Defaults:
+#   INFILE  = /tmp/paired-paper-all-seqs.fa
+#   OUTBASE = /tmp/perf-counters-test
+#   N       = 1000
+#   N_PROCS = 1   (single-proc keeps wall-time numbers clean for cost-claim
+#                 sizing — multi-proc smears the symbol map across child PIDs
+#                 and adds scheduling jitter. For distribution stats only,
+#                 n_procs > 1 is fine.)
+#
+# After the run, the perf log path is:
+#   $OUTBASE/zig-perf.log
+# and the aggregated summary path is:
+#   $OUTBASE/aggregate.txt
+#
+# The script restores the un-instrumented ReleaseFast build at the end so the
+# working tree's binary is back to bit-equality-baseline state.
+
+set -euo pipefail
+
+INFILE="${1:-/tmp/paired-paper-all-seqs.fa}"
+OUTBASE="${2:-/tmp/perf-counters-test}"
+N="${3:-1000}"
+N_PROCS="${4:-1}"
+
+PARTIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ZIG_CORE_DIR="$PARTIS_DIR/packages/zig-core"
+PERF_LOG="$OUTBASE/zig-perf.log"
+AGG_OUT="$OUTBASE/aggregate.txt"
+
+mkdir -p "$OUTBASE"
+rm -f "$PERF_LOG" "$AGG_OUT"
+
+# ── 1. Build with perf counters enabled ─────────────────────────────────────
+echo "==> building partis-zig-core with -Dperf-counters=true"
+(cd "$ZIG_CORE_DIR" && zig build -Doptimize=ReleaseFast -Dperf-counters=true)
+
+# ── 2. Run partition with the perf log set ──────────────────────────────────
+RUN_OUTBASE="$OUTBASE/run-output"
+rm -rf "$RUN_OUTBASE"
+mkdir -p "$RUN_OUTBASE"
+
+echo "==> running partition: N=$N, n_procs=$N_PROCS, infile=$INFILE"
+echo "==> perf log: $PERF_LOG"
+
+# shellcheck disable=SC1091
+source "$PARTIS_DIR/.venv/bin/activate"
+
+PARTIS_ZIG_PERF_LOG="$PERF_LOG" PYTHONHASHSEED=0 python3 "$PARTIS_DIR/bin/partis" \
+    partition --paired-loci \
+    --paired-outdir "$RUN_OUTBASE" \
+    --infname "$INFILE" \
+    --n-max-queries "$N" \
+    --random-seed 1 \
+    --n-procs "$N_PROCS" \
+    --no-time-based-n-proc-reduction \
+    --dont-write-git-info \
+    --zig
+
+# ── 3. Aggregate ────────────────────────────────────────────────────────────
+echo "==> aggregating $PERF_LOG → $AGG_OUT"
+python3 "$PARTIS_DIR/bin/zig-perf-counters-aggregate.py" "$PERF_LOG" | tee "$AGG_OUT"
+
+# ── 4. Restore un-instrumented build ────────────────────────────────────────
+echo "==> restoring un-instrumented partis-zig-core (ReleaseFast, no perf counters)"
+(cd "$ZIG_CORE_DIR" && zig build -Doptimize=ReleaseFast)
+
+echo "==> done. raw log: $PERF_LOG    summary: $AGG_OUT"

--- a/packages/zig-core/build.zig
+++ b/packages/zig-core/build.zig
@@ -1,0 +1,132 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // -Dperf-counters: gate the issue-#366 phase-0 diagnostics counters in
+    // src/ham/perf_counters.zig. When false (default), every counter site
+    // is `if (enabled) { ... }` with `enabled = false`, so the inner-loop
+    // calls compile to nothing and bit-equal output is preserved.
+    const perf_counters = b.option(
+        bool,
+        "perf-counters",
+        "Enable Phase-0 perf counters (issue #366). Default false; counters compile out when off.",
+    ) orelse false;
+    const perf_opts = b.addOptions();
+    perf_opts.addOption(bool, "perf_counters", perf_counters);
+    const build_options_module = perf_opts.createModule();
+
+    // ── partis-zig-core executable: bcrham-compatible CLI ────────────────
+    // `zig build` produces this by default. No external library deps.
+    const exe = b.addExecutable(.{
+        .name = "partis-zig-core",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    exe.root_module.addImport("build_options", build_options_module);
+    // Link libc so release builds can use std.heap.c_allocator (malloc/free),
+    // which avoids GPA's per-allocation tracking overhead.
+    exe.root_module.linkSystemLibrary("c", .{});
+    // Compile glibc_math.c with the system C compiler so that log/exp resolve
+    // to actual glibc (dynamic 'U' symbols) rather than Zig's compiler-rt
+    // (local 't' symbols that may differ from glibc on some CPUs).
+    exe.addCSourceFile(.{ .file = b.path("src/ham/glibc_math.c"), .flags = &.{ "-O2", "-fno-builtin" } });
+    // fast_math.c — fast_softplus LUT (issue #366 item 3.2). Mirrors
+    // packages/ham/src/fast_math.c on the C++ side; both must stay in sync.
+    // -ffp-contract=off keeps the linear-interp arithmetic bit-deterministic
+    // across compilers (cheap insurance for cross-backend bit equality).
+    exe.addCSourceFile(.{ .file = b.path("src/ham/fast_math.c"), .flags = &.{ "-O3", "-ffp-contract=off", "-fno-builtin" } });
+    b.installArtifact(exe);
+
+    // ── compare: equivalence harness binary ──────────────────────────────
+    const compare = b.addExecutable(.{
+        .name = "compare",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/equivalence/compare.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    compare.root_module.addImport("build_options", build_options_module);
+    b.installArtifact(compare);
+
+    // ── lib: C ABI shared library (requires ig-sw sources from partis) ───
+    // Not built by default. Use:
+    //   zig build lib -Digsw-src=<partis>/packages/ig-sw/src/ig_align
+    const igsw_src = b.option([]const u8, "igsw-src",
+        "Path to ig-sw C sources (partis/packages/ig-sw/src/ig_align)") orelse "";
+
+    const cabi_mod = b.createModule(.{
+        .root_source_file = b.path("src/cabi.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    cabi_mod.addImport("build_options", build_options_module);
+    if (igsw_src.len > 0) {
+        cabi_mod.addIncludePath(.{ .cwd_relative = igsw_src });
+    }
+
+    const lib = b.addLibrary(.{
+        .name = "partis-zig-core",
+        .root_module = cabi_mod,
+        .linkage = .dynamic,
+    });
+    if (igsw_src.len > 0) {
+        const flags = &.{ "-std=gnu99", "-O2" };
+        lib.addCSourceFile(.{ .file = .{ .cwd_relative = b.pathJoin(&.{ igsw_src, "ig_align.c" }) }, .flags = flags });
+        lib.addCSourceFile(.{ .file = .{ .cwd_relative = b.pathJoin(&.{ igsw_src, "ksw.c" }) }, .flags = flags });
+        lib.addCSourceFile(.{ .file = .{ .cwd_relative = b.pathJoin(&.{ igsw_src, "kstring.c" }) }, .flags = flags });
+        lib.addIncludePath(.{ .cwd_relative = igsw_src });
+    }
+    lib.linkSystemLibrary("z");
+    lib.linkLibC();
+
+    const lib_step = b.step("lib", "Build C ABI shared library (requires -Digsw-src=...)");
+    lib_step.dependOn(&b.addInstallArtifact(lib, .{}).step);
+
+    // ── partis-zig-igsw executable: ig-sw-compatible CLI (vendored C sources) ─
+    // `zig build` produces this by default alongside partis-zig-core.
+    const igsw_exe_mod = b.createModule(.{
+        .root_source_file = b.path("src/igsw/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    igsw_exe_mod.addIncludePath(b.path("src/igsw/c"));
+    const igsw_exe = b.addExecutable(.{
+        .name = "partis-zig-igsw",
+        .root_module = igsw_exe_mod,
+    });
+    // -fno-sanitize=undefined: ig_align.c has a pre-existing shift-overflow UB
+    // that is harmless in practice but trips Zig's clang UBSan in Debug builds.
+    // ksw.c is NOT listed here — it is replaced by src/igsw/ksw.zig (cross-platform SIMD).
+    const igsw_c_flags = &.{ "-std=gnu99", "-O2", "-fno-sanitize=undefined" };
+    igsw_exe.addCSourceFile(.{ .file = b.path("src/igsw/c/ig_align.c"), .flags = igsw_c_flags });
+    igsw_exe.addCSourceFile(.{ .file = b.path("src/igsw/c/kstring.c"), .flags = igsw_c_flags });
+    igsw_exe.addIncludePath(b.path("src/igsw/c"));
+    igsw_exe.linkSystemLibrary("z");
+    igsw_exe.linkLibC();
+    b.installArtifact(igsw_exe);
+
+    // ── test: unit test runner (ham modules only, no ig-sw needed) ────────
+    const ham_test_mod = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    ham_test_mod.addImport("build_options", build_options_module);
+    // Link libc + glibc_math shim so tests that exercise mathutils.log/exp
+    // resolve `glibc_log` / `glibc_exp`. Without these, unit tests linking
+    // anything that uses the math hot path fail with "undefined symbol:
+    // glibc_log". Symmetric with the `exe` setup above.
+    ham_test_mod.linkSystemLibrary("c", .{});
+    const unit_tests = b.addTest(.{ .root_module = ham_test_mod });
+    unit_tests.addCSourceFile(.{ .file = b.path("src/ham/glibc_math.c"), .flags = &.{ "-O2", "-fno-builtin" } });
+    unit_tests.addCSourceFile(.{ .file = b.path("src/ham/fast_math.c"), .flags = &.{ "-O3", "-ffp-contract=off", "-fno-builtin" } });
+    const run_unit_tests = b.addRunArtifact(unit_tests);
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_unit_tests.step);
+}

--- a/packages/zig-core/src/cabi.zig
+++ b/packages/zig-core/src/cabi.zig
@@ -1,0 +1,103 @@
+/// C ABI surface for partis-zig-core.
+///
+/// This is the ONLY public C-facing interface. All internal Zig modules are
+/// private. Python loads this shared library and calls these functions instead
+/// of spawning a bcrham subprocess.
+///
+/// Stub bodies panic with a clear message until the corresponding component is
+/// ported. The conversion-loop agent fills these in one component at a time.
+///
+/// Function signatures are derived from:
+///   - python/partis.py  (bcrham subprocess invocation arguments)
+///   - ham/src/main.cc   (bcrham entry-point argument parsing)
+///
+/// During first-run bootstrap (T040), the conversion-loop agent reads those
+/// files and populates the full signature list here.
+
+const std = @import("std");
+
+// ─── internal ham modules (imported so their tests run with `zig build test`) ─
+pub const ham_text = @import("ham/text.zig");
+pub const ham_mathutils = @import("ham/mathutils.zig");
+pub const ham_transitions = @import("ham/transitions.zig");
+pub const ham_track = @import("ham/track.zig");
+pub const ham_cluster_path = @import("ham/cluster_path.zig");
+pub const ham_sequences = @import("ham/sequences.zig");
+pub const ham_lexical_table = @import("ham/lexical_table.zig");
+pub const ham_emission = @import("ham/emission.zig");
+pub const ham_state = @import("ham/state.zig");
+pub const ham_hmm_yaml = @import("ham/hmm_yaml.zig");
+pub const ham_model = @import("ham/model.zig");
+pub const ham_traceback_path = @import("ham/traceback_path.zig");
+pub const ham_trellis = @import("ham/trellis.zig");
+pub const ham_args = @import("ham/args.zig");
+pub const ham_bcr_utils = @import("ham/bcr_utils/root.zig");
+pub const ham_dp_handler = @import("ham/dp_handler.zig");
+pub const ham_glomerator = @import("ham/glomerator/root.zig");
+pub const ham_bcrham = @import("ham/bcrham.zig");
+pub const igsw_ig_align = @import("igsw/ig_align.zig");
+
+// ─── bcrham entry points ──────────────────────────────────────────────────────
+
+/// Run the full bcrham pipeline for a set of sequences.
+/// Corresponds to the bcrham subprocess invocation in python/partis.py.
+/// Arguments mirror bcrham's --parameter-dir, --seqs-file, --outfile, etc.
+export fn bcrham_run(
+    parameter_dir: [*:0]const u8,
+    seqs_file: [*:0]const u8,
+    outfile: [*:0]const u8,
+    algorithm: [*:0]const u8,
+    n_max_per_batch: c_int,
+) c_int {
+    _ = parameter_dir;
+    _ = seqs_file;
+    _ = outfile;
+    _ = algorithm;
+    _ = n_max_per_batch;
+    @panic("not yet implemented: bcrham_run");
+}
+
+/// Run the Forward algorithm only and return log-probability.
+export fn bcrham_forward(
+    parameter_dir: [*:0]const u8,
+    seqs_file: [*:0]const u8,
+    outfile: [*:0]const u8,
+) c_int {
+    _ = parameter_dir;
+    _ = seqs_file;
+    _ = outfile;
+    @panic("not yet implemented: bcrham_forward");
+}
+
+/// Run the Viterbi algorithm and return the most probable path annotation.
+export fn bcrham_viterbi(
+    parameter_dir: [*:0]const u8,
+    seqs_file: [*:0]const u8,
+    outfile: [*:0]const u8,
+) c_int {
+    _ = parameter_dir;
+    _ = seqs_file;
+    _ = outfile;
+    @panic("not yet implemented: bcrham_viterbi");
+}
+
+// ─── ig-sw entry points ───────────────────────────────────────────────────────
+
+/// Run Smith-Waterman alignment for V/D/J gene segment matching.
+export fn igsw_align(
+    query_seq: [*:0]const u8,
+    germline_dir: [*:0]const u8,
+    outfile: [*:0]const u8,
+) c_int {
+    _ = query_seq;
+    _ = germline_dir;
+    _ = outfile;
+    @panic("not yet implemented: igsw_align");
+}
+
+// ─── library version / health check ──────────────────────────────────────────
+
+/// Return a null-terminated version string. Safe to call before any porting is done.
+export fn partis_zig_core_version() [*:0]const u8 {
+    return "0.0.1-stub";
+}

--- a/packages/zig-core/src/equivalence/compare.zig
+++ b/packages/zig-core/src/equivalence/compare.zig
@@ -1,0 +1,334 @@
+/// Equivalence harness: diff C++ checkpoint JSON stream vs Zig checkpoint JSON stream.
+///
+/// Usage:
+///   compare <component-id> <cpp-stream-file> <zig-stream-file> [work-queue-json]
+///
+/// Each stream file contains newline-delimited JSON objects, one per checkpoint.
+/// Each object has at minimum: {"checkpoint": "<name>", ...numeric fields...}
+///
+/// Exit codes:
+///   0  all checkpoints within tolerance
+///   1  one or more checkpoints failed
+///   2  harness error (file not found, parse error, etc.)
+
+const std = @import("std");
+const mem = std.mem;
+const json = std.json;
+const fs = std.fs;
+
+/// Per-component tolerance configuration loaded from work-queue.json.
+const Tolerance = struct {
+    float_ulp: u32 = 4,
+    log_prob_absolute: f64 = 1e-6,
+    integer_exact: bool = true,
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    var stdout_buf: [65536]u8 = undefined;
+    var stdout_file_writer = fs.File.stdout().writer(&stdout_buf);
+    const stdout = &stdout_file_writer.interface;
+
+    if (args.len < 4) {
+        std.debug.print(
+            "usage: compare <component-id> <cpp-stream-file> <zig-stream-file> [work-queue-json]\n",
+            .{},
+        );
+        std.process.exit(2);
+    }
+
+    const component_id = args[1];
+    const cpp_path = args[2];
+    const zig_path = args[3];
+    const work_queue_path: ?[]const u8 = if (args.len >= 5) args[4] else null;
+
+    const tolerance = try loadTolerance(allocator, work_queue_path, component_id);
+
+    try stdout.print("equivalence-check: {s}\n", .{component_id});
+
+    // Read both streams.
+    const cpp_data = fs.cwd().readFileAlloc(allocator, cpp_path, 64 * 1024 * 1024) catch |err| {
+        std.debug.print("ERROR: cannot read cpp stream '{s}': {}\n", .{ cpp_path, err });
+        std.process.exit(2);
+    };
+    defer allocator.free(cpp_data);
+
+    const zig_data = fs.cwd().readFileAlloc(allocator, zig_path, 64 * 1024 * 1024) catch |err| {
+        std.debug.print("ERROR: cannot read zig stream '{s}': {}\n", .{ zig_path, err });
+        std.process.exit(2);
+    };
+    defer allocator.free(zig_data);
+
+    const cpp_lines = try splitLines(allocator, cpp_data);
+    defer allocator.free(cpp_lines);
+    const zig_lines = try splitLines(allocator, zig_data);
+    defer allocator.free(zig_lines);
+
+    if (cpp_lines.len != zig_lines.len) {
+        try stdout.print(
+            "  MISMATCH: cpp has {d} checkpoints, zig has {d} checkpoints\n",
+            .{ cpp_lines.len, zig_lines.len },
+        );
+        try stdout.print("RESULT: FAIL (checkpoint count mismatch)\n", .{});
+        try stdout_file_writer.interface.flush();
+        std.process.exit(1);
+    }
+
+    var pass_count: usize = 0;
+    var fail_count: usize = 0;
+
+    for (cpp_lines, zig_lines, 0..) |cpp_line, zig_line, i| {
+        if (cpp_line.len == 0 and zig_line.len == 0) continue;
+
+        const result = compareCheckpoint(allocator, cpp_line, zig_line, tolerance, i) catch |err| {
+            try stdout.print("  checkpoint[{d}]  HARNESS_ERROR: {}\n", .{ i, err });
+            fail_count += 1;
+            continue;
+        };
+
+        if (result.passed) {
+            if (result.delta_info) |info| {
+                try stdout.print("  checkpoint {s:<40}  PASS (delta: {s})\n", .{ result.name, info });
+            } else {
+                try stdout.print("  checkpoint {s:<40}  PASS (exact)\n", .{result.name});
+            }
+            pass_count += 1;
+        } else {
+            try stdout.print(
+                "  checkpoint {s:<40}  FAIL  cpp={s}  zig={s}  delta={s}  threshold={s}\n",
+                .{
+                    result.name,
+                    result.cpp_val,
+                    result.zig_val,
+                    result.delta_info orelse "?",
+                    result.threshold_info orelse "?",
+                },
+            );
+            fail_count += 1;
+        }
+    }
+
+    const total = pass_count + fail_count;
+    if (fail_count == 0) {
+        try stdout.print("\nRESULT: PASS ({d}/{d} checkpoints)\n", .{ pass_count, total });
+        try stdout_file_writer.interface.flush();
+        std.process.exit(0);
+    } else {
+        try stdout.print("\nRESULT: FAIL ({d}/{d} checkpoints passed)\n", .{ pass_count, total });
+        try stdout_file_writer.interface.flush();
+        std.process.exit(1);
+    }
+}
+
+const CheckpointResult = struct {
+    name: []const u8,
+    passed: bool,
+    cpp_val: []const u8 = "",
+    zig_val: []const u8 = "",
+    delta_info: ?[]const u8 = null,
+    threshold_info: ?[]const u8 = null,
+};
+
+fn compareCheckpoint(
+    allocator: mem.Allocator,
+    cpp_line: []const u8,
+    zig_line: []const u8,
+    tolerance: Tolerance,
+    idx: usize,
+) !CheckpointResult {
+    const cpp_parsed = json.parseFromSlice(json.Value, allocator, cpp_line, .{}) catch {
+        return CheckpointResult{
+            .name = try std.fmt.allocPrint(allocator, "[{d}]", .{idx}),
+            .passed = false,
+            .cpp_val = "(parse error)",
+            .zig_val = zig_line,
+        };
+    };
+    defer cpp_parsed.deinit();
+
+    const zig_parsed = json.parseFromSlice(json.Value, allocator, zig_line, .{}) catch {
+        return CheckpointResult{
+            .name = try std.fmt.allocPrint(allocator, "[{d}]", .{idx}),
+            .passed = false,
+            .cpp_val = cpp_line,
+            .zig_val = "(parse error)",
+        };
+    };
+    defer zig_parsed.deinit();
+
+    const cpp_obj = switch (cpp_parsed.value) {
+        .object => |o| o,
+        else => return error.NotAnObject,
+    };
+    const zig_obj = switch (zig_parsed.value) {
+        .object => |o| o,
+        else => return error.NotAnObject,
+    };
+
+    // Allocate an owned copy of the checkpoint name so it survives after
+    // cpp_parsed.deinit() runs at end of this function.
+    const name_raw = if (cpp_obj.get("checkpoint")) |v|
+        switch (v) {
+            .string => |s| s,
+            else => "(unnamed)",
+        }
+    else
+        "(unnamed)";
+    const name = try allocator.dupe(u8, name_raw);
+
+    // Exact match fast path.
+    if (mem.eql(u8, cpp_line, zig_line)) {
+        return CheckpointResult{ .name = name, .passed = true };
+    }
+
+    // Field-by-field comparison with tolerance.
+    var all_pass = true;
+    var first_fail_cpp: []const u8 = "";
+    var first_fail_zig: []const u8 = "";
+    var first_fail_delta: ?[]const u8 = null;
+    var first_fail_threshold: ?[]const u8 = null;
+
+    var it = cpp_obj.iterator();
+    while (it.next()) |entry| {
+        const key = entry.key_ptr.*;
+        if (mem.eql(u8, key, "checkpoint")) continue;
+
+        const cpp_val = entry.value_ptr.*;
+        const zig_val = zig_obj.get(key) orelse continue;
+
+        const field_pass = valuesWithinTolerance(cpp_val, zig_val, tolerance) catch false;
+        if (!field_pass) {
+            all_pass = false;
+            first_fail_cpp = try std.fmt.allocPrint(allocator, "{}", .{cpp_val});
+            first_fail_zig = try std.fmt.allocPrint(allocator, "{}", .{zig_val});
+            first_fail_delta = try std.fmt.allocPrint(allocator, "field={s}", .{key});
+            first_fail_threshold = try std.fmt.allocPrint(
+                allocator,
+                "log_prob_abs={e:.1}",
+                .{tolerance.log_prob_absolute},
+            );
+        }
+    }
+
+    return CheckpointResult{
+        .name = name,
+        .passed = all_pass,
+        .cpp_val = first_fail_cpp,
+        .zig_val = first_fail_zig,
+        .delta_info = first_fail_delta,
+        .threshold_info = first_fail_threshold,
+    };
+}
+
+fn valuesWithinTolerance(cpp: json.Value, zig_val: json.Value, tol: Tolerance) !bool {
+    switch (cpp) {
+        .float => |cf| {
+            const zf = switch (zig_val) {
+                .float => |f| f,
+                .integer => |i| @as(f64, @floatFromInt(i)),
+                else => return false,
+            };
+            const delta = @abs(cf - zf);
+            return delta <= tol.log_prob_absolute;
+        },
+        .integer => |ci| {
+            const zi = switch (zig_val) {
+                .integer => |i| i,
+                else => return false,
+            };
+            return if (tol.integer_exact) ci == zi else true;
+        },
+        .bool => |cb| {
+            const zb = switch (zig_val) {
+                .bool => |b| b,
+                else => return false,
+            };
+            return cb == zb;
+        },
+        .string => |cs| {
+            const zs = switch (zig_val) {
+                .string => |s| s,
+                else => return false,
+            };
+            return mem.eql(u8, cs, zs);
+        },
+        else => return true, // null == null, arrays compared later if needed
+    }
+}
+
+fn loadTolerance(allocator: mem.Allocator, work_queue_path: ?[]const u8, component_id: []const u8) !Tolerance {
+    const default = Tolerance{};
+    const path = work_queue_path orelse return default;
+
+    const data = fs.cwd().readFileAlloc(allocator, path, 4 * 1024 * 1024) catch return default;
+    defer allocator.free(data);
+
+    const parsed = json.parseFromSlice(json.Value, allocator, data, .{}) catch return default;
+    defer parsed.deinit();
+
+    const obj = switch (parsed.value) {
+        .object => |o| o,
+        else => return default,
+    };
+    const components = switch (obj.get("components") orelse return default) {
+        .array => |a| a,
+        else => return default,
+    };
+
+    for (components.items) |item| {
+        const comp = switch (item) {
+            .object => |o| o,
+            else => continue,
+        };
+        const id = switch (comp.get("id") orelse continue) {
+            .string => |s| s,
+            else => continue,
+        };
+        if (!mem.eql(u8, id, component_id)) continue;
+
+        const tol_val = comp.get("tolerance") orelse return default;
+        const tol_obj = switch (tol_val) {
+            .object => |o| o,
+            else => return default,
+        };
+
+        var tol = default;
+        if (tol_obj.get("float_ulp")) |v| {
+            tol.float_ulp = @intCast(switch (v) {
+                .integer => |i| i,
+                else => @as(i64, default.float_ulp),
+            });
+        }
+        if (tol_obj.get("log_prob_absolute")) |v| {
+            tol.log_prob_absolute = switch (v) {
+                .float => |f| f,
+                .integer => |i| @as(f64, @floatFromInt(i)),
+                else => default.log_prob_absolute,
+            };
+        }
+        if (tol_obj.get("integer_exact")) |v| {
+            tol.integer_exact = switch (v) {
+                .bool => |b| b,
+                else => default.integer_exact,
+            };
+        }
+        return tol;
+    }
+    return default;
+}
+
+fn splitLines(allocator: mem.Allocator, data: []const u8) ![][]const u8 {
+    var lines: std.ArrayListUnmanaged([]const u8) = .empty;
+    var iter = mem.splitScalar(u8, data, '\n');
+    while (iter.next()) |line| {
+        const trimmed = mem.trim(u8, line, " \r\t");
+        if (trimmed.len > 0) try lines.append(allocator, trimmed);
+    }
+    return lines.toOwnedSlice(allocator);
+}

--- a/packages/zig-core/src/ham/args.zig
+++ b/packages/zig-core/src/ham/args.zig
@@ -1,0 +1,290 @@
+/// ham/args.zig — Zig port of ham/src/args.cc + ham/include/args.h
+///
+/// Command-line argument holder and CSV input file reader for bcrham.
+/// In the C++ code this uses tclap for argument parsing; in Zig we use
+/// std.process.args directly (matching the existing main.zig pattern).
+///
+/// C++ source: packages/ham/src/args.cc, packages/ham/include/args.h
+/// C++ author: psathyrella/ham
+
+const std = @import("std");
+const ham_text = @import("text.zig");
+
+/// Valid algorithm values (matches C++ `algo_vals_`).
+pub const Algorithm = enum { viterbi, forward };
+
+/// Valid loci (matches C++ loci vector).
+const valid_loci = [_][]const u8{ "igh", "igk", "igl", "tra", "trb", "trg", "trd" };
+
+/// Column headers from the input CSV file (matches C++ *_headers_ sets).
+pub const str_list_headers = [_][]const u8{ "names", "seqs", "only_genes" };
+pub const int_headers = [_][]const u8{ "k_v_min", "k_v_max", "k_d_min", "k_d_max", "cdr3_length" };
+pub const float_headers = [_][]const u8{"mut_freq"};
+
+/// One row of per-sequence query data (derived from one row of the input CSV).
+pub const QueryRow = struct {
+    /// Sequence names (one per sequence in this query).
+    names: std.ArrayListUnmanaged([]u8),
+    /// Sequences (one per sequence in this query).
+    seqs: std.ArrayListUnmanaged([]u8),
+    /// Gene names to restrict search to (may be empty = no restriction).
+    only_genes: std.ArrayListUnmanaged([]u8),
+    /// VDJ k-boundaries.
+    k_v_min: i32,
+    k_v_max: i32,
+    k_d_min: i32,
+    k_d_max: i32,
+    cdr3_length: i32,
+    /// Mutation frequency.
+    mut_freq: f64,
+
+    pub fn deinit(self: *QueryRow, allocator: std.mem.Allocator) void {
+        for (self.names.items) |s| allocator.free(s);
+        self.names.deinit(allocator);
+        for (self.seqs.items) |s| allocator.free(s);
+        self.seqs.deinit(allocator);
+        for (self.only_genes.items) |s| allocator.free(s);
+        self.only_genes.deinit(allocator);
+    }
+};
+
+/// Parsed bcrham arguments and CSV data.
+/// Corresponds to C++ `ham::Args`.
+pub const Args = struct {
+    // ── CLI args ──────────────────────────────────────────────────────────────
+    hmmdir: []u8,
+    datadir: []u8,
+    infile: []u8,
+    outfile: []u8,
+    annotationfile: []u8,
+    input_cachefname: []u8,
+    output_cachefname: []u8,
+    locus: []u8,
+    algorithm: []u8,
+    ambig_base: []u8,
+    seed_unique_id: []u8,
+
+    hamming_fraction_bound_lo: f64,
+    hamming_fraction_bound_hi: f64,
+    logprob_ratio_threshold: f64,
+    max_logprob_drop: f64,
+
+    debug: i32,
+    naive_hamming_cluster: i32,
+    biggest_naive_seq_cluster_to_calculate: i32,
+    biggest_logprob_cluster_to_calculate: i32,
+    n_partitions_to_write: i32,
+
+    n_final_clusters: u32,
+    min_largest_cluster_size: u32,
+    max_cluster_size: u32,
+    random_seed: u32,
+
+    no_chunk_cache: bool,
+    partition: bool,
+    dont_rescale_emissions: bool,
+    cache_naive_seqs: bool,
+    cache_naive_hfracs: bool,
+    only_cache_new_vals: bool,
+    write_logprob_for_each_partition: bool,
+
+    // ── CSV data ──────────────────────────────────────────────────────────────
+    /// One entry per query row in the input CSV.
+    queries: std.ArrayListUnmanaged(QueryRow),
+
+    /// Create an empty Args with default values.
+    pub fn initDefaults(allocator: std.mem.Allocator) !Args {
+        return Args{
+            .hmmdir = try allocator.dupe(u8, ""),
+            .datadir = try allocator.dupe(u8, ""),
+            .infile = try allocator.dupe(u8, ""),
+            .outfile = try allocator.dupe(u8, ""),
+            .annotationfile = try allocator.dupe(u8, ""),
+            .input_cachefname = try allocator.dupe(u8, ""),
+            .output_cachefname = try allocator.dupe(u8, ""),
+            .locus = try allocator.dupe(u8, ""),
+            .algorithm = try allocator.dupe(u8, ""),
+            .ambig_base = try allocator.dupe(u8, ""),
+            .seed_unique_id = try allocator.dupe(u8, ""),
+            .hamming_fraction_bound_lo = 0.0,
+            .hamming_fraction_bound_hi = 1.0,
+            .logprob_ratio_threshold = -std.math.inf(f64),
+            .max_logprob_drop = -1.0,
+            .debug = 0,
+            .naive_hamming_cluster = 0,
+            .biggest_naive_seq_cluster_to_calculate = 99999,
+            .biggest_logprob_cluster_to_calculate = 99999,
+            .n_partitions_to_write = 99999,
+            .n_final_clusters = 0,
+            .min_largest_cluster_size = 0,
+            .max_cluster_size = 0,
+            .random_seed = @intCast(std.time.timestamp() & 0xFFFFFFFF),
+            .no_chunk_cache = false,
+            .partition = false,
+            .dont_rescale_emissions = false,
+            .cache_naive_seqs = false,
+            .cache_naive_hfracs = false,
+            .only_cache_new_vals = false,
+            .write_logprob_for_each_partition = false,
+            .queries = .{},
+        };
+    }
+
+    pub fn deinit(self: *Args, allocator: std.mem.Allocator) void {
+        allocator.free(self.hmmdir);
+        allocator.free(self.datadir);
+        allocator.free(self.infile);
+        allocator.free(self.outfile);
+        allocator.free(self.annotationfile);
+        allocator.free(self.input_cachefname);
+        allocator.free(self.output_cachefname);
+        allocator.free(self.locus);
+        allocator.free(self.algorithm);
+        allocator.free(self.ambig_base);
+        allocator.free(self.seed_unique_id);
+        for (self.queries.items) |*q| q.deinit(allocator);
+        self.queries.deinit(allocator);
+    }
+
+    /// Parse the CSV input file (infile must already be set).
+    /// Corresponds to the file-reading portion of C++ `Args::Args(argc, argv)`.
+    pub fn readInfile(self: *Args, allocator: std.mem.Allocator) !void {
+        const content = try std.fs.cwd().readFileAlloc(allocator, self.infile, 64 * 1024 * 1024);
+        defer allocator.free(content);
+
+        var line_iter = std.mem.splitScalar(u8, content, '\n');
+
+        // Parse header line
+        const header_line = line_iter.next() orelse return error.EmptyInputFile;
+        var headers: std.ArrayListUnmanaged([]const u8) = .{};
+        defer headers.deinit(allocator);
+        {
+            var tok = std.mem.splitScalar(u8, std.mem.trim(u8, header_line, " \t\r"), ' ');
+            while (tok.next()) |h| {
+                if (h.len > 0) try headers.append(allocator, h);
+            }
+        }
+
+        // Parse data rows
+        while (line_iter.next()) |raw_line| {
+            const line = std.mem.trim(u8, raw_line, " \t\r");
+            if (line.len < 10) continue; // skip blank/short lines
+
+            var q = QueryRow{
+                .names = .{},
+                .seqs = .{},
+                .only_genes = .{},
+                .k_v_min = 0,
+                .k_v_max = 0,
+                .k_d_min = 0,
+                .k_d_max = 0,
+                .cdr3_length = 0,
+                .mut_freq = 0.0,
+            };
+            errdefer q.deinit(allocator);
+
+            var tok = std.mem.splitScalar(u8, line, ' ');
+            for (headers.items) |head| {
+                const field = tok.next() orelse break;
+                if (isStrListHeader(head)) {
+                    // Split on ':' — matches C++ SplitString(tmpstr, ":")
+                    var parts = try ham_text.splitString(allocator, field, ":");
+                    defer {
+                        for (parts.items) |p| allocator.free(p);
+                        parts.deinit(allocator);
+                    }
+                    if (std.mem.eql(u8, head, "names")) {
+                        for (parts.items) |p| try q.names.append(allocator, try allocator.dupe(u8, p));
+                    } else if (std.mem.eql(u8, head, "seqs")) {
+                        for (parts.items) |p| {
+                            // Strip newlines from each sequence
+                            const owned = try allocator.dupe(u8, p);
+                            try q.seqs.append(allocator, owned);
+                        }
+                    } else if (std.mem.eql(u8, head, "only_genes")) {
+                        for (parts.items) |p| try q.only_genes.append(allocator, try allocator.dupe(u8, p));
+                    }
+                } else if (isIntHeader(head)) {
+                    const val = try std.fmt.parseInt(i32, field, 10);
+                    if (std.mem.eql(u8, head, "k_v_min")) q.k_v_min = val
+                    else if (std.mem.eql(u8, head, "k_v_max")) q.k_v_max = val
+                    else if (std.mem.eql(u8, head, "k_d_min")) q.k_d_min = val
+                    else if (std.mem.eql(u8, head, "k_d_max")) q.k_d_max = val
+                    else if (std.mem.eql(u8, head, "cdr3_length")) q.cdr3_length = val;
+                } else if (isFloatHeader(head)) {
+                    const val = try std.fmt.parseFloat(f64, field);
+                    if (std.mem.eql(u8, head, "mut_freq")) q.mut_freq = val;
+                } else {
+                    return error.UnexpectedHeader;
+                }
+            }
+            try self.queries.append(allocator, q);
+        }
+    }
+
+    fn isStrListHeader(head: []const u8) bool {
+        for (str_list_headers) |h| if (std.mem.eql(u8, h, head)) return true;
+        return false;
+    }
+
+    fn isIntHeader(head: []const u8) bool {
+        for (int_headers) |h| if (std.mem.eql(u8, h, head)) return true;
+        return false;
+    }
+
+    fn isFloatHeader(head: []const u8) bool {
+        for (float_headers) |h| if (std.mem.eql(u8, h, head)) return true;
+        return false;
+    }
+
+    /// Validate that locus is one of the known valid values.
+    pub fn validateLocus(self: *const Args) !void {
+        for (valid_loci) |l| if (std.mem.eql(u8, l, self.locus)) return;
+        return error.InvalidLocus;
+    }
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "Args: initDefaults" {
+    const allocator = std.testing.allocator;
+    var args = try Args.initDefaults(allocator);
+    defer args.deinit(allocator);
+
+    try std.testing.expectEqualStrings("", args.hmmdir);
+    try std.testing.expectEqual(@as(i32, 0), args.debug);
+    try std.testing.expectEqual(@as(i32, 99999), args.biggest_naive_seq_cluster_to_calculate);
+    try std.testing.expect(!args.partition);
+}
+
+test "Args: readInfile with minimal CSV" {
+    const allocator = std.testing.allocator;
+
+    // Write a minimal input CSV to a temp file
+    const csv = "names seqs only_genes k_v_min k_v_max k_d_min k_d_max cdr3_length mut_freq\n" ++
+        "seq1 ACGT gene1:gene2 1 10 1 5 30 0.05\n";
+
+    const tmp = "/tmp/test_args_input.csv";
+    {
+        const f = try std.fs.createFileAbsolute(tmp, .{});
+        defer f.close();
+        try f.writeAll(csv);
+    }
+    defer std.fs.deleteFileAbsolute(tmp) catch {};
+
+    var args = try Args.initDefaults(allocator);
+    defer args.deinit(allocator);
+    allocator.free(args.infile);
+    args.infile = try allocator.dupe(u8, tmp);
+
+    try args.readInfile(allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), args.queries.items.len);
+    const q = &args.queries.items[0];
+    try std.testing.expectEqual(@as(usize, 1), q.names.items.len);
+    try std.testing.expectEqualStrings("seq1", q.names.items[0]);
+    try std.testing.expectEqualStrings("ACGT", q.seqs.items[0]);
+    try std.testing.expectEqual(@as(usize, 2), q.only_genes.items.len);
+    try std.testing.expectEqual(@as(i32, 1), q.k_v_min);
+    try std.testing.expectApproxEqAbs(0.05, q.mut_freq, 1e-9);
+}

--- a/packages/zig-core/src/ham/bcr_utils/germ_lines.zig
+++ b/packages/zig-core/src/ham/bcr_utils/germ_lines.zig
@@ -1,0 +1,262 @@
+/// ham/bcr_utils/germ_lines.zig — Zig port of ham::GermLines
+///
+/// Loads germline FASTA sequences + cyst/tryp positions for a locus.
+/// C++ source: packages/ham/src/bcrutils.cc
+
+const std = @import("std");
+const ham_text = @import("../text.zig");
+
+pub const Region = enum { v, d, j };
+
+pub const regions = [_]Region{ .v, .d, .j };
+
+pub fn regionStr(r: Region) []const u8 {
+    return switch (r) {
+        .v => "v",
+        .d => "d",
+        .j => "j",
+    };
+}
+
+/// Corresponds to C++ `ham::GermLines`.
+pub const GermLines = struct {
+    locus: []u8,
+    /// Region gene name lists (v/d/j keys).
+    names: std.StringHashMapUnmanaged(std.ArrayListUnmanaged([]u8)),
+    /// Gene-name → sequence mapping.
+    seqs: std.StringHashMapUnmanaged([]u8),
+    /// Gene-name → cyst position.
+    cyst_positions: std.StringHashMapUnmanaged(i32),
+    /// Gene-name → tryp position.
+    tryp_positions: std.StringHashMapUnmanaged(i32),
+    /// For loci without D genes, the synthetic dummy D gene name.
+    dummy_d_gene: ?[]u8,
+
+    allocator: std.mem.Allocator,
+
+    /// Load germline data from `gldir` for `locus`.
+    /// Corresponds to C++ `GermLines::GermLines(gldir, locus)`.
+    pub fn init(allocator: std.mem.Allocator, gldir: []const u8, locus: []const u8) !GermLines {
+        var self = GermLines{
+            .locus = try allocator.dupe(u8, locus),
+            .names = .{},
+            .seqs = .{},
+            .cyst_positions = .{},
+            .tryp_positions = .{},
+            .dummy_d_gene = null,
+            .allocator = allocator,
+        };
+        errdefer self.deinit();
+
+        // Initialise empty name lists for each region
+        for (regions) |r| {
+            try self.names.put(allocator, try allocator.dupe(u8, regionStr(r)), .{});
+        }
+
+        const has_d = hasDGene(locus);
+
+        if (!has_d) {
+            // Build dummy D gene name e.g. "IGKDx-x*x"
+            const upper = try allocator.dupe(u8, locus);
+            defer allocator.free(upper);
+            for (upper) |*c| c.* = std.ascii.toUpper(c.*);
+            const dummy = try std.fmt.allocPrint(allocator, "{s}Dx-x*x", .{upper});
+            self.dummy_d_gene = dummy;
+
+            if (self.names.getPtr("d")) |d_list| {
+                try d_list.append(allocator, try allocator.dupe(u8, dummy));
+            }
+            try self.seqs.put(allocator, try allocator.dupe(u8, dummy), try allocator.dupe(u8, "A"));
+        }
+
+        // Read FASTA files for each region
+        for (regions) |r| {
+            const rs = regionStr(r);
+            if (!has_d and r == .d) continue;
+
+            const infname = try std.fmt.allocPrint(allocator, "{s}/{s}/{s}{s}.fasta", .{ gldir, locus, locus, rs });
+            defer allocator.free(infname);
+
+            const content = std.fs.cwd().readFileAlloc(allocator, infname, 64 * 1024 * 1024) catch |err| {
+                return err; // file must exist
+            };
+            defer allocator.free(content);
+
+            var name_buf: ?[]u8 = null;
+            var seq_buf: std.ArrayListUnmanaged(u8) = .{};
+            defer seq_buf.deinit(allocator);
+
+            var line_iter = std.mem.splitScalar(u8, content, '\n');
+            while (line_iter.next()) |raw| {
+                const line = std.mem.trimRight(u8, raw, "\r");
+                if (line.len == 0) continue;
+
+                if (line[0] == '>') {
+                    // flush previous sequence
+                    if (name_buf) |nm| {
+                        const seq_owned = try allocator.dupe(u8, seq_buf.items);
+                        try self.seqs.put(allocator, nm, seq_owned);
+                        seq_buf.clearRetainingCapacity();
+                        name_buf = null;
+                    }
+                    // parse new header: take up to first space after '>'
+                    const rest = line[1..];
+                    const sp = std.mem.indexOfScalar(u8, rest, ' ') orelse rest.len;
+                    const gene_name = try allocator.dupe(u8, rest[0..sp]);
+                    name_buf = gene_name;
+                    if (self.names.getPtr(rs)) |lst| {
+                        try lst.append(allocator, try allocator.dupe(u8, gene_name));
+                    }
+                } else {
+                    try seq_buf.appendSlice(allocator, line);
+                }
+            }
+            // flush last sequence
+            if (name_buf) |nm| {
+                const seq_owned = try allocator.dupe(u8, seq_buf.items);
+                try self.seqs.put(allocator, nm, seq_owned);
+            }
+        }
+
+        // Read extras.csv for cyst/tryp positions
+        const extras_fname = try std.fmt.allocPrint(allocator, "{s}/{s}/extras.csv", .{ gldir, locus });
+        defer allocator.free(extras_fname);
+
+        const extras = std.fs.cwd().readFileAlloc(allocator, extras_fname, 4 * 1024 * 1024) catch null;
+        if (extras) |content| {
+            defer allocator.free(content);
+            var line_iter = std.mem.splitScalar(u8, content, '\n');
+
+            // Read and checkpoint the header line (matches C++ SplitString call).
+            if (line_iter.next()) |header_raw| {
+                const header_line = std.mem.trim(u8, header_raw, " \t\r");
+                if (header_line.len > 0) {
+                    var header_parts = try ham_text.splitString(allocator, header_line, ",");
+                    defer {
+                        for (header_parts.items) |s| allocator.free(s);
+                        header_parts.deinit(allocator);
+                    }
+                }
+            }
+
+            while (line_iter.next()) |raw| {
+                const line = std.mem.trim(u8, raw, " \t\r");
+                if (line.len == 0) continue;
+
+                // Use splitString to emit checkpoint (matches C++ instrumentation).
+                var parts = try ham_text.splitString(allocator, line, ",");
+                defer {
+                    for (parts.items) |s| allocator.free(s);
+                    parts.deinit(allocator);
+                }
+
+                if (parts.items.len < 2) continue;
+                const gene_name = parts.items[0];
+                const cyst_str = parts.items[1];
+                const tryp_str = if (parts.items.len > 2) parts.items[2] else "";
+                const phen_str = if (parts.items.len > 3) parts.items[3] else "";
+
+                if (cyst_str.len > 0) {
+                    const val = std.fmt.parseInt(i32, cyst_str, 10) catch continue;
+                    try self.cyst_positions.put(allocator, try allocator.dupe(u8, gene_name), val);
+                } else if (tryp_str.len > 0) {
+                    const val = std.fmt.parseInt(i32, tryp_str, 10) catch continue;
+                    try self.tryp_positions.put(allocator, try allocator.dupe(u8, gene_name), val);
+                } else if (phen_str.len > 0) {
+                    const val = std.fmt.parseInt(i32, phen_str, 10) catch continue;
+                    try self.tryp_positions.put(allocator, try allocator.dupe(u8, gene_name), val);
+                }
+            }
+        }
+
+        return self;
+    }
+
+    pub fn deinit(self: *GermLines) void {
+        const allocator = self.allocator;
+
+        allocator.free(self.locus);
+        if (self.dummy_d_gene) |d| allocator.free(d);
+
+        // free names map
+        var names_it = self.names.iterator();
+        while (names_it.next()) |entry| {
+            for (entry.value_ptr.items) |s| allocator.free(s);
+            entry.value_ptr.deinit(allocator);
+            allocator.free(entry.key_ptr.*);
+        }
+        self.names.deinit(allocator);
+
+        // free seqs map
+        var seqs_it = self.seqs.iterator();
+        while (seqs_it.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+            allocator.free(entry.value_ptr.*);
+        }
+        self.seqs.deinit(allocator);
+
+        // free cyst positions
+        var cyst_it = self.cyst_positions.iterator();
+        while (cyst_it.next()) |entry| allocator.free(entry.key_ptr.*);
+        self.cyst_positions.deinit(allocator);
+
+        // free tryp positions
+        var tryp_it = self.tryp_positions.iterator();
+        while (tryp_it.next()) |entry| allocator.free(entry.key_ptr.*);
+        self.tryp_positions.deinit(allocator);
+    }
+
+    /// Sanitize gene name: replace '*' with '_star_' and '/' with '_slash_'.
+    /// Corresponds to C++ `GermLines::SanitizeName`.
+    pub fn sanitizeName(allocator: std.mem.Allocator, gene_name: []const u8) ![]u8 {
+        // Replace * with _star_, then / with _slash_ (chaining ownership)
+        const step1 = try std.mem.replaceOwned(u8, allocator, gene_name, "*", "_star_");
+        errdefer allocator.free(step1);
+        const step2 = try std.mem.replaceOwned(u8, allocator, step1, "/", "_slash_");
+        allocator.free(step1);
+        return step2;
+    }
+
+    /// Get region from gene name.
+    /// Corresponds to C++ `GermLines::GetRegion`.
+    pub fn getRegion(gene: []const u8) !Region {
+        if (!std.mem.startsWith(u8, gene, "IG") and !std.mem.startsWith(u8, gene, "TR"))
+            return error.BadGeneName;
+        if (gene.len < 4) return error.BadGeneName;
+        const ch = std.ascii.toLower(gene[3]);
+        return switch (ch) {
+            'v' => .v,
+            'd' => .d,
+            'j' => .j,
+            else => error.BadRegion,
+        };
+    }
+};
+
+/// Whether the locus has a D gene segment.
+/// Corresponds to C++ `ham::HasDGene`.
+pub fn hasDGene(locus: []const u8) bool {
+    return std.mem.eql(u8, locus, "igh") or
+        std.mem.eql(u8, locus, "trb") or
+        std.mem.eql(u8, locus, "trd");
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "hasDGene" {
+    try std.testing.expect(hasDGene("igh"));
+    try std.testing.expect(hasDGene("trb"));
+    try std.testing.expect(!hasDGene("igk"));
+    try std.testing.expect(!hasDGene("igl"));
+}
+
+test "GermLines.sanitizeName" {
+    const allocator = std.testing.allocator;
+    const s = try GermLines.sanitizeName(allocator, "IGHV3-15*01");
+    defer allocator.free(s);
+    try std.testing.expectEqualStrings("IGHV3-15_star_01", s);
+
+    const s2 = try GermLines.sanitizeName(allocator, "IGHV3-15*01/OR1");
+    defer allocator.free(s2);
+    try std.testing.expect(std.mem.indexOf(u8, s2, "_slash_") != null);
+}

--- a/packages/zig-core/src/ham/bcr_utils/hmm_holder.zig
+++ b/packages/zig-core/src/ham/bcr_utils/hmm_holder.zig
@@ -1,0 +1,113 @@
+/// ham/bcr_utils/hmm_holder.zig — Zig port of ham::HMMHolder
+///
+/// Lazy-loading cache of Model objects keyed by gene name.
+/// C++ source: packages/ham/src/bcrutils.cc
+
+const std = @import("std");
+const Model = @import("../model.zig").Model;
+const germ_lines_mod = @import("germ_lines.zig");
+const GermLines = germ_lines_mod.GermLines;
+const Region = germ_lines_mod.Region;
+const regions = germ_lines_mod.regions;
+const regionStr = germ_lines_mod.regionStr;
+
+/// Corresponds to C++ `ham::HMMHolder`.
+pub const HMMHolder = struct {
+    hmm_dir: []u8,
+    gl: *GermLines,
+    /// gene name → owned Model pointer
+    hmms: std.StringHashMapUnmanaged(*Model),
+    allocator: std.mem.Allocator,
+
+    pub fn init(allocator: std.mem.Allocator, hmm_dir: []const u8, gl: *GermLines) !HMMHolder {
+        return HMMHolder{
+            .hmm_dir = try allocator.dupe(u8, hmm_dir),
+            .gl = gl,
+            .hmms = .{},
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *HMMHolder) void {
+        const allocator = self.allocator;
+        allocator.free(self.hmm_dir);
+        var it = self.hmms.iterator();
+        while (it.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+            entry.value_ptr.*.deinit(allocator);
+            allocator.destroy(entry.value_ptr.*);
+        }
+        self.hmms.deinit(allocator);
+    }
+
+    /// Get (or lazy-load) a Model for `gene`.
+    /// Corresponds to C++ `HMMHolder::Get`.
+    pub fn get(self: *HMMHolder, gene: []const u8) !*Model {
+        if (self.hmms.get(gene)) |m| return m;
+
+        // Not yet cached — load from disk
+        const sanitized = try GermLines.sanitizeName(self.allocator, gene);
+        defer self.allocator.free(sanitized);
+        const infname = try std.fmt.allocPrint(self.allocator, "{s}/{s}.yaml", .{ self.hmm_dir, sanitized });
+        defer self.allocator.free(infname);
+
+        const m = try self.allocator.create(Model);
+        errdefer self.allocator.destroy(m);
+        m.* = try Model.init(self.allocator);
+        errdefer m.deinit(self.allocator);
+        try m.parse(self.allocator, infname);
+
+        const key = try self.allocator.dupe(u8, gene);
+        errdefer self.allocator.free(key);
+        try self.hmms.put(self.allocator, key, m);
+        return m;
+    }
+
+    /// Read all available HMMs into memory.
+    /// Corresponds to C++ `HMMHolder::CacheAll`.
+    pub fn cacheAll(self: *HMMHolder) !void {
+        for (regions) |region| {
+            const names = self.gl.names.get(regionStr(region)) orelse continue;
+            for (names.items) |gene| {
+                const sanitized = try GermLines.sanitizeName(self.allocator, gene);
+                defer self.allocator.free(sanitized);
+                const infname = try std.fmt.allocPrint(self.allocator, "{s}/{s}.yaml", .{ self.hmm_dir, sanitized });
+                defer self.allocator.free(infname);
+                // Only cache if file exists
+                std.fs.cwd().access(infname, .{}) catch continue;
+                _ = try self.get(gene);
+            }
+        }
+    }
+
+    /// Rescale overall_mute_freq for all genes in `only_genes`.
+    pub fn rescaleOverallMuteFreqs(
+        self: *HMMHolder,
+        only_genes: *std.AutoHashMapUnmanaged(Region, std.StringHashMapUnmanaged(void)),
+        overall_mute_freq: f64,
+    ) !void {
+        for (regions) |region| {
+            const gene_set = only_genes.get(region) orelse continue;
+            var git = gene_set.iterator();
+            while (git.next()) |entry| {
+                const m = try self.get(entry.key_ptr.*);
+                try m.rescaleOverallMuteFreq(self.allocator, overall_mute_freq);
+            }
+        }
+    }
+
+    /// Undo rescaling.
+    pub fn unRescaleOverallMuteFreqs(
+        self: *HMMHolder,
+        only_genes: *std.AutoHashMapUnmanaged(Region, std.StringHashMapUnmanaged(void)),
+    ) !void {
+        for (regions) |region| {
+            const gene_set = only_genes.get(region) orelse continue;
+            var git = gene_set.iterator();
+            while (git.next()) |entry| {
+                const m = try self.get(entry.key_ptr.*);
+                m.unRescaleOverallMuteFreq();
+            }
+        }
+    }
+};

--- a/packages/zig-core/src/ham/bcr_utils/insertions.zig
+++ b/packages/zig-core/src/ham/bcr_utils/insertions.zig
@@ -1,0 +1,41 @@
+/// ham/bcr_utils/insertions.zig — Zig port of ham::Insertions
+///
+/// Maps each VDJ region to its associated insertion names.
+/// C++ source: packages/ham/include/bcrutils.h
+
+const std = @import("std");
+const Region = @import("germ_lines.zig").Region;
+
+/// Corresponds to C++ `ham::Insertions`.
+pub const Insertions = struct {
+    /// v region: fv insertion
+    v: [1][]const u8 = .{"fv"},
+    /// d region: vd insertion
+    d: [1][]const u8 = .{"vd"},
+    /// j region: dj and jf insertions
+    j: [2][]const u8 = .{ "dj", "jf" },
+
+    /// Return a slice of insertion names for a given region.
+    /// Corresponds to C++ `operator[](string region)`.
+    pub fn forRegion(self: *const Insertions, region: Region) []const []const u8 {
+        return switch (region) {
+            .v => &self.v,
+            .d => &self.d,
+            .j => &self.j,
+        };
+    }
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "Insertions: forRegion" {
+    const ins = Insertions{};
+    const v_ins = ins.forRegion(.v);
+    try std.testing.expectEqual(@as(usize, 1), v_ins.len);
+    try std.testing.expectEqualStrings("fv", v_ins[0]);
+
+    const j_ins = ins.forRegion(.j);
+    try std.testing.expectEqual(@as(usize, 2), j_ins.len);
+    try std.testing.expectEqualStrings("dj", j_ins[0]);
+    try std.testing.expectEqualStrings("jf", j_ins[1]);
+}

--- a/packages/zig-core/src/ham/bcr_utils/k_bounds.zig
+++ b/packages/zig-core/src/ham/bcr_utils/k_bounds.zig
@@ -1,0 +1,88 @@
+/// ham/bcr_utils/k_bounds.zig — Zig port of ham::KSet and ham::KBounds
+///
+/// k_v / k_d cut-point pairs and their bounding box.
+/// C++ source: packages/ham/include/bcrutils.h
+
+const std = @import("std");
+
+/// A pair of (k_v, k_d) values specifying how to chop a query sequence.
+/// Corresponds to C++ `ham::KSet`.
+pub const KSet = struct {
+    v: usize,
+    d: usize,
+
+    pub fn isNull(self: KSet) bool {
+        return self.v == 0 and self.d == 0;
+    }
+
+    pub fn eql(self: KSet, rhs: KSet) bool {
+        return self.v == rhs.v and self.d == rhs.d;
+    }
+
+    /// Less-than for use as map key (v first, then d).
+    pub fn lessThan(_: void, lhs: KSet, rhs: KSet) bool {
+        if (lhs.v != rhs.v) return lhs.v < rhs.v;
+        return lhs.d < rhs.d;
+    }
+};
+
+/// Bounding box over KSet space.
+/// Corresponds to C++ `ham::KBounds`.
+pub const KBounds = struct {
+    vmin: usize = 0,
+    dmin: usize = 0,
+    vmax: usize = 0,
+    dmax: usize = 0,
+
+    pub fn initFromSets(kmin: KSet, kmax: KSet) KBounds {
+        return KBounds{
+            .vmin = kmin.v,
+            .dmin = kmin.d,
+            .vmax = kmax.v,
+            .dmax = kmax.d,
+        };
+    }
+
+    pub fn eql(self: KBounds, rhs: KBounds) bool {
+        return self.vmin == rhs.vmin and self.vmax == rhs.vmax and
+            self.dmin == rhs.dmin and self.dmax == rhs.dmax;
+    }
+
+    /// Return the union of `self` and `rhs`.
+    /// Corresponds to C++ `KBounds::LogicalOr`.
+    pub fn logicalOr(self: KBounds, rhs: KBounds) KBounds {
+        return KBounds{
+            .vmin = @min(self.vmin, rhs.vmin),
+            .dmin = @min(self.dmin, rhs.dmin),
+            .vmax = @max(self.vmax, rhs.vmax),
+            .dmax = @max(self.dmax, rhs.dmax),
+        };
+    }
+
+    pub fn stringify(self: KBounds, allocator: std.mem.Allocator) ![]u8 {
+        return std.fmt.allocPrint(allocator, "{d}-{d}, {d}-{d}", .{
+            self.vmin, self.vmax, self.dmin, self.dmax,
+        });
+    }
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "KSet: isNull and eql" {
+    const null_ks = KSet{ .v = 0, .d = 0 };
+    const real_ks = KSet{ .v = 3, .d = 2 };
+    try std.testing.expect(null_ks.isNull());
+    try std.testing.expect(!real_ks.isNull());
+    try std.testing.expect(real_ks.eql(KSet{ .v = 3, .d = 2 }));
+    try std.testing.expect(!real_ks.eql(null_ks));
+}
+
+test "KBounds: logicalOr" {
+    const a = KBounds{ .vmin = 1, .vmax = 5, .dmin = 1, .dmax = 3 };
+    const b = KBounds{ .vmin = 2, .vmax = 7, .dmin = 0, .dmax = 4 };
+    const u = a.logicalOr(b);
+    try std.testing.expectEqual(@as(usize, 1), u.vmin);
+    try std.testing.expectEqual(@as(usize, 7), u.vmax);
+    try std.testing.expectEqual(@as(usize, 0), u.dmin);
+    try std.testing.expectEqual(@as(usize, 4), u.dmax);
+}

--- a/packages/zig-core/src/ham/bcr_utils/reco_event.zig
+++ b/packages/zig-core/src/ham/bcr_utils/reco_event.zig
@@ -1,0 +1,196 @@
+/// ham/bcr_utils/reco_event.zig — Zig port of ham::RecoEvent
+///
+/// A single VDJ recombination event annotation.
+/// C++ source: packages/ham/src/bcrutils.cc
+
+const std = @import("std");
+const SupportPair = @import("support_pair.zig").SupportPair;
+const GermLines = @import("germ_lines.zig").GermLines;
+
+/// Corresponds to C++ `ham::RecoEvent`.
+pub const RecoEvent = struct {
+    /// Region gene assignments: "v", "d", "j" → gene name.
+    genes: std.StringHashMapUnmanaged([]u8),
+    /// Deletion lengths: "v_5p", "v_3p", "d_5p", "d_3p", "j_5p", "j_3p".
+    deletions: std.StringHashMapUnmanaged(usize),
+    /// Insertion sequences: "fv", "vd", "dj", "jf".
+    insertions: std.StringHashMapUnmanaged([]u8),
+    naive_seq: []u8,
+    score: f64,
+    cyst_position: i32,
+    tryp_position: i32,
+    cdr3_length: i32,
+    /// Per-region sorted (gene, logprob) support.
+    per_gene_support: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(SupportPair)),
+
+    /// Create an empty RecoEvent (score = 999, as in C++).
+    pub fn init(allocator: std.mem.Allocator) !RecoEvent {
+        _ = allocator;
+        return RecoEvent{
+            .genes = .{},
+            .deletions = .{},
+            .insertions = .{},
+            .naive_seq = &.{},
+            .score = 999,
+            .cyst_position = 0,
+            .tryp_position = 0,
+            .cdr3_length = 0,
+            .per_gene_support = .{},
+        };
+    }
+
+    pub fn deinit(self: *RecoEvent, allocator: std.mem.Allocator) void {
+        var git = self.genes.iterator();
+        while (git.next()) |e| {
+            allocator.free(e.key_ptr.*);
+            allocator.free(e.value_ptr.*);
+        }
+        self.genes.deinit(allocator);
+
+        var dit = self.deletions.iterator();
+        while (dit.next()) |e| allocator.free(e.key_ptr.*);
+        self.deletions.deinit(allocator);
+
+        var iit = self.insertions.iterator();
+        while (iit.next()) |e| {
+            allocator.free(e.key_ptr.*);
+            allocator.free(e.value_ptr.*);
+        }
+        self.insertions.deinit(allocator);
+
+        if (self.naive_seq.len > 0) allocator.free(self.naive_seq);
+
+        var pit = self.per_gene_support.iterator();
+        while (pit.next()) |e| {
+            allocator.free(e.key_ptr.*);
+            e.value_ptr.deinit(allocator);
+        }
+        self.per_gene_support.deinit(allocator);
+    }
+
+    pub fn setGenes(self: *RecoEvent, allocator: std.mem.Allocator, vgene: []const u8, dgene: []const u8, jgene: []const u8) !void {
+        try self.setGene(allocator, "v", vgene);
+        try self.setGene(allocator, "d", dgene);
+        try self.setGene(allocator, "j", jgene);
+    }
+
+    pub fn setGene(self: *RecoEvent, allocator: std.mem.Allocator, region: []const u8, gene: []const u8) !void {
+        const key = try allocator.dupe(u8, region);
+        errdefer allocator.free(key);
+        const val = try allocator.dupe(u8, gene);
+        errdefer allocator.free(val);
+        // Free old entry if present
+        if (self.genes.fetchRemove(key)) |old| {
+            allocator.free(old.key);
+            allocator.free(old.value);
+        }
+        try self.genes.put(allocator, key, val);
+    }
+
+    pub fn setDeletion(self: *RecoEvent, allocator: std.mem.Allocator, name: []const u8, len: usize) !void {
+        const key = try allocator.dupe(u8, name);
+        errdefer allocator.free(key);
+        if (self.deletions.fetchRemove(key)) |old| allocator.free(old.key);
+        try self.deletions.put(allocator, key, len);
+    }
+
+    pub fn setInsertion(self: *RecoEvent, allocator: std.mem.Allocator, name: []const u8, seq: []const u8) !void {
+        const key = try allocator.dupe(u8, name);
+        errdefer allocator.free(key);
+        const val = try allocator.dupe(u8, seq);
+        errdefer allocator.free(val);
+        if (self.insertions.fetchRemove(key)) |old| {
+            allocator.free(old.key);
+            allocator.free(old.value);
+        }
+        try self.insertions.put(allocator, key, val);
+    }
+
+    pub fn setScore(self: *RecoEvent, s: f64) void {
+        self.score = s;
+    }
+
+    pub fn clear(self: *RecoEvent, allocator: std.mem.Allocator) void {
+        var git = self.genes.iterator();
+        while (git.next()) |e| {
+            allocator.free(e.key_ptr.*);
+            allocator.free(e.value_ptr.*);
+        }
+        self.genes.clearRetainingCapacity();
+
+        var dit = self.deletions.iterator();
+        while (dit.next()) |e| allocator.free(e.key_ptr.*);
+        self.deletions.clearRetainingCapacity();
+
+        var iit = self.insertions.iterator();
+        while (iit.next()) |e| {
+            allocator.free(e.key_ptr.*);
+            allocator.free(e.value_ptr.*);
+        }
+        self.insertions.clearRetainingCapacity();
+    }
+
+    /// Less-than by score (for sorting).
+    pub fn lessThan(_: void, lhs: RecoEvent, rhs: RecoEvent) bool {
+        return lhs.score < rhs.score;
+    }
+
+    /// Build naive_seq from germline sequences and indel lengths.
+    /// Corresponds to C++ `RecoEvent::SetNaiveSeq`.
+    pub fn setNaiveSeq(self: *RecoEvent, allocator: std.mem.Allocator, gl: *const GermLines) !void {
+        const vgene = self.genes.get("v") orelse return error.MissingVGene;
+        const dgene = self.genes.get("d") orelse return error.MissingDGene;
+        const jgene = self.genes.get("j") orelse return error.MissingJGene;
+
+        const v_seq = gl.seqs.get(vgene) orelse return error.MissingSeq;
+        const d_seq = gl.seqs.get(dgene) orelse return error.MissingSeq;
+        const j_seq = gl.seqs.get(jgene) orelse return error.MissingSeq;
+
+        const v_5p: usize = self.deletions.get("v_5p") orelse 0;
+        const v_3p: usize = self.deletions.get("v_3p") orelse 0;
+        const d_5p: usize = self.deletions.get("d_5p") orelse 0;
+        const d_3p: usize = self.deletions.get("d_3p") orelse 0;
+        const j_5p: usize = self.deletions.get("j_5p") orelse 0;
+        const j_3p: usize = self.deletions.get("j_3p") orelse 0;
+
+        const fv = self.insertions.get("fv") orelse "";
+        const vd = self.insertions.get("vd") orelse "";
+        const dj = self.insertions.get("dj") orelse "";
+        const jf = self.insertions.get("jf") orelse "";
+
+        const eroded_v = if (v_5p + v_3p <= v_seq.len) v_seq[v_5p .. v_seq.len - v_3p] else "";
+        const eroded_d = if (d_5p + d_3p <= d_seq.len) d_seq[d_5p .. d_seq.len - d_3p] else "";
+        const eroded_j = if (j_5p + j_3p <= j_seq.len) j_seq[j_5p .. j_seq.len - j_3p] else "";
+
+        if (self.naive_seq.len > 0) allocator.free(self.naive_seq);
+        self.naive_seq = try std.fmt.allocPrint(allocator, "{s}{s}{s}{s}{s}{s}{s}", .{
+            fv, eroded_v, vd, eroded_d, dj, eroded_j, jf,
+        });
+
+        // Set CDR3 positions
+        const v_cyst = gl.cyst_positions.get(vgene) orelse 0;
+        const j_tryp = gl.tryp_positions.get(jgene) orelse 0;
+        const eroded_cpos: i32 = v_cyst - @as(i32, @intCast(v_5p)) + @as(i32, @intCast(fv.len));
+        const tpos_in_joined: i32 = j_tryp - @as(i32, @intCast(j_5p)) +
+            @as(i32, @intCast(fv.len + eroded_v.len + vd.len + eroded_d.len + dj.len));
+        self.cyst_position = eroded_cpos;
+        self.tryp_position = tpos_in_joined;
+        self.cdr3_length = tpos_in_joined - eroded_cpos + 3;
+    }
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "RecoEvent: init, setGene, setDeletion, clear" {
+    const allocator = std.testing.allocator;
+    var ev = try RecoEvent.init(allocator);
+    defer ev.deinit(allocator);
+
+    try ev.setGene(allocator, "v", "IGHV3-15*01");
+    try ev.setDeletion(allocator, "v_3p", 2);
+    try std.testing.expectEqualStrings("IGHV3-15*01", ev.genes.get("v").?);
+    try std.testing.expectEqual(@as(usize, 2), ev.deletions.get("v_3p").?);
+
+    ev.clear(allocator);
+    try std.testing.expectEqual(@as(usize, 0), ev.genes.count());
+}

--- a/packages/zig-core/src/ham/bcr_utils/result.zig
+++ b/packages/zig-core/src/ham/bcr_utils/result.zig
@@ -1,0 +1,143 @@
+/// ham/bcr_utils/result.zig — Zig port of ham::Result
+///
+/// Holds the collection of RecoEvents for all ksets, finalizes to best.
+/// C++ source: packages/ham/src/bcrutils.cc
+
+const std = @import("std");
+const SupportPair = @import("support_pair.zig").SupportPair;
+const RecoEvent = @import("reco_event.zig").RecoEvent;
+const GermLines = @import("germ_lines.zig").GermLines;
+const k_bounds_mod = @import("k_bounds.zig");
+const KSet = k_bounds_mod.KSet;
+const KBounds = k_bounds_mod.KBounds;
+const germ_lines_mod = @import("germ_lines.zig");
+const hasDGene = germ_lines_mod.hasDGene;
+const Region = germ_lines_mod.Region;
+const regions = germ_lines_mod.regions;
+const regionStr = germ_lines_mod.regionStr;
+const mathutils = @import("../mathutils.zig");
+
+/// Corresponds to C++ `ham::Result`.
+pub const Result = struct {
+    total_score: f64,
+    no_path: bool,
+    locus: []u8,
+    better_kbounds: KBounds,
+    boundary_error: bool,
+    could_not_expand: bool,
+    finalized: bool,
+    events: std.ArrayListUnmanaged(RecoEvent),
+    best_event: ?RecoEvent,
+
+    allocator: std.mem.Allocator,
+
+    pub fn init(allocator: std.mem.Allocator, kbounds: KBounds, locus: []const u8) !Result {
+        return Result{
+            .total_score = mathutils.NEG_INF,
+            .no_path = false,
+            .locus = try allocator.dupe(u8, locus),
+            .better_kbounds = kbounds,
+            .boundary_error = false,
+            .could_not_expand = false,
+            .finalized = false,
+            .events = .{},
+            .best_event = null,
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *Result) void {
+        const allocator = self.allocator;
+        allocator.free(self.locus);
+        for (self.events.items) |*ev| ev.deinit(allocator);
+        self.events.deinit(allocator);
+        if (self.best_event) |*ev| ev.deinit(allocator);
+    }
+
+    pub fn pushBackRecoEvent(self: *Result, event: RecoEvent) !void {
+        try self.events.append(self.allocator, event);
+    }
+
+    /// Sort events by score, set best_event, set per_gene_support on best.
+    /// Corresponds to C++ `Result::Finalize`.
+    pub fn finalize(
+        self: *Result,
+        _gl: *const GermLines,
+        unsorted_per_gene_support: *const std.StringHashMapUnmanaged(f64),
+        best_kset: KSet,
+        kbounds: KBounds,
+    ) !void {
+        _ = _gl;
+        std.debug.assert(!self.finalized);
+
+        // Sort events descending by score. STABLE sort to make tied scores
+        // resolve to first-pushed (deterministic across runs and backends).
+        // With score stored as f64 (#377) the f32-collapse failure mode from
+        // #375 is gone, but two ksets can still produce machine-epsilon-equal
+        // f64 scores; an unstable pdqsort/introsort would otherwise pick
+        // different "best" events between Zig and C++, cascading through
+        // naive_seq → hfrac → cluster merges. Originally added in #375.
+        std.sort.block(RecoEvent, self.events.items, {}, struct {
+            fn desc(_: void, a: RecoEvent, b: RecoEvent) bool {
+                return a.score > b.score;
+            }
+        }.desc);
+
+        // Take ownership of the best event by removing it from the events list.
+        // This avoids a double-free: deinit frees both best_event and every item
+        // in events, so the best event must appear in exactly one of the two.
+        self.best_event = self.events.orderedRemove(0);
+
+        // Build per_gene_support for best event
+        for (regions) |region| {
+            var support: std.ArrayListUnmanaged(SupportPair) = .{};
+            var it = unsorted_per_gene_support.iterator();
+            while (it.next()) |entry| {
+                const gene = entry.key_ptr.*;
+                const logprob = entry.value_ptr.*;
+                const r = GermLines.getRegion(gene) catch continue;
+                if (r != region) continue;
+                try support.append(self.allocator, SupportPair{ .gene = gene, .logprob = logprob });
+            }
+            // Sort descending by logprob
+            std.mem.sort(SupportPair, support.items, {}, struct {
+                fn desc(_: void, a: SupportPair, b: SupportPair) bool {
+                    return a.logprob > b.logprob;
+                }
+            }.desc);
+            const key = try self.allocator.dupe(u8, regionStr(region));
+            errdefer self.allocator.free(key);
+            if (self.best_event) |*be| {
+                try be.per_gene_support.put(self.allocator, key, support);
+            } else {
+                support.deinit(self.allocator);
+                self.allocator.free(key);
+            }
+        }
+
+        self.checkBoundaries(best_kset, kbounds);
+        self.finalized = true;
+    }
+
+    fn checkBoundaries(self: *Result, best: KSet, kbounds: KBounds) void {
+        const delta: usize = 2;
+        if (best.v == kbounds.vmin) {
+            self.boundary_error = true;
+            self.better_kbounds.vmin = if (kbounds.vmin > delta) kbounds.vmin - delta else 1;
+        }
+        if (best.v == kbounds.vmax -| 1) {
+            self.boundary_error = true;
+            self.better_kbounds.vmax = kbounds.vmax + delta;
+        }
+        if (hasDGene(self.locus) and best.d == kbounds.dmin) {
+            self.boundary_error = true;
+            self.better_kbounds.dmin = if (kbounds.dmin > delta) kbounds.dmin - delta else 1;
+        }
+        if (hasDGene(self.locus) and best.d == kbounds.dmax -| 1) {
+            self.boundary_error = true;
+            self.better_kbounds.dmax = kbounds.dmax + delta;
+        }
+        if (self.boundary_error and self.better_kbounds.eql(kbounds))
+            self.could_not_expand = true;
+    }
+};

--- a/packages/zig-core/src/ham/bcr_utils/root.zig
+++ b/packages/zig-core/src/ham/bcr_utils/root.zig
@@ -1,0 +1,29 @@
+/// ham/bcr_utils/root.zig — Zig port of ham::bcrutils (directory group)
+///
+/// Re-exports all sub-modules of the bcr_utils directory group.
+/// C++ source: packages/ham/src/bcrutils.cc, packages/ham/include/bcrutils.h
+/// C++ author: psathyrella/ham
+
+pub const support_pair = @import("support_pair.zig");
+pub const insertions = @import("insertions.zig");
+pub const term_colors = @import("term_colors.zig");
+pub const germ_lines = @import("germ_lines.zig");
+pub const k_bounds = @import("k_bounds.zig");
+pub const reco_event = @import("reco_event.zig");
+pub const hmm_holder = @import("hmm_holder.zig");
+pub const result = @import("result.zig");
+pub const utils = @import("utils.zig");
+
+// Convenience re-exports of the most-used types
+pub const SupportPair = support_pair.SupportPair;
+pub const Insertions = insertions.Insertions;
+pub const TermColors = term_colors.TermColors;
+pub const GermLines = germ_lines.GermLines;
+pub const hasDGene = germ_lines.hasDGene;
+pub const Region = germ_lines.Region;
+pub const regionStr = germ_lines.regionStr;
+pub const KSet = k_bounds.KSet;
+pub const KBounds = k_bounds.KBounds;
+pub const RecoEvent = reco_event.RecoEvent;
+pub const HMMHolder = hmm_holder.HMMHolder;
+pub const Result = result.Result;

--- a/packages/zig-core/src/ham/bcr_utils/support_pair.zig
+++ b/packages/zig-core/src/ham/bcr_utils/support_pair.zig
@@ -1,0 +1,29 @@
+/// ham/bcr_utils/support_pair.zig — Zig port of ham::SupportPair
+///
+/// A (gene-name, log-prob) pair used to rank per-gene support.
+/// C++ source: packages/ham/include/bcrutils.h
+/// C++ author: psathyrella/ham
+
+const std = @import("std");
+
+/// Corresponds to C++ `ham::SupportPair`.
+pub const SupportPair = struct {
+    gene: []const u8,
+    logprob: f64,
+
+    /// Less-than: returns true when `self` is LESS likely than `rhs`.
+    /// Matches C++ `operator<`: return logprob() < rhs.logprob().
+    pub fn lessThan(_: void, lhs: SupportPair, rhs: SupportPair) bool {
+        return lhs.logprob < rhs.logprob;
+    }
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "SupportPair: lessThan ordering" {
+    const a = SupportPair{ .gene = "IGHV3-15*01", .logprob = -5.0 };
+    const b = SupportPair{ .gene = "IGHV3-23*01", .logprob = -3.0 };
+    try std.testing.expect(SupportPair.lessThan({}, a, b));
+    try std.testing.expect(!SupportPair.lessThan({}, b, a));
+    try std.testing.expect(!SupportPair.lessThan({}, a, a));
+}

--- a/packages/zig-core/src/ham/bcr_utils/term_colors.zig
+++ b/packages/zig-core/src/ham/bcr_utils/term_colors.zig
@@ -1,0 +1,203 @@
+/// ham/bcr_utils/term_colors.zig — Zig port of ham::TermColors
+///
+/// ANSI terminal color helpers used for debug printing in bcrham.
+/// C++ source: packages/ham/src/bcrutils.cc, packages/ham/include/bcrutils.h
+
+const std = @import("std");
+const Region = @import("germ_lines.zig").Region;
+const regionStr = @import("germ_lines.zig").regionStr;
+
+/// ANSI escape code table.  Corresponds to C++ `TermColors::codes_`.
+const color_codes = std.StaticStringMap([]const u8).initComptime(.{
+    .{ "bold", "\x1b[1m" },
+    .{ "reverse", "\x1b[7m" },
+    .{ "purple", "\x1b[95m" },
+    .{ "blue", "\x1b[94m" },
+    .{ "light_blue", "\x1b[1;34m" },
+    .{ "green", "\x1b[92m" },
+    .{ "yellow", "\x1b[93m" },
+    .{ "red", "\x1b[91m" },
+    .{ "end", "\x1b[0m" },
+});
+
+/// Corresponds to C++ `ham::TermColors`.
+pub const TermColors = struct {
+    /// Wrap `seq` with ANSI color escape codes.
+    /// Caller owns the returned slice (allocated with `allocator`).
+    /// Corresponds to C++ `TermColors::Color(col, seq)`.
+    pub fn color(allocator: std.mem.Allocator, col: []const u8, seq: []const u8) ![]u8 {
+        const start = color_codes.get(col) orelse return error.UnknownColor;
+        const end_code = color_codes.get("end").?;
+        return std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ start, seq, end_code });
+    }
+
+    /// Return `nuc` wrapped in red if it differs from `germline_nuc`.
+    /// Corresponds to C++ `TermColors::RedifyIfMuted`.
+    pub fn redifyIfMuted(allocator: std.mem.Allocator, germline_nuc: u8, nuc: u8) ![]u8 {
+        if (nuc == germline_nuc) {
+            const s = try allocator.alloc(u8, 1);
+            s[0] = nuc;
+            return s;
+        }
+        const single = [_]u8{nuc};
+        return color(allocator, "red", &single);
+    }
+
+    /// Extract region from a gene name (e.g. "IGHD1-1*01" → .d).
+    /// Corresponds to C++ `TermColors::GetRegion(gene)`.
+    pub fn getRegion(gene: []const u8) !Region {
+        if (!std.mem.startsWith(u8, gene, "IG") and !std.mem.startsWith(u8, gene, "TR"))
+            return error.BadGeneName;
+        if (gene.len < 4) return error.BadGeneName;
+        const ch = std.ascii.toLower(gene[3]);
+        return switch (ch) {
+            'v' => .v,
+            'd' => .d,
+            'j' => .j,
+            else => error.BadRegion,
+        };
+    }
+
+    /// Return `seq` with every occurrence of `ch_to_color` colored.
+    /// Corresponds to C++ `TermColors::ColorChars`.
+    pub fn colorChars(allocator: std.mem.Allocator, ch_to_color: u8, col: []const u8, seq: []const u8) ![]u8 {
+        var buf: std.ArrayListUnmanaged(u8) = .{};
+        defer buf.deinit(allocator);
+        for (seq) |c| {
+            if (c == ch_to_color) {
+                const colored = try color(allocator, col, &[_]u8{c});
+                defer allocator.free(colored);
+                try buf.appendSlice(allocator, colored);
+            } else {
+                try buf.append(allocator, c);
+            }
+        }
+        return buf.toOwnedSlice(allocator);
+    }
+
+    /// Colorize a gene name (e.g. "IGHV3-15*01") with region, version, allele parts.
+    /// Caller owns the returned slice (allocated with `allocator`).
+    /// Corresponds to C++ `TermColors::ColorGene(gene)`.
+    pub fn colorGene(allocator: std.mem.Allocator, gene: []const u8) ![]u8 {
+        const region = try getRegion(gene);
+        const rs = regionStr(region);
+        const region_colored = try color(allocator, "red", rs);
+        defer allocator.free(region_colored);
+
+        var buf: std.ArrayListUnmanaged(u8) = .{};
+        defer buf.deinit(allocator);
+        try buf.appendSlice(allocator, region_colored);
+
+        // Find positions of '-' and '*' and '_' in the gene name
+        const dash_pos = std.mem.indexOfScalar(u8, gene, '-');
+        const star_pos = std.mem.indexOfScalar(u8, gene, '*');
+        const underscore_pos = std.mem.indexOfScalar(u8, gene, '_');
+
+        if (region == .j) {
+            // For j genes: n_version = gene[4..star_pos], no subversion
+            const version_end = star_pos orelse gene.len;
+            const n_version = gene[4..version_end];
+            const version_colored = try color(allocator, "purple", n_version);
+            defer allocator.free(version_colored);
+            try buf.appendSlice(allocator, version_colored);
+        } else {
+            // For v and d genes: n_version = gene[4..dash_pos], n_subversion = gene[dash_pos+1..star_pos]
+            const d_pos = dash_pos orelse gene.len;
+            const n_version = gene[4..d_pos];
+            const version_colored = try color(allocator, "purple", n_version);
+            defer allocator.free(version_colored);
+            try buf.appendSlice(allocator, version_colored);
+            try buf.append(allocator, '-');
+            const s_pos = star_pos orelse gene.len;
+            if (d_pos + 1 <= s_pos) {
+                const n_subversion = gene[d_pos + 1 .. s_pos];
+                const subversion_colored = try color(allocator, "purple", n_subversion);
+                defer allocator.free(subversion_colored);
+                try buf.appendSlice(allocator, subversion_colored);
+            }
+        }
+
+        // Allele: gene[star_pos+1..underscore_pos]
+        if (star_pos) |sp| {
+            const allele_end = underscore_pos orelse gene.len;
+            const allele = gene[sp + 1 .. allele_end];
+            const allele_colored = try color(allocator, "yellow", allele);
+            defer allocator.free(allele_colored);
+            try buf.appendSlice(allocator, allele_colored);
+        }
+
+        // Suffix after '_' (if present)
+        if (underscore_pos) |up| {
+            try buf.appendSlice(allocator, gene[up..]);
+        }
+
+        return buf.toOwnedSlice(allocator);
+    }
+
+    /// Return `seq` with mutant positions highlighted.
+    /// Corresponds to C++ `TermColors::ColorMutants`.
+    pub fn colorMutants(
+        allocator: std.mem.Allocator,
+        col: []const u8,
+        seq: []const u8,
+        ref1: []const u8,
+        other_refs: []const []const u8,
+        ambiguous_char: []const u8,
+    ) ![]u8 {
+        // Build full ref list: other_refs + ref1 (if non-empty)
+        var refs: std.ArrayListUnmanaged([]const u8) = .{};
+        defer refs.deinit(allocator);
+        try refs.appendSlice(allocator, other_refs);
+        if (ref1.len > 0) try refs.append(allocator, ref1);
+
+        var buf: std.ArrayListUnmanaged(u8) = .{};
+        defer buf.deinit(allocator);
+
+        for (seq, 0..) |nuc, inuc| {
+            if (nuc == 'i') {
+                const colored = try color(allocator, "yellow", &[_]u8{nuc});
+                defer allocator.free(colored);
+                try buf.appendSlice(allocator, colored);
+            } else {
+                var ndiff: usize = 0;
+                for (refs.items) |ref| {
+                    if (inuc >= ref.len) continue;
+                    const ambig = ambiguous_char.len > 0 and (ref[inuc] == ambiguous_char[0] or nuc == ambiguous_char[0]);
+                    if (!ambig and nuc != ref[inuc]) ndiff += 1;
+                }
+                if (ndiff == 0) {
+                    try buf.append(allocator, nuc);
+                } else if (ndiff == 1) {
+                    const colored = try color(allocator, col, &[_]u8{nuc});
+                    defer allocator.free(colored);
+                    try buf.appendSlice(allocator, colored);
+                } else {
+                    const inner = try color(allocator, col, &[_]u8{nuc});
+                    defer allocator.free(inner);
+                    const outer = try color(allocator, "reverse", inner);
+                    defer allocator.free(outer);
+                    try buf.appendSlice(allocator, outer);
+                }
+            }
+        }
+        return buf.toOwnedSlice(allocator);
+    }
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "TermColors: getRegion" {
+    try std.testing.expectEqual(Region.v, try TermColors.getRegion("IGHV3-15*01"));
+    try std.testing.expectEqual(Region.d, try TermColors.getRegion("IGHD1-1*01"));
+    try std.testing.expectEqual(Region.j, try TermColors.getRegion("IGHJ4*02"));
+    try std.testing.expectError(error.BadGeneName, TermColors.getRegion("bad"));
+}
+
+test "TermColors: color wraps with ANSI codes" {
+    const allocator = std.testing.allocator;
+    const s = try TermColors.color(allocator, "red", "ABC");
+    defer allocator.free(s);
+    try std.testing.expect(std.mem.startsWith(u8, s, "\x1b[91m"));
+    try std.testing.expect(std.mem.endsWith(u8, s, "\x1b[0m"));
+    try std.testing.expect(std.mem.indexOf(u8, s, "ABC") != null);
+}

--- a/packages/zig-core/src/ham/bcr_utils/utils.zig
+++ b/packages/zig-core/src/ham/bcr_utils/utils.zig
@@ -1,0 +1,225 @@
+/// ham/bcr_utils/utils.zig — Free functions from ham::bcrutils
+///
+/// CSV/output streaming, sequence utilities, memory query helpers.
+/// C++ source: packages/ham/src/bcrutils.cc
+
+const std = @import("std");
+const c = @cImport(@cInclude("stdio.h"));
+const SupportPair = @import("support_pair.zig").SupportPair;
+const RecoEvent = @import("reco_event.zig").RecoEvent;
+const Sequence = @import("../sequences.zig").Sequence;
+
+/// Whether the locus has a D gene segment (re-exported for use outside this module).
+pub const hasDGene = @import("germ_lines.zig").hasDGene;
+
+// ── C++-compatible float formatting ─────────────────────────────────────────
+
+/// Format a float like C++ `ostream << double` (6 significant digits, `%.6g`).
+fn fmtG6(buf: *[32]u8, val: f64) []const u8 {
+    const n: usize = @intCast(c.snprintf(buf, 32, "%.6g", val));
+    return buf[0..n];
+}
+
+/// Format a float like C++ `std::to_string(double)` (6 decimal places, `%.6f`).
+fn fmtF6(buf: *[64]u8, val: f64) []const u8 {
+    const n: usize = @intCast(c.snprintf(buf, 64, "%.6f", val));
+    return buf[0..n];
+}
+
+// ── Output streaming ──────────────────────────────────────────────────────────
+
+/// Write CSV header line for the given algorithm.
+/// Corresponds to C++ `ham::StreamHeader`.
+pub fn streamHeader(writer: anytype, algorithm: []const u8) !void {
+    if (std.mem.eql(u8, algorithm, "viterbi")) {
+        try writer.writeAll(
+            "unique_ids,v_gene,d_gene,j_gene,fv_insertion,vd_insertion,dj_insertion,jf_insertion," ++
+                "v_5p_del,v_3p_del,d_5p_del,d_3p_del,j_5p_del,j_3p_del,logprob,seqs," ++
+                "v_per_gene_support,d_per_gene_support,j_per_gene_support,errors\n",
+        );
+    } else if (std.mem.eql(u8, algorithm, "forward")) {
+        try writer.writeAll("unique_ids,logprob,errors\n");
+    } else {
+        return error.BadAlgorithm;
+    }
+}
+
+/// Build per-gene support string: "gene:logprob;gene:logprob;..."
+/// Corresponds to C++ `ham::PerGeneSupportString`.
+pub fn perGeneSupportString(
+    allocator: std.mem.Allocator,
+    support: []const SupportPair,
+) ![]u8 {
+    var buf: std.ArrayListUnmanaged(u8) = .{};
+    defer buf.deinit(allocator);
+    for (support, 0..) |sp, i| {
+        if (i > 0) try buf.append(allocator, ';');
+        var fbuf: [64]u8 = undefined;
+        const fstr = fmtF6(&fbuf, sp.logprob);
+        try buf.appendSlice(allocator, sp.gene);
+        try buf.append(allocator, ':');
+        try buf.appendSlice(allocator, fstr);
+    }
+    return buf.toOwnedSlice(allocator);
+}
+
+/// Write error output row to the CSV file.
+/// Corresponds to C++ `ham::StreamErrorput`.
+pub fn streamErrorput(
+    writer: anytype,
+    algorithm: []const u8,
+    allocator: std.mem.Allocator,
+    seqs: []const *const Sequence,
+    errors: []const u8,
+) !void {
+    const names = try seqNameStr(allocator, seqs, ":");
+    defer allocator.free(names);
+    const seq_str = try seqStr(allocator, seqs, ":");
+    defer allocator.free(seq_str);
+
+    if (std.mem.eql(u8, algorithm, "viterbi")) {
+        try writer.print("{s},,,,,,,,,,,,,,,{s},,,,{s}\n", .{ names, seq_str, errors });
+    } else {
+        try writer.print("{s},,{s}\n", .{ names, errors });
+    }
+}
+
+/// Write Viterbi output row to the CSV file.
+/// Corresponds to C++ `ham::StreamViterbiOutput`.
+pub fn streamViterbiOutput(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    event: *const RecoEvent,
+    seqs: []const *const Sequence,
+    errors: []const u8,
+) !void {
+    const names = try seqNameStr(allocator, seqs, ":");
+    defer allocator.free(names);
+    const seq_str = try seqStr(allocator, seqs, ":");
+    defer allocator.free(seq_str);
+
+    const vgene = event.genes.get("v") orelse "";
+    const dgene = event.genes.get("d") orelse "";
+    const jgene = event.genes.get("j") orelse "";
+    const fv_ins = event.insertions.get("fv") orelse "";
+    const vd_ins = event.insertions.get("vd") orelse "";
+    const dj_ins = event.insertions.get("dj") orelse "";
+    const jf_ins = event.insertions.get("jf") orelse "";
+    const v5p = event.deletions.get("v_5p") orelse 0;
+    const v3p = event.deletions.get("v_3p") orelse 0;
+    const d5p = event.deletions.get("d_5p") orelse 0;
+    const d3p = event.deletions.get("d_3p") orelse 0;
+    const j5p = event.deletions.get("j_5p") orelse 0;
+    const j3p = event.deletions.get("j_3p") orelse 0;
+
+    const empty_support: []const SupportPair = &.{};
+    const vsupp = if (event.per_gene_support.get("v")) |s| s.items else empty_support;
+    const dsupp = if (event.per_gene_support.get("d")) |s| s.items else empty_support;
+    const jsupp = if (event.per_gene_support.get("j")) |s| s.items else empty_support;
+
+    const vs = try perGeneSupportString(allocator, vsupp);
+    defer allocator.free(vs);
+    const ds = try perGeneSupportString(allocator, dsupp);
+    defer allocator.free(ds);
+    const js = try perGeneSupportString(allocator, jsupp);
+    defer allocator.free(js);
+
+    var score_buf: [32]u8 = undefined;
+    const score_str = fmtG6(&score_buf, event.score);
+    try writer.print("{s},{s},{s},{s},{s},{s},{s},{s},{d},{d},{d},{d},{d},{d},{s},{s},{s},{s},{s},{s}\n", .{
+        names, vgene, dgene, jgene,
+        fv_ins, vd_ins, dj_ins, jf_ins,
+        v5p, v3p, d5p, d3p, j5p, j3p,
+        score_str, seq_str, vs, ds, js, errors,
+    });
+}
+
+/// Write Forward output row.
+/// Corresponds to C++ `ham::StreamForwardOutput`.
+pub fn streamForwardOutput(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    seqs: []const *const Sequence,
+    total_score: f64,
+    errors: []const u8,
+) !void {
+    const names = try seqNameStr(allocator, seqs, ":");
+    defer allocator.free(names);
+    var score_buf: [32]u8 = undefined;
+    const score_str = fmtG6(&score_buf, total_score);
+    try writer.print("{s},{s},{s}\n", .{ names, score_str, errors });
+}
+
+// ── Sequence string helpers ────────────────────────────────────────────────────
+
+/// Join undigitized sequences with a delimiter.
+/// Corresponds to C++ `ham::SeqStr`.
+pub fn seqStr(
+    allocator: std.mem.Allocator,
+    seqs: []const *const Sequence,
+    delimiter: []const u8,
+) ![]u8 {
+    var buf: std.ArrayListUnmanaged(u8) = .{};
+    defer buf.deinit(allocator);
+    for (seqs, 0..) |seq, i| {
+        if (i > 0) try buf.appendSlice(allocator, delimiter);
+        try buf.appendSlice(allocator, seq.undigitized);
+    }
+    return buf.toOwnedSlice(allocator);
+}
+
+/// Join sequence names with a delimiter.
+/// Corresponds to C++ `ham::SeqNameStr`.
+pub fn seqNameStr(
+    allocator: std.mem.Allocator,
+    seqs: []const *const Sequence,
+    delimiter: []const u8,
+) ![]u8 {
+    var buf: std.ArrayListUnmanaged(u8) = .{};
+    defer buf.deinit(allocator);
+    for (seqs, 0..) |seq, i| {
+        if (i > 0) try buf.appendSlice(allocator, delimiter);
+        try buf.appendSlice(allocator, seq.name);
+    }
+    return buf.toOwnedSlice(allocator);
+}
+
+// ── Multi-sequence annotation quality check ────────────────────────────────────
+
+/// Return true if the annotation looks unreliable for multi-seq input.
+/// Corresponds to C++ `ham::FishyMultiSeqAnnotation`.
+pub fn fishyMultiSeqAnnotation(n_seqs: usize, event: *const RecoEvent) bool {
+    if (n_seqs < 3) return false;
+    const real_deletions = [_][]const u8{ "v_3p", "d_5p", "d_3p", "j_5p" };
+    for (real_deletions) |delname| {
+        if ((event.deletions.get(delname) orelse 0) > 2) return true;
+    }
+    return false;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "streamHeader: viterbi and forward" {
+    const allocator = std.testing.allocator;
+    var buf: std.ArrayListUnmanaged(u8) = .{};
+    defer buf.deinit(allocator);
+    const writer = buf.writer(allocator);
+    try streamHeader(writer, "viterbi");
+    try std.testing.expect(std.mem.startsWith(u8, buf.items, "unique_ids,v_gene"));
+
+    buf.clearRetainingCapacity();
+    try streamHeader(writer, "forward");
+    try std.testing.expect(std.mem.startsWith(u8, buf.items, "unique_ids,logprob"));
+}
+
+test "perGeneSupportString" {
+    const allocator = std.testing.allocator;
+    const support = [_]SupportPair{
+        .{ .gene = "IGHV3-15*01", .logprob = -5.0 },
+        .{ .gene = "IGHV3-23*01", .logprob = -3.0 },
+    };
+    const s = try perGeneSupportString(allocator, &support);
+    defer allocator.free(s);
+    try std.testing.expect(std.mem.indexOf(u8, s, "IGHV3-15*01") != null);
+    try std.testing.expect(std.mem.indexOf(u8, s, ";") != null);
+}

--- a/packages/zig-core/src/ham/bcrham.zig
+++ b/packages/zig-core/src/ham/bcrham.zig
@@ -1,0 +1,302 @@
+/// ham/bcrham.zig — Zig port of ham/src/bcrham.cc
+///
+/// bcrham entry point: wires together Args, Track, GermLines, HMMHolder,
+/// Sequences, DPHandler, and Glomerator.  The C++ `main()` is replaced here
+/// by `run()`, which is called from cabi.zig's bcrham_run / bcrham_forward /
+/// bcrham_viterbi stubs once they are implemented.
+///
+/// C++ source: packages/ham/src/bcrham.cc
+/// C++ author: psathyrella/ham
+
+const std = @import("std");
+const Args = @import("args.zig").Args;
+const Track = @import("track.zig").Track;
+const Sequence = @import("sequences.zig").Sequence;
+const bcr = @import("bcr_utils/root.zig");
+const GermLines = bcr.GermLines;
+const HMMHolder = bcr.HMMHolder;
+const KSet = bcr.KSet;
+const KBounds = bcr.KBounds;
+const DPHandler = @import("dp_handler.zig").DPHandler;
+const glomerator_mod = @import("glomerator/root.zig");
+const Glomerator = glomerator_mod.Glomerator;
+const bcr_utils = @import("bcr_utils/root.zig");
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+/// Build the flat list-of-lists of Sequence from parsed Args.
+/// Corresponds to C++ `GetSeqs(args, trk)`.
+pub fn getSeqs(
+    allocator: std.mem.Allocator,
+    args: *const Args,
+    trk: *const Track,
+) !std.ArrayListUnmanaged(std.ArrayListUnmanaged(Sequence)) {
+    var all_seqs: std.ArrayListUnmanaged(std.ArrayListUnmanaged(Sequence)) = .{};
+    errdefer {
+        for (all_seqs.items) |*sv| {
+            for (sv.items) |*sq| sq.deinit(allocator);
+            sv.deinit(allocator);
+        }
+        all_seqs.deinit(allocator);
+    }
+    for (args.queries.items) |*qrow| {
+        var seqs: std.ArrayListUnmanaged(Sequence) = .{};
+        errdefer {
+            for (seqs.items) |*sq| sq.deinit(allocator);
+            seqs.deinit(allocator);
+        }
+        const n = qrow.names.items.len;
+        for (0..n) |iseq| {
+            const sq = try Sequence.initFromString(
+                allocator,
+                trk,
+                qrow.names.items[iseq],
+                qrow.seqs.items[iseq],
+            );
+            try seqs.append(allocator, sq);
+        }
+        try all_seqs.append(allocator, seqs);
+    }
+    return all_seqs;
+}
+
+// ─── run_algorithm ────────────────────────────────────────────────────────────
+
+/// Run the Forward or Viterbi algorithm for each query and stream output.
+/// Corresponds to C++ `run_algorithm(hmms, gl, qry_seq_list, args)`.
+pub fn runAlgorithm(
+    allocator: std.mem.Allocator,
+    hmms: *HMMHolder,
+    gl: *GermLines,
+    qry_seq_list: *std.ArrayListUnmanaged(std.ArrayListUnmanaged(Sequence)),
+    args: *Args,
+    writer: anytype,
+) !void {
+    const bcr_text = @import("bcr_utils/utils.zig");
+    try bcr_text.streamHeader(writer, args.algorithm);
+
+    var n_vtb: i32 = 0;
+    var n_fwd: i32 = 0;
+
+    for (qry_seq_list.items, 0..) |*qseqs, iqry| {
+        const qrow = &args.queries.items[iqry];
+        const kmin = KSet{ .v = @intCast(qrow.k_v_min), .d = @intCast(qrow.k_d_min) };
+        const kmax = KSet{ .v = @intCast(qrow.k_v_max), .d = @intCast(qrow.k_d_max) };
+        const kbounds = KBounds.initFromSets(kmin, kmax);
+
+        // Build only_genes slice ([]const []const u8) from qrow.only_genes
+        const only_genes = try allocator.alloc([]const u8, qrow.only_genes.items.len);
+        defer allocator.free(only_genes);
+        for (qrow.only_genes.items, only_genes) |g, *out| out.* = g;
+
+        // Build pointer view into qseqs for the DP and stream calls (item 16).
+        const qseq_ptrs = try allocator.alloc(*const Sequence, qseqs.items.len);
+        defer allocator.free(qseq_ptrs);
+        for (qseqs.items, qseq_ptrs) |*sq, *out| out.* = sq;
+
+        var dph = try DPHandler.init(allocator, args.algorithm, args, gl, hmms);
+        defer dph.deinit();
+
+        var result = try dph.run(qseq_ptrs, kbounds, only_genes, qrow.mut_freq, true);
+        defer result.deinit();
+
+        if (result.no_path) {
+            try bcr_text.streamErrorput(writer, args.algorithm, allocator, qseq_ptrs, "no_path");
+        } else if (std.mem.eql(u8, args.algorithm, "viterbi")) {
+            try bcr_text.streamViterbiOutput(writer, allocator, &result.best_event.?, qseq_ptrs, "");
+        } else if (std.mem.eql(u8, args.algorithm, "forward")) {
+            try bcr_text.streamForwardOutput(writer, allocator, qseq_ptrs, result.total_score, "");
+        } else {
+            return error.UnknownAlgorithm;
+        }
+
+        if (std.mem.eql(u8, args.algorithm, "viterbi"))
+            n_vtb += 1
+        else if (std.mem.eql(u8, args.algorithm, "forward"))
+            n_fwd += 1;
+    }
+    {
+        var buf: [128]u8 = undefined;
+        const s = try std.fmt.bufPrint(&buf, "        calcd:   vtb {: <4}  fwd {: <4}\n", .{ @as(u32, @intCast(n_vtb)), @as(u32, @intCast(n_fwd)) });
+        try std.fs.File.stdout().writeAll(s);
+    }
+}
+
+// ─── top-level run ────────────────────────────────────────────────────────────
+
+/// Top-level bcrham run.  Corresponds to C++ `main()`.
+/// `argv` is a slice of null-terminated argument strings (excluding argv[0]).
+pub fn run(allocator: std.mem.Allocator, argv: []const [*:0]const u8) !void {
+    const start = std.time.milliTimestamp();
+
+    // Parse args from argv: build defaults then populate each --flag value
+    var args = try Args.initDefaults(allocator);
+    defer args.deinit(allocator);
+    {
+        // Table-driven arg parsing: each tuple maps "--flag-name" → "field_name".
+        const string_flags = .{
+            .{ "--hmmdir", "hmmdir" },
+            .{ "--datadir", "datadir" },
+            .{ "--infile", "infile" },
+            .{ "--outfile", "outfile" },
+            .{ "--annotationfile", "annotationfile" },
+            .{ "--input-cachefname", "input_cachefname" },
+            .{ "--output-cachefname", "output_cachefname" },
+            .{ "--locus", "locus" },
+            .{ "--algorithm", "algorithm" },
+            .{ "--ambig-base", "ambig_base" },
+            .{ "--seed-unique-id", "seed_unique_id" },
+        };
+        const i32_flags = .{
+            .{ "--debug", "debug" },
+            .{ "--n-partitions-to-write", "n_partitions_to_write" },
+            .{ "--biggest-naive-seq-cluster-to-calculate", "biggest_naive_seq_cluster_to_calculate" },
+            .{ "--biggest-logprob-cluster-to-calculate", "biggest_logprob_cluster_to_calculate" },
+        };
+        const u32_flags = .{
+            .{ "--n-final-clusters", "n_final_clusters" },
+            .{ "--max-cluster-size", "max_cluster_size" },
+            .{ "--random-seed", "random_seed" },
+            .{ "--min-largest-cluster-size", "min_largest_cluster_size" },
+        };
+        const f64_flags = .{
+            .{ "--hamming-fraction-bound-lo", "hamming_fraction_bound_lo" },
+            .{ "--hamming-fraction-bound-hi", "hamming_fraction_bound_hi" },
+            .{ "--logprob-ratio-threshold", "logprob_ratio_threshold" },
+            .{ "--max-logprob-drop", "max_logprob_drop" },
+        };
+        const bool_flags = .{
+            .{ "--no-chunk-cache", "no_chunk_cache" },
+            .{ "--partition", "partition" },
+            .{ "--dont-rescale-emissions", "dont_rescale_emissions" },
+            .{ "--cache-naive-seqs", "cache_naive_seqs" },
+            .{ "--cache-naive-hfracs", "cache_naive_hfracs" },
+            .{ "--only-cache-new-vals", "only_cache_new_vals" },
+            .{ "--write-logprob-for-each-partition", "write_logprob_for_each_partition" },
+        };
+
+        var i: usize = 0;
+        while (i < argv.len) : (i += 1) {
+            const flag = std.mem.span(argv[i]);
+            var matched = false;
+
+            // Boolean flags: no value argument consumed
+            inline for (bool_flags) |entry| {
+                if (std.mem.eql(u8, flag, entry[0])) {
+                    @field(args, entry[1]) = true;
+                    matched = true;
+                }
+            }
+            if (matched) continue;
+
+            // All remaining flags consume a value argument
+            if (i + 1 >= argv.len) break;
+            const val = std.mem.span(argv[i + 1]);
+
+            inline for (string_flags) |entry| {
+                if (std.mem.eql(u8, flag, entry[0])) {
+                    allocator.free(@field(args, entry[1]));
+                    @field(args, entry[1]) = try allocator.dupe(u8, val);
+                    matched = true;
+                }
+            }
+            inline for (i32_flags) |entry| {
+                if (std.mem.eql(u8, flag, entry[0])) {
+                    @field(args, entry[1]) = try std.fmt.parseInt(i32, val, 10);
+                    matched = true;
+                }
+            }
+            inline for (u32_flags) |entry| {
+                if (std.mem.eql(u8, flag, entry[0])) {
+                    @field(args, entry[1]) = try std.fmt.parseInt(u32, val, 10);
+                    matched = true;
+                }
+            }
+            inline for (f64_flags) |entry| {
+                if (std.mem.eql(u8, flag, entry[0])) {
+                    @field(args, entry[1]) = try std.fmt.parseFloat(f64, val);
+                    matched = true;
+                }
+            }
+            if (matched) i += 1; // consume the value argument
+        }
+    }
+    // Validate required arguments
+    var missing = false;
+    if (args.hmmdir.len == 0) { std.debug.print("ERROR: missing required argument --hmmdir\n", .{}); missing = true; }
+    if (args.datadir.len == 0) { std.debug.print("ERROR: missing required argument --datadir\n", .{}); missing = true; }
+    if (args.infile.len == 0) { std.debug.print("ERROR: missing required argument --infile\n", .{}); missing = true; }
+    if (args.outfile.len == 0) { std.debug.print("ERROR: missing required argument --outfile\n", .{}); missing = true; }
+    if (args.locus.len == 0) { std.debug.print("ERROR: missing required argument --locus\n", .{}); missing = true; }
+    if (args.algorithm.len == 0) { std.debug.print("ERROR: missing required argument --algorithm\n", .{}); missing = true; }
+    if (missing) {
+        std.debug.print(
+            \\
+            \\Usage: partis-zig-core --hmmdir <dir> --datadir <dir> --infile <file>
+            \\                       --outfile <file> --locus <igh|igk|igl|tra|trb|trg|trd>
+            \\                       --algorithm <viterbi|forward> [--ambig-base <base>]
+            \\                       [--debug <0|1|2>] [--random-seed <n>] [--partition]
+            \\
+        , .{});
+        std.process.exit(1);
+    }
+
+    if (args.infile.len > 0) try args.readInfile(allocator);
+
+    // Build track
+    const characters = [_][]const u8{ "A", "C", "G", "T" };
+    var track = try Track.init(allocator, "NUKES");
+    defer track.deinit(allocator);
+    for (characters) |c| {
+        try track.addSymbol(allocator, c);
+    }
+    if (args.ambig_base.len > 0) try track.setAmbiguous(allocator, args.ambig_base);
+
+    // Load germlines and HMMs
+    var gl = try GermLines.init(allocator, args.datadir, args.locus);
+    defer gl.deinit();
+
+    var hmms = try HMMHolder.init(allocator, args.hmmdir, &gl);
+    defer hmms.deinit();
+
+    // Build query sequences
+    var qry_seq_list = try getSeqs(allocator, &args, &track);
+    defer {
+        for (qry_seq_list.items) |*sv| {
+            for (sv.items) |*sq| sq.deinit(allocator);
+            sv.deinit(allocator);
+        }
+        qry_seq_list.deinit(allocator);
+    }
+
+    // Open outfile
+    const outfile = try std.fs.createFileAbsolute(args.outfile, .{});
+    defer outfile.close();
+    var bw_buf: [65536]u8 = undefined;
+    var bw = outfile.writer(&bw_buf);
+
+    if (args.cache_naive_seqs or args.partition) {
+        // Convert ArrayList(ArrayList(Sequence)) → [][]Sequence for Glomerator
+        const seq_slices = try allocator.alloc([]Sequence, qry_seq_list.items.len);
+        defer allocator.free(seq_slices);
+        for (qry_seq_list.items, 0..) |sv, i| seq_slices[i] = sv.items;
+        var glom = try Glomerator.init(allocator, &hmms, &gl, seq_slices, &args, &track);
+        defer glom.deinit();
+        if (args.cache_naive_seqs) {
+            try glom.cacheNaiveSeqs();
+        } else {
+            try glom.cluster();
+        }
+    } else {
+        try runAlgorithm(allocator, &hmms, &gl, &qry_seq_list, &args, &bw.interface);
+    }
+
+    try bw.interface.flush();
+
+    const elapsed_s = @as(f64, @floatFromInt(std.time.milliTimestamp() - start)) / 1000.0;
+    {
+        var buf: [64]u8 = undefined;
+        const s = try std.fmt.bufPrint(&buf, "        time: bcrham {d:.1}\n", .{elapsed_s});
+        try std.fs.File.stdout().writeAll(s);
+    }
+}

--- a/packages/zig-core/src/ham/cluster_path.zig
+++ b/packages/zig-core/src/ham/cluster_path.zig
@@ -1,0 +1,162 @@
+/// ham/cluster_path.zig — Zig port of ham/src/clusterpath.cc + ham/include/clusterpath.h
+///
+/// Sequence of gradually coalescing partitions with associated log-probabilities.
+/// Used by the Glomerator for hierarchical clustering.
+///
+/// C++ source: packages/ham/src/clusterpath.cc, packages/ham/include/clusterpath.h
+/// C++ author: psathyrella/ham
+
+const std = @import("std");
+const math = std.math;
+const mathutils = @import("mathutils.zig");
+
+/// A partition: a set of sequence IDs (strings) forming a cluster.
+/// Corresponds to C++ `typedef set<string> Partition`.
+/// We represent as a sorted ArrayList of owned strings for simplicity.
+pub const Partition = std.ArrayListUnmanaged([]u8);
+
+/// Sequence of partitions with associated log-probabilities, tracking the best.
+/// Corresponds to C++ `ham::ClusterPath`.
+pub const ClusterPath = struct {
+    /// Sequence of partitions (front = oldest, back = most recent).
+    partitions: std.ArrayListUnmanaged(Partition),
+    /// Log-probabilities for each partition (parallel to partitions).
+    logprobs: std.ArrayListUnmanaged(f64),
+    /// Whether this path is finished (no more clustering steps).
+    finished: bool,
+    /// Index of the partition in the batch that gave rise to this path.
+    initial_path_index: i32,
+    /// Log-prob of the best partition seen so far.
+    max_log_prob_of_partition: f64,
+    /// Index of the best partition.
+    i_best: usize,
+
+    /// Create an empty ClusterPath with no partitions.
+    pub fn init() ClusterPath {
+        return ClusterPath{
+            .partitions = .{},
+            .logprobs = .{},
+            .finished = false,
+            .initial_path_index = 0,
+            .max_log_prob_of_partition = mathutils.NEG_INF,
+            .i_best = 0,
+        };
+    }
+
+    /// Create a ClusterPath with an initial partition.
+    /// Takes ownership of `initial_partition`.
+    /// Corresponds to C++ `ClusterPath(Partition initial_partition, double initial_logprob)`.
+    pub fn initWithPartition(
+        allocator: std.mem.Allocator,
+        initial_partition: Partition,
+        initial_logprob: f64,
+    ) !ClusterPath {
+        var cp = ClusterPath.init();
+        try cp.partitions.append(allocator, initial_partition);
+        try cp.logprobs.append(allocator, initial_logprob);
+        return cp;
+    }
+
+    pub fn deinit(self: *ClusterPath, allocator: std.mem.Allocator) void {
+        for (self.partitions.items) |*p| {
+            for (p.items) |s| allocator.free(s);
+            p.deinit(allocator);
+        }
+        self.partitions.deinit(allocator);
+        self.logprobs.deinit(allocator);
+    }
+
+    /// Update the log-probability for partition at index `il` and update best tracking.
+    /// Corresponds to C++ `ClusterPath::set_logprob(size_t il, double logprob)`.
+    pub fn setLogprob(self: *ClusterPath, il: usize, logprob: f64) void {
+        self.logprobs.items[il] = logprob;
+        if (self.max_log_prob_of_partition == mathutils.NEG_INF or logprob > self.max_log_prob_of_partition) {
+            self.max_log_prob_of_partition = logprob;
+            self.i_best = il;
+        }
+    }
+
+    /// Append a new partition.
+    /// Takes ownership of `partition`.
+    /// Corresponds to C++ `ClusterPath::AddPartition(Partition, double, size_t n_max_partitions)`.
+    pub fn addPartition(
+        self: *ClusterPath,
+        allocator: std.mem.Allocator,
+        partition: Partition,
+        logprob: f64,
+        n_max_partitions: usize,
+    ) !void {
+        try self.partitions.append(allocator, partition);
+        try self.logprobs.append(allocator, logprob);
+
+        if (self.max_log_prob_of_partition == mathutils.NEG_INF or logprob > self.max_log_prob_of_partition) {
+            self.max_log_prob_of_partition = logprob;
+            self.i_best = self.logprobs.items.len - 1;
+        }
+
+        // Trim oldest entries if over the limit (n_max_partitions == 0 means unlimited)
+        if (n_max_partitions > 0 and self.partitions.items.len > n_max_partitions) {
+            var old = self.partitions.orderedRemove(0);
+            for (old.items) |s| allocator.free(s);
+            old.deinit(allocator);
+            _ = self.logprobs.orderedRemove(0);
+        }
+    }
+
+    /// Return the most recent (current) partition.
+    /// Corresponds to C++ `ClusterPath::CurrentPartition()`.
+    pub fn currentPartition(self: *const ClusterPath) *const Partition {
+        return &self.partitions.items[self.partitions.items.len - 1];
+    }
+
+    /// Return the log-prob of the most recent partition.
+    /// Corresponds to C++ `ClusterPath::CurrentLogProb()`.
+    pub fn currentLogProb(self: *const ClusterPath) f64 {
+        return self.logprobs.items[self.logprobs.items.len - 1];
+    }
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "ClusterPath: init empty" {
+    const cp = ClusterPath.init();
+    try std.testing.expectEqual(false, cp.finished);
+    try std.testing.expectEqual(@as(usize, 0), cp.partitions.items.len);
+}
+
+test "ClusterPath: addPartition and best tracking" {
+    const allocator = std.testing.allocator;
+    var cp = ClusterPath.init();
+    defer cp.deinit(allocator);
+
+    // Add first partition with logprob -5.0
+    var p1: Partition = .{};
+    try p1.append(allocator, try allocator.dupe(u8, "seq1"));
+    try cp.addPartition(allocator, p1, -5.0, 0);
+
+    try std.testing.expectEqual(@as(f64, -5.0), cp.currentLogProb());
+    try std.testing.expectEqual(@as(f64, -5.0), cp.max_log_prob_of_partition);
+    try std.testing.expectEqual(@as(usize, 0), cp.i_best);
+
+    // Add second partition with better logprob -2.0
+    var p2: Partition = .{};
+    try p2.append(allocator, try allocator.dupe(u8, "seq1"));
+    try p2.append(allocator, try allocator.dupe(u8, "seq2"));
+    try cp.addPartition(allocator, p2, -2.0, 0);
+
+    try std.testing.expectEqual(@as(f64, -2.0), cp.currentLogProb());
+    try std.testing.expectEqual(@as(f64, -2.0), cp.max_log_prob_of_partition);
+    try std.testing.expectEqual(@as(usize, 1), cp.i_best);
+}
+
+test "ClusterPath: setLogprob updates best" {
+    const allocator = std.testing.allocator;
+    var cp = ClusterPath.init();
+    defer cp.deinit(allocator);
+
+    const p1: Partition = .{};
+    try cp.addPartition(allocator, p1, -10.0, 0);
+
+    cp.setLogprob(0, -3.0);
+    try std.testing.expectEqual(@as(f64, -3.0), cp.max_log_prob_of_partition);
+}

--- a/packages/zig-core/src/ham/dp_handler.zig
+++ b/packages/zig-core/src/ham/dp_handler.zig
@@ -1,0 +1,1508 @@
+/// ham/dp_handler.zig — Zig port of ham/src/dphandler.cc + ham/include/dphandler.h
+///
+/// Dynamic programming handler: runs Forward + Viterbi over a kset grid.
+/// Core bcrham algorithm.
+///
+/// C++ source: packages/ham/src/dphandler.cc, packages/ham/include/dphandler.h
+/// C++ author: psathyrella/ham
+
+const std = @import("std");
+const log = @import("mathutils.zig").log;
+const Trellis = @import("trellis.zig").Trellis;
+const TracebackPath = @import("traceback_path.zig").TracebackPath;
+const Model = @import("model.zig").Model;
+const Sequences = @import("sequences.zig").Sequences;
+const Sequence = @import("sequences.zig").Sequence;
+const mathutils = @import("mathutils.zig");
+const perf_counters = @import("perf_counters.zig");
+const Args = @import("args.zig").Args;
+const bcr = @import("bcr_utils/root.zig");
+const GermLines = bcr.GermLines;
+const HMMHolder = bcr.HMMHolder;
+const KSet = bcr.KSet;
+const KBounds = bcr.KBounds;
+const RecoEvent = bcr.RecoEvent;
+const Result = bcr.Result;
+const Insertions = bcr.Insertions;
+const Region = bcr.Region;
+const regionStr = bcr.regionStr;
+const TermColors = bcr.TermColors;
+
+/// Key for the per-gene score/path caches.
+const GeneKSetKey = struct {
+    gene: []const u8,
+    kset: KSet,
+};
+
+/// Cached trellis entry. Owns the Sequences the trellis was built over.
+///
+/// The entry itself is **heap-allocated** and the cache list holds pointers
+/// (`ArrayListUnmanaged(*TrellisEntry)`), so the entry's address is stable
+/// across cache-list reallocations. Inlining `query_seqs` here (rather than
+/// holding it via an extra `*Sequences` indirection) means `Trellis.seqs`
+/// can borrow `&entry.query_seqs` directly with one fewer pointer chase
+/// during prefix-match scans and DP setup.
+///
+/// Prefix-match for chunk-cache hits reads
+/// `entry.query_seqs.seqs.items[i].undigitized` — there is no separate
+/// `query_strs` list.
+const TrellisEntry = struct {
+    query_seqs: Sequences,
+    trellis: Trellis,
+};
+
+/// Per-gene inner-map pointer bundle hoisted once at the top of
+/// `runKSet`'s per-gene loop iteration. Replaces 2-3 redundant
+/// `self.{scratch_cachefo,paths,scores}.getPtr(gene)` lookups in the
+/// gene-block body and inside `fillTrellis` with a single struct of
+/// pre-resolved pointers.
+///
+/// Honest cost framing: the lookups this hoist eliminates show as
+/// 0.00% of partition wall in the post-#380 perf-record (the
+/// `getIndex` symbols for value-types `AutoHashMapUnmanaged(KSet,
+/// TracebackPath)`, `AutoHashMapUnmanaged(KSet, f64)`, and
+/// `ArrayListUnmanaged(*TrellisEntry)` do not appear at the top of
+/// `/tmp/perf-1.1-results/partition-5k.perf.report`). The 24.63%
+/// `getIndex__anon_27622` bucket cited in the Phase A memo is
+/// HMMHolder's `[]const u8 → *Model` map only — a different value
+/// type, with one call per (gene, kset) on the cache-miss path that
+/// this hoist intentionally does NOT touch (hoisting it would add a
+/// `hmms.get` call on the cache-hit path where the original code
+/// uses `cached_path.hmm.?` instead). So this hoist is best framed
+/// as a code-clarity / dead-error-path-removal refactor; any wall
+/// improvement is in the noise.
+///
+/// Pointer-stability invariants (load-bearing):
+///   - `initCache(gene)` is the only site that grows
+///     `scratch_cachefo` / `paths` / `scores`. It runs immediately
+///     above the cache build at the top of each gene-block iteration.
+///   - Within one gene-block iteration, the outer string-keyed maps
+///     don't grow. Inner-map writes (`gp.put(scratch, kset, ...)`,
+///     `cache_list.append(allocator, entry)`, etc.) modify the inner
+///     map's internal pointers but don't relocate the outer-map
+///     value slot.
+///   - `.?` unwraps below would panic in `Debug`/`ReleaseSafe` if
+///     the invariant ever broke; `ReleaseFast` would silently UAF.
+///     The `partis-test.py --paired --safe` rung covers the
+///     `ReleaseSafe` build mode (originally added so the UAF risk
+///     of caching pointers across put-calls would surface loudly in
+///     CI). If you change the locking around `initCache` or add a
+///     new outer-map writer, also re-confirm via that rung.
+const PerGeneCache = struct {
+    cachefo: *std.ArrayListUnmanaged(*TrellisEntry),
+    paths: *std.AutoHashMapUnmanaged(KSet, TracebackPath),
+    scores: *std.AutoHashMapUnmanaged(KSet, f64),
+};
+
+/// Corresponds to C++ `ham::DPHandler`.
+pub const DPHandler = struct {
+    algorithm: []const u8,
+    args: *Args,
+    gl: *GermLines,
+    hmms: *HMMHolder,
+
+    /// Caller-supplied allocator. Used **only** for allocations that
+    /// outlive the DPHandler — Result, RecoEvent and any owned strings
+    /// reachable from them (gene names on RecoEvent, naive_seq, deletion
+    /// keys, insertion seqs). See item 4 of issue #342 for the lifetime
+    /// table; any allocation that lands in `parent_allocator` rather than
+    /// `scratchAllocator()` is a deliberate cross-boundary write.
+    parent_allocator: std.mem.Allocator,
+
+    /// Per-query arena, lives for the full DPHandler lifetime. Backs every
+    /// internal scratch allocation: scratch_cachefo, paths, scores,
+    /// per_gene_support, and the run()-local maps (only_genes,
+    /// best_scores, total_scores, best_genes). On `clear()`,
+    /// reset(.retain_capacity) drops every dependent allocation in O(1)
+    /// and reuses the backing pages for the next call. Item 4, #342.
+    query_arena: std.heap.ArenaAllocator,
+
+    /// scratch_cachefo_: gene → list of *TrellisEntry. Entries are
+    /// individually heap-allocated for stable address (the trellis at each
+    /// entry borrows `&entry.query_seqs` and that pointer must stay valid
+    /// across appends to the same gene's list). Address stability is
+    /// preserved under the per-query arena because arenas only grow —
+    /// past allocations are never relocated.
+    ///
+    /// The string keys are NOT owned by this map — they are shared with
+    /// `paths` and `scores`, which are populated by the same `initCache`
+    /// call (item 5 of #342). `scores` owns the duped key bytes; `clear()`
+    /// frees keys only when iterating `scores` to avoid a triple-free.
+    scratch_cachefo: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(*TrellisEntry)),
+    /// paths_: gene → (KSet → TracebackPath). Keys are borrowed (see
+    /// `scratch_cachefo` doc-block); the canonical owner is `scores`.
+    paths: std.StringHashMapUnmanaged(std.AutoHashMapUnmanaged(KSet, TracebackPath)),
+    /// scores_: gene → (KSet → f64). Owns the gene-name keys shared with
+    /// `scratch_cachefo` and `paths` (item 5 of #342).
+    scores: std.StringHashMapUnmanaged(std.AutoHashMapUnmanaged(KSet, f64)),
+    /// per_gene_support_: gene → best full-annotation log-prob
+    per_gene_support: std.StringHashMapUnmanaged(f64),
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        algorithm: []const u8,
+        args: *Args,
+        gl: *GermLines,
+        hmms: *HMMHolder,
+    ) !DPHandler {
+        return DPHandler{
+            .algorithm = algorithm,
+            .args = args,
+            .gl = gl,
+            .hmms = hmms,
+            .parent_allocator = allocator,
+            .query_arena = std.heap.ArenaAllocator.init(allocator),
+            .scratch_cachefo = .{},
+            .paths = .{},
+            .scores = .{},
+            .per_gene_support = .{},
+        };
+    }
+
+    /// Per-query scratch allocator. **Always re-derive at the use site** —
+    /// caching `arena.allocator()` in a struct field would silently break
+    /// after a DPHandler move, since the returned `Allocator.ptr` points
+    /// at the arena's address at call time. (Item 4, #342.)
+    pub inline fn scratchAllocator(self: *DPHandler) std.mem.Allocator {
+        return self.query_arena.allocator();
+    }
+
+    pub fn deinit(self: *DPHandler) void {
+        self.clear();
+        self.query_arena.deinit();
+    }
+
+    /// Clear all cached trellis data.
+    /// Corresponds to C++ `DPHandler::Clear`.
+    ///
+    /// Under the per-query arena (item 4, #342), every individual `free` /
+    /// `destroy` / `deinit` below is a no-op — the arena reset at the end
+    /// reclaims everything in one shot. The explicit cleanup loops are kept
+    /// as documentation and as a safety belt: they make the ownership
+    /// graph readable, and if a future change ever pulls one of these
+    /// allocations off the arena and back onto a real allocator, the
+    /// existing `free` will keep doing the right thing.
+    pub fn clear(self: *DPHandler) void {
+        const allocator = self.scratchAllocator();
+
+        // Free scratch_cachefo. Each *TrellisEntry is heap-allocated and the
+        // entry's trellis borrows from the inline `query_seqs`. Deinit the
+        // trellis first (it doesn't own seqs but may use seq_len etc.), then
+        // the Sequences, then destroy the entry struct itself.
+        // Keys are shared with `paths` and `scores` (item 5 of #342); freed
+        // once below when iterating `scores`.
+        var cit = self.scratch_cachefo.iterator();
+        while (cit.next()) |entry| {
+            for (entry.value_ptr.items) |te| {
+                te.trellis.deinit();
+                te.query_seqs.deinit(allocator);
+                allocator.destroy(te);
+            }
+            entry.value_ptr.deinit(allocator);
+        }
+        self.scratch_cachefo.deinit(allocator);
+        self.scratch_cachefo = .{};
+
+        // Free paths. Keys are shared with `scores` (see above).
+        var pit = self.paths.iterator();
+        while (pit.next()) |entry| {
+            var inner_it = entry.value_ptr.iterator();
+            while (inner_it.next()) |kv| kv.value_ptr.deinit(allocator);
+            entry.value_ptr.deinit(allocator);
+        }
+        self.paths.deinit(allocator);
+        self.paths = .{};
+
+        // Free scores. This is the canonical owner of the gene-name keys
+        // shared with `scratch_cachefo` and `paths`.
+        var sit = self.scores.iterator();
+        while (sit.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+            entry.value_ptr.deinit(allocator);
+        }
+        self.scores.deinit(allocator);
+        self.scores = .{};
+
+        // Free per_gene_support
+        var pgit = self.per_gene_support.iterator();
+        while (pgit.next()) |entry| allocator.free(entry.key_ptr.*);
+        self.per_gene_support.deinit(allocator);
+        self.per_gene_support = .{};
+
+        // Reset the per-query arena: this is what actually reclaims memory
+        // (the loops above are no-ops on the arena). Retains capacity so
+        // the next run() in handleFishyAnnotations reuses the backing pages.
+        _ = self.query_arena.reset(.retain_capacity);
+    }
+
+    /// Run the DP for a single Sequence.
+    /// Corresponds to C++ `DPHandler::Run(Sequence, ...)`.
+    /// The Sequence's heap buffers (name/header/undigitized/seqq) are borrowed
+    /// for the duration of the call; the caller retains ownership.
+    pub fn runSeq(
+        self: *DPHandler,
+        seq: *const Sequence,
+        kbounds: KBounds,
+        only_gene_list: []const []const u8,
+        overall_mute_freq: f64,
+        clear_cache: bool,
+    ) !Result {
+        const seqvec = [_]*const Sequence{seq};
+        return self.run(&seqvec, kbounds, only_gene_list, overall_mute_freq, clear_cache);
+    }
+
+    /// Run the DP over a vector of sequences.
+    /// Corresponds to C++ `DPHandler::Run(vector<Sequence>, ...)`.
+    /// `seqvector` is borrowed: each pointed-to Sequence's heap buffers must
+    /// outlive the call; the internal Sequences container holds shallow
+    /// struct-copies that share those buffers (items 2 + 16 of issue #342).
+    /// The container's items are not deinit'd at function end — only the
+    /// backing array allocation is freed.
+    pub fn run(
+        self: *DPHandler,
+        seqvector: []const *const Sequence,
+        kbounds: KBounds,
+        only_gene_list: []const []const u8,
+        overall_mute_freq: f64,
+        clear_cache: bool,
+    ) !Result {
+        // Per-query scratch arena: every internal allocation routes here.
+        // `parent` is reserved for the returned Result and any RecoEvent
+        // strings the caller will read after run() exits. Item 4, #342.
+        //
+        // `clear_cache` MUST run before any per-call scratch allocations.
+        // `clear()` resets the arena, which would invalidate any seqs /
+        // only_genes / etc. already built off `scratchAllocator()`.
+        if (clear_cache) self.clear();
+        const allocator = self.scratchAllocator();
+        const parent = self.parent_allocator;
+        const run_start = std.time.milliTimestamp();
+
+        // Phase-0 diagnostics (#366): per-query counter reset. No-op when
+        // `-Dperf-counters=false` (default), so the bit-equal default build
+        // is unaffected.
+        perf_counters.reset();
+        // Phase-B outer-perimeter timer: total time inside this run() body
+        // (excluding the reset() above). Tick AFTER reset so reset doesn't
+        // wipe it. Read in `dumpPerfCounters` via a final `addElapsed` at
+        // each exit point that dumps; non-dumping early returns leak the
+        // tick but contribute zero work.
+        const t_run = perf_counters.tick();
+
+        // Build a Sequences container that borrows from `seqvector`.
+        // Each Sequence is a shallow struct-copy: slice headers are duplicated,
+        // but the underlying name/header/undigitized/seqq buffers are shared
+        // with `seqvector`. We must not deinit the items at end-of-call —
+        // only the backing array allocation is freed.
+        var seqs = Sequences.init();
+        defer seqs.seqs.deinit(allocator);
+        try seqs.seqs.ensureTotalCapacityPrecise(allocator, seqvector.len);
+        for (seqvector) |sq_ptr| {
+            const sq = sq_ptr.*;
+            if (seqs.seqs.items.len == 0) {
+                seqs.sequence_length = sq.size();
+            } else if (sq.size() != seqs.sequence_length) {
+                return error.SequenceLengthMismatch;
+            }
+            seqs.seqs.appendAssumeCapacity(sq);
+        }
+
+        // Build only_genes map: region → set of gene names
+        var only_genes: std.AutoHashMapUnmanaged(Region, std.StringHashMapUnmanaged(void)) = .{};
+        defer {
+            var oit = only_genes.iterator();
+            while (oit.next()) |entry| {
+                var inner_it = entry.value_ptr.iterator();
+                while (inner_it.next()) |kv| allocator.free(kv.key_ptr.*);
+                entry.value_ptr.deinit(allocator);
+            }
+            only_genes.deinit(allocator);
+        }
+
+        if (only_gene_list.len > 0) {
+            for (bcr.germ_lines.regions) |r| {
+                try only_genes.put(allocator, r, .{});
+            }
+            for (only_gene_list) |gene| {
+                const r = try GermLines.getRegion(gene);
+                if (only_genes.getPtr(r)) |set| {
+                    const gkey = try allocator.dupe(u8, gene);
+                    errdefer allocator.free(gkey);
+                    try set.put(allocator, gkey, {});
+                }
+            }
+            // Validate each region has at least one gene
+            for (bcr.germ_lines.regions) |r| {
+                const set = only_genes.get(r) orelse return error.NoGenesForRegion;
+                if (set.count() == 0) return error.NoGenesForRegion;
+            }
+        } else {
+            // Populate from GermLines
+            for (bcr.germ_lines.regions) |r| {
+                var set: std.StringHashMapUnmanaged(void) = .{};
+                if (self.gl.names.get(regionStr(r))) |name_list| {
+                    for (name_list.items) |gene| {
+                        try set.put(allocator, try allocator.dupe(u8, gene), {});
+                    }
+                }
+                try only_genes.put(allocator, r, set);
+            }
+        }
+
+        if (kbounds.vmin == 0 or kbounds.dmin == 0 or
+            kbounds.vmax <= kbounds.vmin or kbounds.dmax <= kbounds.dmin)
+            return error.TrivialKBounds;
+
+        var best_scores: std.AutoHashMapUnmanaged(KSet, f64) = .{};
+        defer best_scores.deinit(allocator);
+        var total_scores: std.AutoHashMapUnmanaged(KSet, f64) = .{};
+        defer total_scores.deinit(allocator);
+        var best_genes: std.AutoHashMapUnmanaged(KSet, std.AutoHashMapUnmanaged(Region, []u8)) = .{};
+        defer {
+            var bgit = best_genes.iterator();
+            while (bgit.next()) |entry| {
+                var inner = entry.value_ptr.iterator();
+                while (inner.next()) |kv| {
+                    allocator.free(kv.value_ptr.*);
+                }
+                entry.value_ptr.deinit(allocator);
+            }
+            best_genes.deinit(allocator);
+        }
+
+        if (!self.args.dont_rescale_emissions) {
+            try self.hmms.rescaleOverallMuteFreqs(&only_genes, overall_mute_freq);
+        }
+
+        var result = try Result.init(parent, kbounds, self.args.locus);
+
+        var best_score: f64 = mathutils.NEG_INF;
+        var best_kset = KSet{ .v = 0, .d = 0 };
+        var n_too_long: usize = 0;
+        var n_run: usize = 0;
+        var n_total: usize = 0;
+
+        // Loop over k-space in reverse order (for chunk caching)
+        var k_v: usize = kbounds.vmax - 1;
+        while (true) {
+            var k_d: usize = kbounds.dmax - 1;
+            while (true) {
+                n_total += 1;
+                if (k_v + k_d >= seqs.sequence_length) {
+                    n_too_long += 1;
+                } else {
+                    const kset = KSet{ .v = k_v, .d = k_d };
+                    perf_counters.bumpKSet();
+                    try self.runKSet(&seqs, kset, &only_genes, &best_scores, &total_scores, &best_genes);
+                    n_run += 1;
+                    const total_kset = total_scores.get(kset) orelse mathutils.NEG_INF;
+                    result.total_score = mathutils.addInLogSpace(total_kset, result.total_score);
+                    if (self.args.debug == 2 and std.mem.eql(u8, self.algorithm, "forward")) {
+                        const fwd_msg = try std.fmt.allocPrint(allocator, "            {d: >12.6} ({e:.1})  tot: {d: >12.6}\n", .{ total_kset, @as(f64, @exp(total_kset)), result.total_score });
+                        defer allocator.free(fwd_msg);
+                        try std.fs.File.stdout().writeAll(fwd_msg);
+                    }
+
+                    const best_kset_score = best_scores.get(kset) orelse mathutils.NEG_INF;
+                    if (best_kset_score > best_score) {
+                        best_score = best_kset_score;
+                        best_kset = kset;
+                    }
+
+                    if (std.mem.eql(u8, self.algorithm, "viterbi") and best_kset_score != mathutils.NEG_INF) {
+                        const bg = best_genes.get(kset) orelse continue;
+                        const event = try self.fillRecoEvent(&seqs, kset, &bg, best_kset_score);
+                        try result.pushBackRecoEvent(event);
+                    }
+                }
+                if (k_d == kbounds.dmin) break;
+                k_d -= 1;
+            }
+            if (k_v == kbounds.vmin) break;
+            k_v -= 1;
+        }
+        if (self.args.debug > 0 and n_too_long > 0) {
+            const skip_msg = try std.fmt.allocPrint(allocator, "      skipped {d} (of {d}) k sets 'cause they were longer than the sequence (ran {d})\n", .{ n_too_long, n_total, n_run });
+            defer allocator.free(skip_msg);
+            try std.fs.File.stdout().writeAll(skip_msg);
+        }
+
+        // No valid path
+        if (best_kset.v == 0 and best_kset.d == 0) {
+            const name_str = try seqs.nameStr(allocator, " "); // C++ name_str() default delimiter is space (sequences.h:62)
+            defer allocator.free(name_str);
+            const no_path_msg = try std.fmt.allocPrint(allocator, "    no valid paths for query {s}\n", .{name_str});
+            defer allocator.free(no_path_msg);
+            try std.fs.File.stdout().writeAll(no_path_msg);
+            result.no_path = true;
+            if (!self.args.dont_rescale_emissions) {
+                try self.hmms.unRescaleOverallMuteFreqs(&only_genes);
+            }
+            perf_counters.addElapsed(&perf_counters.dpHandler_run_total_ns, t_run);
+            // Accumulate into the process-lifetime counter for Glomerator
+            // attribution. dpHandler_run_total_ns gets reset() to zero on
+            // the next run() entry, so we mirror it here BEFORE the reset.
+            // `comptime` so the dead-write in Debug builds collapses too.
+            if (comptime perf_counters.enabled) {
+                perf_counters.cumul_dpHandler_run_ns +%= perf_counters.dpHandler_run_total_ns;
+            }
+            if (comptime perf_counters.enabled) try self.dumpPerfCounters(&seqs);
+            return result;
+        }
+
+        if (std.mem.eql(u8, self.algorithm, "viterbi")) {
+            try result.finalize(self.gl, &self.per_gene_support, best_kset, kbounds);
+        }
+
+        // Debug: summary line (debug >= 1)
+        if (self.args.debug > 0) {
+            const prob: f64 = if (std.mem.eql(u8, self.algorithm, "viterbi")) best_score else result.total_score;
+            const alg_str: []const u8 = if (std.mem.eql(u8, self.algorithm, "viterbi")) "vtb" else "fwd";
+            var kstr_buf: [300]u8 = undefined;
+            const kstr = if (std.mem.eql(u8, self.algorithm, "viterbi"))
+                try std.fmt.bufPrint(&kstr_buf, "{d} [{d}-{d})  {d} [{d}-{d})", .{ best_kset.v, kbounds.vmin, kbounds.vmax, best_kset.d, kbounds.dmin, kbounds.dmax })
+            else
+                try std.fmt.bufPrint(&kstr_buf, "    [{d}-{d})     [{d}-{d})", .{ kbounds.vmin, kbounds.vmax, kbounds.dmin, kbounds.dmax });
+            const n_v = if (only_genes.get(.v)) |s| s.count() else 0;
+            const n_d = if (only_genes.get(.d)) |s| s.count() else 0;
+            const n_j = if (only_genes.get(.j)) |s| s.count() else 0;
+            const name_str = try seqs.nameStr(allocator, ":");
+            defer allocator.free(name_str);
+            const elapsed_ms = std.time.milliTimestamp() - run_start;
+            const cpu_seconds = @as(f64, @floatFromInt(elapsed_ms)) / 1000.0;
+            const summary = try std.fmt.allocPrint(allocator, "           {s} {d: >15.6}   {s: <25}  {d: >2}v {d: >2}d {d: >2}j  {d: >5.2}s   {d: >4}  {s}\n", .{ alg_str, prob, kstr, n_v, n_d, n_j, cpu_seconds, seqs.nSeqs(), name_str });
+            defer allocator.free(summary);
+            try std.fs.File.stdout().writeAll(summary);
+        }
+
+        if (!self.args.dont_rescale_emissions) {
+            try self.hmms.unRescaleOverallMuteFreqs(&only_genes);
+        }
+
+        perf_counters.addElapsed(&perf_counters.dpHandler_run_total_ns, t_run);
+        // See the no-path early-return above for the rationale: mirror
+        // into the process-lifetime cumul before the next reset() fires.
+        // `comptime` so the dead-write in Debug builds collapses too.
+        if (comptime perf_counters.enabled) {
+            perf_counters.cumul_dpHandler_run_ns +%= perf_counters.dpHandler_run_total_ns;
+        }
+        if (comptime perf_counters.enabled) try self.dumpPerfCounters(&seqs);
+        return result;
+    }
+
+    /// Phase-0 diagnostics dump (#366). No-op when `-Dperf-counters=false`.
+    /// Emits one PERFCOUNTER and one PERFCOUNTER_CACHE line per query.
+    ///
+    /// Output target: file path from `PARTIS_ZIG_PERF_LOG` env var (append).
+    /// Side-channel rather than stdout because partis captures bcrham stdout
+    /// and discards everything except recognised dbgstrs (utils.py:5896+);
+    /// the env-var redirect keeps the diagnostic output entirely outside
+    /// the partis input/output protocol so partis-test.py's parity checks
+    /// stay clean. When the env var is unset, the dump is silent.
+    fn dumpPerfCounters(self: *DPHandler, seqs: *const Sequences) !void {
+        if (!perf_counters.enabled) return;
+        const allocator = self.scratchAllocator();
+
+        const log_path = std.process.getEnvVarOwned(allocator, "PARTIS_ZIG_PERF_LOG") catch |err| switch (err) {
+            error.EnvironmentVariableNotFound => return,
+            else => return err,
+        };
+        defer allocator.free(log_path);
+
+        const name_str = try seqs.nameStr(allocator, ":");
+        defer allocator.free(name_str);
+
+        // cache_list length histogram across all genes in scratch_cachefo.
+        // Buckets are log-ish (0,1,2,3,4,5,[6-9],[10-19],[20-49],[50-99],
+        // [100-199],[200+]) — matches the order-of-magnitude questions the
+        // issue asks about chunk-cache state.
+        var buckets = [_]u64{0} ** 12;
+        var it = self.scratch_cachefo.iterator();
+        while (it.next()) |entry| {
+            const n = entry.value_ptr.items.len;
+            const idx: usize =
+                if (n == 0) 0 else if (n == 1) 1 else if (n == 2) 2 else if (n == 3) 3 else if (n == 4) 4 else if (n == 5) 5 else if (n < 10) 6 else if (n < 20) 7 else if (n < 50) 8 else if (n < 100) 9 else if (n < 200) 10 else 11;
+            buckets[idx] += 1;
+        }
+
+        // Build the PERFCOUNTER + PERFCOUNTER_CACHE + PERFCOUNTER_TIMING
+        // block in one buffer and emit with a single writeAll. With
+        // multiple bcrham processes appending to the same log
+        // (`partis --n-procs N > 1`), splitting this into multiple writes
+        // would let another process slip a line between ours, separating
+        // the trio. Concatenated, all three share one O_APPEND atomic
+        // write.
+        const main_line = (try perf_counters.formatPerfCounters(allocator, self.algorithm, name_str, seqs.seqs.items.len)) orelse return;
+        defer allocator.free(main_line);
+        const cache_line = try std.fmt.allocPrint(
+            allocator,
+            "PERFCOUNTER_CACHE alg={s} q={s} 0={d} 1={d} 2={d} 3={d} 4={d} 5={d} 6_9={d} 10_19={d} 20_49={d} 50_99={d} 100_199={d} 200p={d}\n",
+            .{ self.algorithm, name_str, buckets[0], buckets[1], buckets[2], buckets[3], buckets[4], buckets[5], buckets[6], buckets[7], buckets[8], buckets[9], buckets[10], buckets[11] },
+        );
+        defer allocator.free(cache_line);
+        const timing_line = (try perf_counters.formatPerfCountersTiming(allocator, self.algorithm, name_str, seqs.seqs.items.len)) orelse return;
+        defer allocator.free(timing_line);
+        const blob = try std.mem.concat(allocator, u8, &.{ main_line, cache_line, timing_line });
+        defer allocator.free(blob);
+
+        // O_APPEND on regular files: Linux serializes the
+        // seek-to-end-and-write pair at the syscall level, so each
+        // writeAll lands as one atomic append regardless of size — there
+        // is no PIPE_BUF-style upper bound for regular files. (PIPE_BUF
+        // applies to pipes, not files.) Concurrent bcrham processes
+        // therefore can't interleave the bytes of a single writeAll.
+        const log_path_z = try allocator.dupeZ(u8, log_path);
+        defer allocator.free(log_path_z);
+        const flags: std.posix.O = .{ .ACCMODE = .WRONLY, .APPEND = true, .CREAT = true };
+        const fd = try std.posix.openZ(log_path_z, flags, 0o644);
+        const file = std.fs.File{ .handle = fd };
+        defer file.close();
+        try file.writeAll(blob);
+    }
+
+    /// Get subsequences for one region.
+    /// Corresponds to C++ `DPHandler::GetSubSeqs(seqs, kset, region)`.
+    ///
+    /// `allocator` is taken explicitly so the caller (`runKSet`) can route
+    /// the per-region clones through its per-kset arena rather than the
+    /// per-query arena. The clone strings live only for the region's
+    /// inner loop. (Item 4, #342.)
+    ///
+    /// Free function (no `self` access): nothing here reads DPHandler state.
+    fn getSubSeqs(allocator: std.mem.Allocator, seqs: *const Sequences, kset: KSet, region: Region) !Sequences {
+        var result = Sequences.init();
+        errdefer result.deinit(allocator);
+
+        const k_v = kset.v;
+        const k_d = kset.d;
+        const start: usize = switch (region) {
+            .v => 0,
+            .d => k_v,
+            .j => k_v + k_d,
+        };
+        const length: usize = switch (region) {
+            .v => k_v,
+            .d => k_d,
+            .j => seqs.sequence_length - k_v - k_d,
+        };
+
+        for (seqs.seqs.items) |*sq| {
+            var sub = try Sequence.initSlice(allocator, sq, start, length);
+            errdefer sub.deinit(allocator);
+            try result.addSeq(allocator, sub);
+        }
+        return result;
+    }
+
+    /// Borrow the undigitized strings of `seqs` into a freshly-allocated slice
+    /// of `[]const u8` (slice-of-slices, no string copies). The returned slice
+    /// is allocated with `allocator` and must be `free`d by the caller; the
+    /// individual strings borrow into `seqs.seqs.items[i].undigitized` and
+    /// must not outlive `seqs`.
+    fn borrowQueryStrs(allocator: std.mem.Allocator, seqs: *const Sequences) ![][]const u8 {
+        const out = try allocator.alloc([]const u8, seqs.seqs.items.len);
+        for (seqs.seqs.items, 0..) |*sq, i| out[i] = sq.undigitized;
+        return out;
+    }
+
+    /// Ensure per-gene caches are initialised for `gene`.
+    /// One duped key is shared across `scratch_cachefo`, `paths`, and `scores`
+    /// (item 5 of #342). All three maps live on `query_arena` and are torn
+    /// down together by `clear()` / `deinit()`, so shared ownership is safe.
+    /// Capacity is reserved up front so the puts cannot fail after the dupe,
+    /// keeping the failure mode obvious if these maps ever move off the arena.
+    fn initCache(self: *DPHandler, gene: []const u8) !void {
+        if (self.scores.contains(gene)) return;
+
+        const allocator = self.scratchAllocator();
+        try self.scratch_cachefo.ensureUnusedCapacity(allocator, 1);
+        try self.paths.ensureUnusedCapacity(allocator, 1);
+        try self.scores.ensureUnusedCapacity(allocator, 1);
+
+        const key = try allocator.dupe(u8, gene);
+        self.scratch_cachefo.putAssumeCapacity(key, .{});
+        self.paths.putAssumeCapacity(key, .{});
+        self.scores.putAssumeCapacity(key, .{});
+    }
+
+    /// Look for a cached kset whose region sequences are a prefix of the
+    /// query's per-region undigitized strings (built via `getSubSeqs`).
+    /// Returns null-kset if none found. `gene_scores` is the per-gene
+    /// inner map hoisted by the caller (see `PerGeneCache`); replaces
+    /// the prior `self.scores.get(gene)` lookup at this site.
+    fn findPartialCacheMatch(_: *DPHandler, region: Region, gene_scores: *const std.AutoHashMapUnmanaged(KSet, f64), kset: KSet) KSet {
+        if (gene_scores.get(kset) != null) return kset;
+
+        switch (region) {
+            .v => {
+                // C++ map<KSet,double> iterates in ascending (v,d) order, so
+                // it returns the smallest-d match. We must replicate that.
+                var best: ?KSet = null;
+                var it = gene_scores.iterator();
+                while (it.next()) |kv| {
+                    if (kv.key_ptr.v == kset.v) {
+                        if (best == null or kv.key_ptr.d < best.?.d)
+                            best = kv.key_ptr.*;
+                    }
+                }
+                if (best) |b| return b;
+            },
+            .j => {
+                var best: ?KSet = null;
+                var it = gene_scores.iterator();
+                while (it.next()) |kv| {
+                    if (kv.key_ptr.v + kv.key_ptr.d == kset.v + kset.d) {
+                        if (best == null or kv.key_ptr.v < best.?.v or
+                            (kv.key_ptr.v == best.?.v and kv.key_ptr.d < best.?.d))
+                            best = kv.key_ptr.*;
+                    }
+                }
+                if (best) |b| return b;
+            },
+            .d => {},
+        }
+        return KSet{ .v = 0, .d = 0 };
+    }
+
+    /// Fill the trellis for the given (gene, kset, query_seqs).
+    /// Stores result in scores_[gene][kset] and (for viterbi) paths_[gene][kset].
+    /// `query_seqs` is borrowed; its lifetime must span the call. For the
+    /// fresh path (no chunk-cache hit), the trellis is stored in
+    /// `scratch_cachefo[gene]` and a clone of `query_seqs` is heap-allocated
+    /// to give the stored trellis a stable, long-lived borrow target.
+    /// `kset_alloc` is the per-kset arena. Used **only** for the chunk-cache
+    /// temp trellis (its scoring buffers and traceback_table are reset at
+    /// end-of-kset). Everything that lives across ksets — `scratch_cachefo`
+    /// entries, `paths`, `scores` — uses `scratchAllocator()`. The
+    /// traceback path's items are explicitly routed through `scratch` even
+    /// when the temp trellis runs viterbi: they are stored in `self.paths`
+    /// and outlive the kset. (Item 4, #342.)
+    fn fillTrellis(
+        self: *DPHandler,
+        kset_alloc: std.mem.Allocator,
+        kset: KSet,
+        query_seqs: *const Sequences,
+        gene: []const u8,
+        gc: *const PerGeneCache,
+    ) ![]const u8 {
+        const allocator = self.scratchAllocator();
+        perf_counters.bumpFillTrellis();
+        // Phase-B: time the whole fillTrellis body so we can divide the
+        // chunkScan/init/tmpInit/viterbi/forward/traceback/put numbers by
+        // their parent total instead of by bcrham wall (which includes
+        // runKSet overhead and the cache-hit path).
+        const t_total = perf_counters.tick();
+        defer perf_counters.addElapsed(&perf_counters.fillTrellis_total_ns, t_total);
+
+        // Look for a chunk-cached trellis. Prefix-match is on undigitized
+        // strings of the cached trellis's stored query_seqs.
+        var cached_trellis: ?*const Trellis = null;
+        if (!self.args.no_chunk_cache) {
+            perf_counters.bumpChunkCacheLookup();
+            const t_scan = perf_counters.tick();
+            for (gc.cachefo.items) |te| {
+                const cached_seqs = te.query_seqs.seqs.items;
+                const current_seqs = query_seqs.seqs.items;
+                if (cached_seqs.len != current_seqs.len) continue;
+                var all_match = true;
+                for (cached_seqs, current_seqs) |*cached, *current| {
+                    // cached must START WITH current (prefix match)
+                    if (!std.mem.startsWith(u8, cached.undigitized, current.undigitized)) {
+                        all_match = false;
+                        break;
+                    }
+                }
+                if (all_match) {
+                    cached_trellis = &te.trellis;
+                    perf_counters.bumpChunkCacheHit();
+                    break;
+                }
+            }
+            perf_counters.addElapsed(&perf_counters.fillTrellis_chunkScan_ns, t_scan);
+        }
+
+        // Match C++ DPHandler::FillTrellis logic exactly:
+        //   - When no cached trellis: create scratch, store it, run algorithm ON THE SCRATCH directly.
+        //   - When cached trellis exists: create a temp trellis that borrows from the cache,
+        //     run algorithm on the temp trellis.
+        // This is critical: when no cache, do NOT create a second trellis that borrows from
+        // the (empty) scratch — the scratch itself is the working trellis.
+
+        // trell_ptr points to the trellis on which the algorithm is run.
+        // tmptrell is only used when borrowing from a cached trellis.
+        var tmptrell: ?Trellis = null;
+        defer if (tmptrell) |*t| t.deinit();
+
+        // Lazy model load. We do NOT hoist this into PerGeneCache: the
+        // original code only paid `hmms.get(gene)` on the cache-miss path
+        // (the cache-hit path in runKSet uses `cached_path.hmm.?` instead).
+        // Phase 0 reports cache-hit at 78–86% of ksets, so hoisting model
+        // would *add* a per-kset `hmms.get` call to that majority path.
+        const model = try self.hmms.get(gene);
+
+        var origin: []const u8 = "scratch";
+        const trell_ptr: *Trellis = if (cached_trellis == null) blk: {
+            // No cache: heap-allocate a TrellisEntry to give the stored trellis
+            // a stable borrow target. Inline `query_seqs` lives at a fixed offset
+            // from the entry's heap address, so `trellis.seqs = &entry.query_seqs`
+            // stays valid across cache_list appends (which only move the *entry
+            // pointers in the list, not the entries themselves).
+            const t_init = perf_counters.tick();
+            const entry = try allocator.create(TrellisEntry);
+            errdefer allocator.destroy(entry);
+            entry.query_seqs = try query_seqs.clone(allocator);
+            errdefer entry.query_seqs.deinit(allocator);
+            entry.trellis = try Trellis.initWithSeqs(allocator, model, &entry.query_seqs, null);
+            errdefer entry.trellis.deinit();
+
+            // gc.cachefo is guaranteed non-null by the caller (initCache
+            // ran before the gc was built — see PerGeneCache doc-block).
+            try gc.cachefo.append(allocator, entry);
+            perf_counters.addElapsed(&perf_counters.fillTrellis_init_ns, t_init);
+            break :blk &entry.trellis;
+        } else blk: {
+            // Have cache: temp trellis borrows from the caller's query_seqs
+            // (no clone — lifetime is just this call). Backed by the per-kset
+            // arena (`kset_alloc`): scoring buffers + traceback_table are
+            // reset at end-of-kset rather than accumulating across ksets in
+            // the per-query arena. Worst case under the per-query arena
+            // would be n_genes × n_ksets × seq_len × n_states × 2 bytes per
+            // viterbi-mode query — hundreds of MB on annotation workloads.
+            // The path items below are explicitly routed through `allocator`
+            // (per-query scratch), not `kset_alloc`, since they're stored in
+            // `self.paths` and outlive the kset. (Item 4, #342.)
+            const t_tmpInit = perf_counters.tick();
+            tmptrell = try Trellis.initWithSeqs(kset_alloc, model, query_seqs, cached_trellis);
+            perf_counters.addElapsed(&perf_counters.fillTrellis_tmpInit_ns, t_tmpInit);
+            origin = "chunk";
+            break :blk &tmptrell.?;
+        };
+
+        // Run the algorithm on trell_ptr
+        const uncorrected_score: f64 = if (std.mem.eql(u8, self.algorithm, "viterbi")) blk: {
+            const t_vit = perf_counters.tick();
+            try trell_ptr.viterbi();
+            perf_counters.addElapsed(&perf_counters.fillTrellis_viterbi_ns, t_vit);
+            const sc = trell_ptr.ending_viterbi_log_prob;
+            // Store traceback path
+            var path = TracebackPath.initWithModel(model);
+            errdefer path.deinit(allocator);
+            if (sc != mathutils.NEG_INF) {
+                // Explicitly pass `allocator` (per-query scratch) so the path's
+                // items don't capture the temp trellis's per-kset arena.
+                const t_tb = perf_counters.tick();
+                try trell_ptr.traceback(allocator, &path);
+                perf_counters.addElapsed(&perf_counters.fillTrellis_traceback_ns, t_tb);
+            }
+            const t_put_p = perf_counters.tick();
+            try gc.paths.put(allocator, kset, path);
+            perf_counters.addElapsed(&perf_counters.fillTrellis_put_ns, t_put_p);
+            break :blk sc;
+        } else blk: {
+            const t_fwd = perf_counters.tick();
+            try trell_ptr.forward();
+            perf_counters.addElapsed(&perf_counters.fillTrellis_forward_ns, t_fwd);
+            break :blk trell_ptr.ending_forward_log_prob;
+        };
+
+        const gene_choice_score = log(model.overall_prob);
+        const final_score = mathutils.addWithMinusInfinities(uncorrected_score, gene_choice_score);
+
+        const t_put_s = perf_counters.tick();
+        try gc.scores.put(allocator, kset, final_score);
+        perf_counters.addElapsed(&perf_counters.fillTrellis_put_ns, t_put_s);
+
+        return origin;
+    }
+
+    /// Print colored germline alignment for a gene path (debug==2 viterbi output).
+    /// Corresponds to C++ `DPHandler::PrintPath`.
+    fn printPath(self: *DPHandler, kset: KSet, query_strs: []const []const u8, gene: []const u8, score: f64, extra_str: []const u8) !void {
+        const allocator = self.scratchAllocator();
+        if (score == mathutils.NEG_INF) return;
+
+        const path_names_list = try self.getPathNames(gene, kset, allocator);
+        defer {
+            for (path_names_list.items) |s| allocator.free(s);
+            var pl = path_names_list;
+            pl.deinit(allocator);
+        }
+        if (path_names_list.items.len == 0) {
+            if (self.args.debug > 0) {
+                const msg = try std.fmt.allocPrint(allocator, "                     {s} has no valid path\n", .{gene});
+                defer allocator.free(msg);
+                try std.fs.File.stdout().writeAll(msg);
+            }
+            return;
+        }
+
+        const path_names = path_names_list.items;
+        var buf_l: [200]u8 = undefined;
+        const left_insert = getInsertion("left", path_names, &buf_l);
+        var buf_r: [200]u8 = undefined;
+        const right_insert = getInsertion("right", path_names, &buf_r);
+        const left_erosion_length = self.getErosionLength("left", path_names, gene);
+        const right_erosion_length = self.getErosionLength("right", path_names, gene);
+
+        // Build modified germline: left_insert + trimmed_germline + right_insert
+        const germline = self.gl.seqs.get(gene) orelse return;
+        const mid_end = if (germline.len >= right_erosion_length) germline.len - right_erosion_length else 0;
+        const mid = if (left_erosion_length <= mid_end) germline[left_erosion_length..mid_end] else "";
+
+        var mg_buf: std.ArrayListUnmanaged(u8) = .{};
+        defer mg_buf.deinit(allocator);
+        try mg_buf.appendSlice(allocator, left_insert);
+        try mg_buf.appendSlice(allocator, mid);
+        try mg_buf.appendSlice(allocator, right_insert);
+        const modified_germline = mg_buf.items;
+
+        // Get ambiguous char from args (matches C++ hmms_.track()->ambiguous_char())
+        const ambig = self.args.ambig_base;
+
+        // Color the match: mutants in red relative to query strings, ambiguous in light_blue
+        const match_colored = try TermColors.colorMutants(allocator, "red", modified_germline, "", query_strs, ambig);
+        defer allocator.free(match_colored);
+        const ambig_ch: u8 = if (ambig.len > 0) ambig[0] else 0;
+        const match_str_inner = if (ambig_ch != 0)
+            try TermColors.colorChars(allocator, ambig_ch, "light_blue", match_colored)
+        else
+            try allocator.dupe(u8, match_colored);
+        defer allocator.free(match_str_inner);
+
+        // Build output with erosion decorations
+        var out_buf: std.ArrayListUnmanaged(u8) = .{};
+        defer out_buf.deinit(allocator);
+
+        if (left_erosion_length > 0) {
+            var le_buf: [16]u8 = undefined;
+            const le_str = try std.fmt.bufPrint(&le_buf, "{d}", .{left_erosion_length});
+            const pad = if (le_str.len < 2) @as(usize, 2) - le_str.len else @as(usize, 0);
+            try out_buf.appendNTimes(allocator, ' ', pad);
+            try out_buf.append(allocator, '.');
+            try out_buf.appendSlice(allocator, le_str);
+            try out_buf.append(allocator, '.');
+        } else {
+            try out_buf.appendSlice(allocator, "    ");
+        }
+        try out_buf.appendSlice(allocator, match_str_inner);
+        if (right_erosion_length > 0) {
+            var re_buf: [16]u8 = undefined;
+            const re_str = try std.fmt.bufPrint(&re_buf, "{d}", .{right_erosion_length});
+            const pad = if (re_str.len < 2) @as(usize, 2) - re_str.len else @as(usize, 0);
+            try out_buf.appendNTimes(allocator, ' ', pad);
+            try out_buf.append(allocator, '.');
+            try out_buf.appendSlice(allocator, re_str);
+            try out_buf.append(allocator, '.');
+        } else {
+            try out_buf.appendSlice(allocator, "    ");
+        }
+
+        // "                    " + match_str + "  " + extra_str + score(w12) + gene(w25)
+        const score_str = try fmtSigFigs(allocator, score, 6);
+        defer allocator.free(score_str);
+        // Pad score to 12 chars right-justified
+        const score_pad = if (score_str.len < 12) @as(usize, 12) - score_str.len else @as(usize, 0);
+        // Pad gene to 25 chars right-justified
+        const gene_pad = if (gene.len < 25) @as(usize, 25) - gene.len else @as(usize, 0);
+
+        var line_buf: std.ArrayListUnmanaged(u8) = .{};
+        defer line_buf.deinit(allocator);
+        try line_buf.appendSlice(allocator, "                    ");
+        try line_buf.appendSlice(allocator, out_buf.items);
+        try line_buf.appendSlice(allocator, "  ");
+        try line_buf.appendSlice(allocator, extra_str);
+        try line_buf.appendNTimes(allocator, ' ', score_pad);
+        try line_buf.appendSlice(allocator, score_str);
+        try line_buf.appendNTimes(allocator, ' ', gene_pad);
+        try line_buf.appendSlice(allocator, gene);
+        try line_buf.append(allocator, '\n');
+        try std.fs.File.stdout().writeAll(line_buf.items);
+
+        // Print insertion indicator line if there were insertions
+        if (left_insert.len + right_insert.len > 0) {
+            var ins_buf: std.ArrayListUnmanaged(u8) = .{};
+            defer ins_buf.deinit(allocator);
+            try ins_buf.appendNTimes(allocator, 'i', left_insert.len);
+            try ins_buf.appendNTimes(allocator, ' ', mid.len);
+            try ins_buf.appendNTimes(allocator, 'i', right_insert.len);
+            const ins_colored = try TermColors.color(allocator, "yellow", ins_buf.items);
+            defer allocator.free(ins_colored);
+            const ins_line = try std.fmt.allocPrint(allocator, "                        {s}  \n", .{ins_colored});
+            defer allocator.free(ins_line);
+            try std.fs.File.stdout().writeAll(ins_line);
+        }
+    }
+
+    /// Run all genes for one kset.
+    ///
+    /// Two arenas are in play here (item 4, #342):
+    ///   - `scratch` (per-query): backs the maps that outlive this kset —
+    ///     `best_scores` / `total_scores` / `best_genes` (passed in, owned
+    ///     by `run()`), the `gene_val` dupe written into `best_genes[kset]`,
+    ///     the cached-path copy stored in `self.paths`, and updates to
+    ///     `self.scores` / `self.per_gene_support`.
+    ///   - `kset_alloc` (per-kset): backs everything that dies at end of
+    ///     this function — `regional_best/total`, `per_gene_support_this_kset`,
+    ///     per-region sub-seq clones, debug-output buffers, sorted-gene
+    ///     slices, and the chunk-cache temp trellis routed through
+    ///     `fillTrellis`. `kset_arena.deinit()` reclaims it all in one shot.
+    fn runKSet(
+        self: *DPHandler,
+        seqs: *Sequences,
+        kset: KSet,
+        only_genes: *std.AutoHashMapUnmanaged(Region, std.StringHashMapUnmanaged(void)),
+        best_scores: *std.AutoHashMapUnmanaged(KSet, f64),
+        total_scores: *std.AutoHashMapUnmanaged(KSet, f64),
+        best_genes: *std.AutoHashMapUnmanaged(KSet, std.AutoHashMapUnmanaged(Region, []u8)),
+    ) !void {
+        // Phase-B outer-perimeter: time the full runKSet body. Pair with
+        // fillTrellis_total_ns + cachedPath_ns to expose runKSet plumbing
+        // (sorted_genes, findPartialCacheMatch, regional_total updates,
+        // per-region sub-seq clones, debug output) as the residual.
+        const t_kset = perf_counters.tick();
+        defer perf_counters.addElapsed(&perf_counters.runKSet_total_ns, t_kset);
+
+        const scratch = self.scratchAllocator();
+        var kset_arena = std.heap.ArenaAllocator.init(self.parent_allocator);
+        defer kset_arena.deinit();
+        const allocator = kset_arena.allocator();
+
+        try best_scores.put(scratch, kset, mathutils.NEG_INF);
+        try total_scores.put(scratch, kset, mathutils.NEG_INF);
+        const bg_entry: std.AutoHashMapUnmanaged(Region, []u8) = .{};
+        try best_genes.put(scratch, kset, bg_entry);
+
+        // Debug: kset header
+        if (self.args.debug == 2) {
+            if (std.mem.eql(u8, self.algorithm, "forward")) {
+                var hdr_buf: [256]u8 = undefined;
+                const s = try std.fmt.bufPrint(&hdr_buf, "         {d: >3}{d: >3} {s: >6} {s: >9}  {s: >7}  {s: >7} {s}\n", .{ kset.v, kset.d, "prob", "logprob", "total", "origin", "---------------" });
+                try std.fs.File.stdout().writeAll(s);
+            } else {
+                var hdr_buf: [256]u8 = undefined;
+                const s = try std.fmt.bufPrint(&hdr_buf, "         {d: >3}{d: >3} {s}\n", .{ kset.v, kset.d, "---------------" });
+                try std.fs.File.stdout().writeAll(s);
+            }
+        }
+
+        var regional_best: std.AutoHashMapUnmanaged(Region, f64) = .{};
+        defer regional_best.deinit(allocator);
+        var regional_total: std.AutoHashMapUnmanaged(Region, f64) = .{};
+        defer regional_total.deinit(allocator);
+        // per_gene_support_this_kset borrows its keys from `only_genes`'s
+        // arena-duped strings (item 22 of #342). `only_genes`'s key bytes
+        // live on the per-query arena (`scratchAllocator()`); they outlive
+        // any single `runKSet` call (per-kset arena dies first), and in
+        // fact persist until the next `clear()` resets the arena.
+        var per_gene_support_this_kset: std.StringHashMapUnmanaged(f64) = .{};
+        defer per_gene_support_this_kset.deinit(allocator);
+
+        for (bcr.germ_lines.regions) |region| {
+            try regional_best.put(allocator, region, mathutils.NEG_INF);
+            try regional_total.put(allocator, region, mathutils.NEG_INF);
+
+            var query_seqs = try getSubSeqs(allocator, seqs, kset, region);
+            defer query_seqs.deinit(allocator);
+
+            // Borrow the undigitized strings (slice headers only — no string copies).
+            // Only the args.debug == 2 paths consume this slice (the region-display
+            // block below and printPath); skip the allocation otherwise.
+            // Lifetime is bounded by query_seqs above.
+            const query_strs: [][]const u8 = if (self.args.debug == 2)
+                try borrowQueryStrs(allocator, &query_seqs)
+            else
+                &.{};
+            defer if (self.args.debug == 2) allocator.free(query_strs);
+
+            // Debug: region query display
+            if (self.args.debug == 2) {
+                const rs = regionStr(region);
+                if (std.mem.eql(u8, self.algorithm, "viterbi")) {
+                    // Get ambiguous char from args (matches C++ hmms_.track()->ambiguous_char())
+                    const ambig = self.args.ambig_base;
+                    const ambig_ch: u8 = if (ambig.len > 0) ambig[0] else 0;
+                    if (query_strs.len > 0) {
+                        const colored = if (ambig_ch != 0)
+                            try TermColors.colorChars(allocator, ambig_ch, "light_blue", query_strs[0])
+                        else
+                            try allocator.dupe(u8, query_strs[0]);
+                        defer allocator.free(colored);
+                        const line = try std.fmt.allocPrint(allocator, "                {s} query {s}\n", .{ rs, colored });
+                        defer allocator.free(line);
+                        try std.fs.File.stdout().writeAll(line);
+                    }
+                    // Additional query strings colored as mutants relative to first
+                    if (query_strs.len > 1) {
+                        for (query_strs[1..]) |qs| {
+                            const mutant = try TermColors.colorMutants(allocator, "purple", qs, "", query_strs, ambig);
+                            defer allocator.free(mutant);
+                            const colored2 = if (ambig_ch != 0)
+                                try TermColors.colorChars(allocator, ambig_ch, "light_blue", mutant)
+                            else
+                                try allocator.dupe(u8, mutant);
+                            defer allocator.free(colored2);
+                            const line = try std.fmt.allocPrint(allocator, "                {s} query {s}\n", .{ rs, colored2 });
+                            defer allocator.free(line);
+                            try std.fs.File.stdout().writeAll(line);
+                        }
+                    }
+                } else {
+                    const line = try std.fmt.allocPrint(allocator, "              {s}\n", .{rs});
+                    defer allocator.free(line);
+                    try std.fs.File.stdout().writeAll(line);
+                }
+            }
+
+            const gene_set = only_genes.get(region) orelse continue;
+            // Collect and sort gene names to match C++ set<string> iteration order
+            const sorted_genes = try allocator.alloc([]const u8, gene_set.count());
+            defer allocator.free(sorted_genes);
+            {
+                var gi = gene_set.iterator();
+                var idx: usize = 0;
+                while (gi.next()) |e| : (idx += 1) sorted_genes[idx] = e.key_ptr.*;
+            }
+            std.mem.sort([]const u8, sorted_genes, {}, struct {
+                fn lessThan(_: void, a: []const u8, b: []const u8) bool {
+                    return std.mem.order(u8, a, b) == .lt;
+                }
+            }.lessThan);
+            for (sorted_genes) |gene| {
+                try self.initCache(gene);
+
+                // Hoist the three gene-keyed inner-map pointers once per
+                // gene-block. After initCache(gene), the outer string-keyed
+                // maps don't grow within this iteration so the inner-slot
+                // pointers stay stable. We deliberately do NOT hoist
+                // `self.hmms.get(gene)` — see PerGeneCache doc-block for the
+                // cache-hit-path regression rationale.
+                const gc = PerGeneCache{
+                    .cachefo = self.scratch_cachefo.getPtr(gene).?,
+                    .paths = self.paths.getPtr(gene).?,
+                    .scores = self.scores.getPtr(gene).?,
+                };
+
+                var origin: []const u8 = "";
+                const partial_match = self.findPartialCacheMatch(region, gc.scores, kset);
+                if (!partial_match.isNull()) {
+                    // Phase-B: time the cache-hit path so we can compare it
+                    // to fillTrellis_total_ns. Excludes findPartialCacheMatch
+                    // above (which runs on both branches).
+                    const t_cached = perf_counters.tick();
+                    // Copy path and score from cached kset. Both go into
+                    // `self.paths` / `self.scores`, which outlive the kset
+                    // — route through `scratch`, not `allocator`.
+                    if (gc.paths.get(partial_match)) |cached_path| {
+                        var path_copy = TracebackPath.init();
+                        errdefer path_copy.deinit(scratch);
+                        try path_copy.path.appendSlice(scratch, cached_path.path.items);
+                        path_copy.setScore(cached_path.score);
+                        path_copy.setModel(cached_path.hmm.?);
+                        try gc.paths.put(scratch, kset, path_copy);
+                    }
+                    const cached_score = gc.scores.get(partial_match) orelse mathutils.NEG_INF;
+                    try gc.scores.put(scratch, kset, cached_score);
+                    origin = "cached";
+                    perf_counters.addElapsed(&perf_counters.cachedPath_ns, t_cached);
+                } else {
+                    origin = try self.fillTrellis(allocator, kset, &query_seqs, gene, &gc);
+                }
+
+                const gene_score = gc.scores.get(kset) orelse mathutils.NEG_INF;
+
+                // Debug: per-gene viterbi output
+                if (self.args.debug == 2 and std.mem.eql(u8, self.algorithm, "viterbi")) {
+                    try self.printPath(kset, query_strs, gene, gene_score, origin);
+                }
+
+                // Update regional totals
+                if (regional_total.getPtr(region)) |rt| {
+                    rt.* = mathutils.addInLogSpace(gene_score, rt.*);
+                }
+
+                // Debug: forward per-gene line
+                if (self.args.debug == 2 and std.mem.eql(u8, self.algorithm, "forward")) {
+                    const rt_val = regional_total.get(region) orelse mathutils.NEG_INF;
+                    const colored_gene = try TermColors.colorGene(allocator, gene);
+                    defer allocator.free(colored_gene);
+                    const fwd_line = try std.fmt.allocPrint(allocator, "                {e: >6.0} {d: >12.6}  {d: >12.6}  {s}  {s}\n", .{ @as(f64, @exp(gene_score)), gene_score, rt_val, origin, colored_gene });
+                    defer allocator.free(fwd_line);
+                    try std.fs.File.stdout().writeAll(fwd_line);
+                }
+
+                // Update regional best + best_genes for this kset.
+                // `regional_best` is kset-local but `best_genes` is owned by
+                // `run()` and read in `fillRecoEvent` after this kset
+                // returns — its `gene_val` dupe must live on `scratch`,
+                // not the per-kset arena.
+                const reg_best = regional_best.get(region) orelse mathutils.NEG_INF;
+                if (gene_score > reg_best) {
+                    if (regional_best.getPtr(region)) |rb| rb.* = gene_score;
+                    if (best_genes.getPtr(kset)) |bg_map| {
+                        const gene_val = try scratch.dupe(u8, gene);
+                        errdefer scratch.free(gene_val);
+                        if (bg_map.fetchRemove(region)) |old| {
+                            scratch.free(old.value);
+                        }
+                        try bg_map.put(scratch, region, gene_val);
+                    }
+                }
+
+                // per_gene_support for this kset. `gene` is borrowed from
+                // `only_genes` (see map declaration above for lifetime).
+                try per_gene_support_this_kset.put(allocator, gene, gene_score);
+            }
+
+            // If no gene found for this region, return early
+            if (best_genes.getPtr(kset)) |bg_map| {
+                if (!bg_map.contains(region)) {
+                    if (self.args.debug == 2) {
+                        const msg = try std.fmt.allocPrint(allocator, "                  found no gene for {s} so skip\n", .{regionStr(region)});
+                        defer allocator.free(msg);
+                        try std.fs.File.stdout().writeAll(msg);
+                    }
+                    return;
+                }
+            }
+        }
+
+        // Store combined best and total scores
+        const rb_v = regional_best.get(.v) orelse mathutils.NEG_INF;
+        const rb_d = regional_best.get(.d) orelse mathutils.NEG_INF;
+        const rb_j = regional_best.get(.j) orelse mathutils.NEG_INF;
+        const rt_v = regional_total.get(.v) orelse mathutils.NEG_INF;
+        const rt_d = regional_total.get(.d) orelse mathutils.NEG_INF;
+        const rt_j = regional_total.get(.j) orelse mathutils.NEG_INF;
+
+        try best_scores.put(scratch, kset, mathutils.addWithMinusInfinities(rb_v, mathutils.addWithMinusInfinities(rb_d, rb_j)));
+        try total_scores.put(scratch, kset, mathutils.addWithMinusInfinities(rt_v, mathutils.addWithMinusInfinities(rt_d, rt_j)));
+
+        // Compute per_gene_support across ksets
+        for (bcr.germ_lines.regions) |region| {
+            const gene_set = only_genes.get(region) orelse continue;
+            // Sort gene names to match C++ set<string> iteration order
+            const sorted_support_genes = try allocator.alloc([]const u8, gene_set.count());
+            defer allocator.free(sorted_support_genes);
+            {
+                var si = gene_set.iterator();
+                var sidx: usize = 0;
+                while (si.next()) |e| : (sidx += 1) sorted_support_genes[sidx] = e.key_ptr.*;
+            }
+            std.mem.sort([]const u8, sorted_support_genes, {}, struct {
+                fn lessThan(_: void, a: []const u8, b: []const u8) bool {
+                    return std.mem.order(u8, a, b) == .lt;
+                }
+            }.lessThan);
+            for (sorted_support_genes) |gene| {
+                var score_this_kset: f64 = 0.0;
+                for (bcr.germ_lines.regions) |tmpreg| {
+                    if (tmpreg == region) {
+                        score_this_kset = mathutils.addWithMinusInfinities(score_this_kset, per_gene_support_this_kset.get(gene) orelse mathutils.NEG_INF);
+                    } else {
+                        score_this_kset = mathutils.addWithMinusInfinities(score_this_kset, regional_best.get(tmpreg) orelse mathutils.NEG_INF);
+                    }
+                }
+
+                const existing = self.per_gene_support.get(gene) orelse mathutils.NEG_INF;
+                if (score_this_kset > existing) {
+                    if (self.per_gene_support.contains(gene)) {
+                        self.per_gene_support.getPtr(gene).?.* = score_this_kset;
+                    } else {
+                        const pg_key = try scratch.dupe(u8, gene);
+                        errdefer scratch.free(pg_key);
+                        try self.per_gene_support.put(scratch, pg_key, score_this_kset);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Build a RecoEvent for the given kset and best gene assignments.
+    ///
+    /// The returned `RecoEvent` is pushed into `Result.events` (and possibly
+    /// `Result.best_event`), which is handed back to the caller of `run()`.
+    /// All allocations that end up owned by the event (gene names,
+    /// deletion keys, insertion seqs, naive_seq) therefore route through
+    /// `parent_allocator`. Transient workspace (path_names_list, del_3p/
+    /// del_5p format strings) uses `scratchAllocator()`. (Item 4, #342.)
+    fn fillRecoEvent(
+        self: *DPHandler,
+        seqs: *Sequences,
+        kset: KSet,
+        best_genes_for_kset: *const std.AutoHashMapUnmanaged(Region, []u8),
+        score: f64,
+    ) !RecoEvent {
+        const parent = self.parent_allocator;
+        const scratch = self.scratchAllocator();
+        var event = try RecoEvent.init(parent);
+        errdefer event.deinit(parent);
+
+        for (bcr.germ_lines.regions) |region| {
+            const rs = regionStr(region);
+            const gene = best_genes_for_kset.get(region) orelse {
+                event.setScore(mathutils.NEG_INF);
+                return event;
+            };
+
+            // The original C++ path called GetQueryStrs and checked items.len > 0;
+            // in practice that's always equal to seqs.nSeqs(), so check directly
+            // and skip the unused string list.
+            if (seqs.nSeqs() == 0) {
+                event.setScore(mathutils.NEG_INF);
+                return event;
+            }
+
+            // Get traceback path names — transient workspace, scratch alloc.
+            const path_names_list = try self.getPathNames(gene, kset, scratch);
+            defer {
+                for (path_names_list.items) |s| scratch.free(s);
+                var pl = path_names_list;
+                pl.deinit(scratch);
+            }
+
+            if (path_names_list.items.len == 0) {
+                event.setScore(mathutils.NEG_INF);
+                return event;
+            }
+
+            try event.setGene(parent, rs, gene);
+            const del_3p = try std.fmt.allocPrint(scratch, "{s}_3p", .{rs});
+            defer scratch.free(del_3p);
+            const del_5p = try std.fmt.allocPrint(scratch, "{s}_5p", .{rs});
+            defer scratch.free(del_5p);
+            try event.setDeletion(parent, del_3p, self.getErosionLength("right", path_names_list.items, gene));
+            try event.setDeletion(parent, del_5p, self.getErosionLength("left", path_names_list.items, gene));
+            try self.setInsertions(region, path_names_list.items, &event);
+        }
+
+        event.setScore(score);
+        try event.setNaiveSeq(parent, self.gl);
+        return event;
+    }
+
+    /// Get the stored path name vector for a gene+kset combination.
+    fn getPathNames(
+        self: *DPHandler,
+        gene: []const u8,
+        kset: KSet,
+        allocator: std.mem.Allocator,
+    ) !std.ArrayListUnmanaged([]u8) {
+        const gene_paths = self.paths.getPtr(gene) orelse return .{};
+        const path = gene_paths.getPtr(kset) orelse return .{};
+        return path.nameVector(allocator);
+    }
+
+    /// Set insertions on `event` based on path state names for `region`.
+    /// Corresponds to C++ `DPHandler::SetInsertions`.
+    fn setInsertions(self: *DPHandler, region: Region, path_names: []const []const u8, event: *RecoEvent) !void {
+        // Insertion seqs are dupe'd onto the event, which lives in
+        // Result returned to the caller — parent_allocator. (Item 4, #342.)
+        const allocator = self.parent_allocator;
+        const ins = Insertions{};
+        for (ins.forRegion(region)) |insertion| {
+            const side: []const u8 = if (std.mem.eql(u8, insertion, "jf")) "right" else "left";
+            var buf: [200]u8 = undefined;
+            const inserted = getInsertion(side, path_names, &buf);
+            try event.setInsertion(allocator, insertion, inserted);
+        }
+    }
+
+    /// Extract inserted bases from path state names for the given side.
+    /// Corresponds to C++ `DPHandler::GetInsertion`.
+    fn getInsertion(side: []const u8, names: []const []const u8, buf: *[200]u8) []const u8 {
+        if (std.mem.eql(u8, side, "left")) {
+            // Scan left-to-right: collect last char of each "insert..." state
+            const max = @min(names.len, 200);
+            var len: usize = 0;
+            for (names[0..max]) |name| {
+                if (!std.mem.startsWith(u8, name, "insert")) break;
+                buf[len] = name[name.len - 1];
+                len += 1;
+            }
+            return buf[0..len];
+        } else {
+            // right: scan right-to-left
+            var len: usize = 0;
+            var i: usize = names.len;
+            while (i > 0) {
+                i -= 1;
+                if (!std.mem.startsWith(u8, names[i], "insert")) break;
+                if (len < 200) {
+                    // prepend
+                    std.mem.copyBackwards(u8, buf[1 .. len + 1], buf[0..len]);
+                    buf[0] = names[i][names[i].len - 1];
+                    len += 1;
+                }
+            }
+            return buf[0..len];
+        }
+    }
+
+    /// Get the number of eroded bases on the given side.
+    /// Corresponds to C++ `DPHandler::GetErosionLength`.
+    fn getErosionLength(self: *DPHandler, side: []const u8, names: []const []const u8, gene_name: []const u8) usize {
+        const germline = self.gl.seqs.get(gene_name) orelse return 0;
+
+        // Check if all states are inserts
+        var all_inserts = true;
+        for (names) |name| {
+            if (!std.mem.startsWith(u8, name, "insert")) {
+                all_inserts = false;
+                break;
+            }
+        }
+        if (all_inserts) {
+            if (std.mem.eql(u8, side, "left"))
+                return germline.len / 2
+            else
+                return (germline.len + 1) / 2;
+        }
+
+        // Find the relevant boundary state
+        if (std.mem.eql(u8, side, "left")) {
+            // leftmost non-insert state
+            var istate: usize = 0;
+            for (names, 0..) |name, il| {
+                if (!std.mem.startsWith(u8, name, "insert")) {
+                    istate = il;
+                    break;
+                }
+            }
+            const state_idx = parseStateIndex(names[istate]) orelse return 0;
+            return state_idx;
+        } else {
+            // rightmost non-insert state
+            var istate: usize = 0;
+            var found = false;
+            var il: usize = names.len;
+            while (il > 0) {
+                il -= 1;
+                if (!std.mem.startsWith(u8, names[il], "insert")) {
+                    istate = il;
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) return 0;
+            const state_idx = parseStateIndex(names[istate]) orelse return 0;
+            if (germline.len == 0) return 0;
+            return germline.len - state_idx - 1;
+        }
+    }
+
+    /// Handle fishy multi-seq annotations by re-running with naive seq.
+    /// Corresponds to C++ `DPHandler::HandleFishyAnnotations`.
+    pub fn handleFishyAnnotations(
+        self: *DPHandler,
+        multi_seq_result: *Result,
+        qry_seqs: []const *const Sequence,
+        kbounds: KBounds,
+        only_gene_list: []const []const u8,
+        overall_mute_freq: f64,
+    ) !void {
+        // `multi_seq_result` was built by an earlier `run()` call with
+        // `parent_allocator`; mutating its `best_event` here must use the
+        // same allocator so the existing entries' frees match. (Item 4, #342.)
+        //
+        // `naive_seq` MUST also use `parent_allocator`, NOT scratch: the
+        // inner `self.run(... clear_cache=true)` call on the line below
+        // calls `self.clear()` as its first action, which resets the
+        // per-query arena. Any naive_seq buffers (`name`/`header`/
+        // `undigitized`/`seqq`) allocated on scratch would be reclaimed
+        // before the inner DP loop reads `seqq[i]` in `emissionLogprobSeqs`,
+        // producing a use-after-reset. The fix is to keep naive_seq's
+        // backing on the caller's long-lived allocator.
+        const parent = self.parent_allocator;
+        const best_ev = multi_seq_result.best_event orelse return;
+
+        // Create naive sequence (use first query's track)
+        const first_track = qry_seqs[0].track orelse return;
+        var naive_seq = try Sequence.initFromString(parent, first_track, "naive-seq", best_ev.naive_seq);
+        defer naive_seq.deinit(parent);
+
+        const naive_seqs = [_]*const Sequence{&naive_seq};
+        var naive_result = try self.run(&naive_seqs, kbounds, only_gene_list, overall_mute_freq, true);
+        defer naive_result.deinit();
+
+        const naive_ev = naive_result.best_event orelse return;
+        if (multi_seq_result.best_event) |*me| {
+            for (bcr.germ_lines.regions) |region| {
+                const rs = regionStr(region);
+                const ng = naive_ev.genes.get(rs) orelse continue;
+                try me.setGene(parent, rs, ng);
+            }
+            const all_dels = [_][]const u8{ "v_5p", "v_3p", "d_5p", "d_3p", "j_5p", "j_3p" };
+            for (all_dels) |delname| {
+                const nd = naive_ev.deletions.get(delname) orelse 0;
+                try me.setDeletion(parent, delname, nd);
+            }
+            const all_ins = [_][]const u8{ "fv", "vd", "dj", "jf" };
+            for (all_ins) |ins_name| {
+                const ni = naive_ev.insertions.get(ins_name) orelse "";
+                try me.setInsertion(parent, ins_name, ni);
+            }
+        }
+    }
+};
+
+/// Parse the state index from a state name like "IGHV3-15*01_42".
+/// Returns the integer after the last underscore, or null.
+fn parseStateIndex(name: []const u8) ?usize {
+    const last_under = std.mem.lastIndexOfScalar(u8, name, '_') orelse return null;
+    const idx_str = name[last_under + 1 ..];
+    return std.fmt.parseInt(usize, idx_str, 10) catch null;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Format a float with N significant digits, matching C++ `cout << setprecision(N) << value`
+/// (i.e. %g format with rounding).  Caller owns the returned slice.
+fn fmtSigFigs(allocator: std.mem.Allocator, value: f64, sig_figs: u8) ![]u8 {
+    const abs_val = @abs(value);
+    // Determine number of integer digits (digits before decimal point)
+    const int_digits: u8 = if (abs_val < 1.0) 0 else blk: {
+        var d: u8 = 0;
+        var v = abs_val;
+        while (v >= 1.0) : (d += 1) v /= 10.0;
+        break :blk d;
+    };
+    // Number of decimal places needed for sig_figs significant digits
+    const dec_places: u8 = if (sig_figs > int_digits) sig_figs - int_digits else 0;
+    // Round to the right number of decimal places
+    const factor = std.math.pow(f64, 10.0, @as(f64, @floatFromInt(dec_places)));
+    const rounded = @round(value * factor) / factor;
+    // Format with exact decimal places
+    const raw = try std.fmt.allocPrint(allocator, "{d}", .{rounded});
+    defer allocator.free(raw);
+    // Find decimal point
+    const dot_pos = std.mem.indexOfScalar(u8, raw, '.') orelse return try allocator.dupe(u8, raw);
+    // Compute how many chars to keep after decimal point
+    const end = @min(dot_pos + 1 + @as(usize, dec_places), raw.len);
+    // Trim trailing zeros after decimal point (matching %g behavior)
+    var trim_end = end;
+    while (trim_end > dot_pos + 1 and raw[trim_end - 1] == '0') trim_end -= 1;
+    if (trim_end > 0 and raw[trim_end - 1] == '.') trim_end -= 1;
+    return try allocator.dupe(u8, raw[0..trim_end]);
+}
+
+test "fmtSigFigs matches C++ cout default" {
+    const a = std.testing.allocator;
+    // -103.3918 rounded to 6 sig figs → -103.392
+    const s1 = try fmtSigFigs(a, -103.3918, 6);
+    defer a.free(s1);
+    try std.testing.expectEqualStrings("-103.392", s1);
+    // -72.9176 = 6 sig figs (exact)
+    const s2 = try fmtSigFigs(a, -72.9176, 6);
+    defer a.free(s2);
+    try std.testing.expectEqualStrings("-72.9176", s2);
+    // -10.4 = trailing zeros trimmed
+    const s3 = try fmtSigFigs(a, -10.4, 6);
+    defer a.free(s3);
+    try std.testing.expectEqualStrings("-10.4", s3);
+}
+
+test "DPHandler: parseStateIndex" {
+    try std.testing.expectEqual(@as(?usize, 42), parseStateIndex("IGHV3-15_star_01_42"));
+    try std.testing.expectEqual(@as(?usize, 0), parseStateIndex("IGHV3-15_star_01_0"));
+    try std.testing.expectEqual(@as(?usize, null), parseStateIndex("insert_left_A"));
+}

--- a/packages/zig-core/src/ham/emission.zig
+++ b/packages/zig-core/src/ham/emission.zig
@@ -1,0 +1,223 @@
+/// ham/emission.zig — Zig port of ham/src/emission.cc + ham/include/emission.h
+///
+/// Emission probability model for a single HMM state.
+/// Wraps a LexicalTable and provides Parse (from YAML-extracted data), score, and rescaling.
+///
+/// C++ source: packages/ham/src/emission.cc, packages/ham/include/emission.h
+/// C++ author: psathyrella/ham
+
+const std = @import("std");
+const Track = @import("track.zig").Track;
+const Sequence = @import("sequences.zig").Sequence;
+const LexicalTable = @import("lexical_table.zig").LexicalTable;
+
+const log = @import("mathutils.zig").log;
+
+/// EPS for normalization check (matches C++ build define -DEPS=1e-6).
+const EPS: f64 = 1e-6;
+
+/// Emission probability model for a single HMM state.
+/// Corresponds to C++ `ham::Emission`.
+pub const Emission = struct {
+    /// Sum of raw probabilities (checked during parse; kept for diagnostics).
+    total: f64,
+    /// Inner lookup table (indexed by digitized symbol).
+    scores: LexicalTable,
+    /// Pointer to the track (not owned; must outlive this Emission).
+    track: ?*const Track,
+
+    /// Create an empty Emission with no data.
+    /// Corresponds to C++ `Emission()`.
+    pub fn init() Emission {
+        return Emission{
+            .total = 0.0,
+            .scores = LexicalTable.init(),
+            .track = null,
+        };
+    }
+
+    pub fn deinit(self: *Emission, allocator: std.mem.Allocator) void {
+        self.scores.deinit(allocator);
+    }
+
+    /// Parse emission probabilities from an already-extracted prob map.
+    ///
+    /// `probs_map` is a `StringHashMap(f64)` mapping each symbol name (e.g. "A") to its
+    /// raw probability.  This corresponds to the `probs` sub-node extracted from the YAML
+    /// `emissions` node by the caller (ham/Model).
+    ///
+    /// Corresponds to C++ `Emission::Parse(YAML::Node config, Track *track)`.
+    pub fn parse(
+        self: *Emission,
+        allocator: std.mem.Allocator,
+        probs_map: std.StringHashMap(f64),
+        trk: *const Track,
+    ) !void {
+        self.track = trk;
+        self.scores.setTrack(trk);
+
+        const alphabet_size = trk.alphabetSize();
+        if (probs_map.count() != alphabet_size) {
+            return error.EmissionProbsSizeMismatch;
+        }
+
+        var log_probs = try allocator.alloc(f64, alphabet_size);
+        defer allocator.free(log_probs);
+
+        self.total = 0.0;
+        for (0..alphabet_size) |ip| {
+            const sym = trk.symbol(ip);
+            const prob = probs_map.get(sym) orelse return error.MissingEmissionSymbol;
+            log_probs[ip] = log(prob);
+            self.total += prob;
+        }
+        if (@abs(self.total - 1.0) >= EPS) {
+            return error.BadNormalization;
+        }
+        try self.scores.setLogProbs(allocator, log_probs);
+    }
+
+    /// Replace log probs (for mute-freq rescaling).
+    /// Corresponds to C++ `void ReplaceLogProbs(vector<double>)`.
+    pub fn replaceLogProbs(self: *Emission, new_log_probs: []const f64) !void {
+        try self.scores.replaceLogProbs(new_log_probs);
+    }
+
+    /// Revert to original log probs.
+    /// Corresponds to C++ `void UnReplaceLogProbs()`.
+    pub fn unReplaceLogProbs(self: *Emission) void {
+        self.scores.unReplaceLogProbs();
+    }
+
+    /// Score (log-probability) for a digitized symbol index.
+    /// Corresponds to C++ `inline double score(uint8_t index)`.
+    pub inline fn scoreIndex(self: *const Emission, index: u8) f64 {
+        return self.scores.logProb(index);
+    }
+
+    /// Score (log-probability) for the symbol at `pos` in `seq`.
+    /// Corresponds to C++ `double score(Sequence *seq, size_t pos)`.
+    pub fn scoreSeq(self: *const Emission, seq: *const Sequence, pos: usize) f64 {
+        return self.scores.logProbSeq(seq, pos);
+    }
+
+    /// Return a copy of the log_probs slice.
+    /// Corresponds to C++ `vector<double> log_probs()`.
+    pub fn logProbs(self: *const Emission, allocator: std.mem.Allocator) ![]f64 {
+        return self.scores.logProbs(allocator);
+    }
+
+    /// Return the track pointer.
+    pub fn getTrack(self: *const Emission) ?*const Track {
+        return self.track;
+    }
+
+    /// Print emission probabilities to stdout.
+    /// Corresponds to C++ `Emission::Print()`.
+    pub fn print(self: *const Emission) void {
+        const trk = self.track orelse return;
+        const n = trk.alphabetSize();
+        std.debug.print("    {s}     (normed to within at least {e})\n", .{ trk.name, EPS });
+        for (0..n) |i| {
+            const prob = @exp(self.scores.logProb(@intCast(i)));
+            if (prob < 0.01) {
+                std.debug.print("{e:>22}", .{prob});
+            } else {
+                std.debug.print("{d:>22.9}", .{prob});
+            }
+        }
+        std.debug.print("\n", .{});
+    }
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "Emission: parse uniform distribution" {
+    const allocator = std.testing.allocator;
+    const sym_list = [_][]const u8{ "A", "C", "G", "T" };
+    var track = try Track.initWithSymbols(allocator, "nucs", &sym_list, "N");
+    defer track.deinit(allocator);
+
+    var probs = std.StringHashMap(f64).init(allocator);
+    defer probs.deinit();
+    try probs.put("A", 0.25);
+    try probs.put("C", 0.25);
+    try probs.put("G", 0.25);
+    try probs.put("T", 0.25);
+
+    var em = Emission.init();
+    defer em.deinit(allocator);
+
+    try em.parse(allocator, probs, &track);
+
+    try std.testing.expectApproxEqAbs(1.0, em.total, EPS);
+    try std.testing.expectApproxEqAbs(@log(0.25), em.scoreIndex(0), 1e-9);
+    try std.testing.expectApproxEqAbs(@log(0.25), em.scoreIndex(3), 1e-9);
+}
+
+test "Emission: parse non-uniform distribution" {
+    const allocator = std.testing.allocator;
+    const sym_list = [_][]const u8{ "A", "C", "G", "T" };
+    var track = try Track.initWithSymbols(allocator, "nucs", &sym_list, "N");
+    defer track.deinit(allocator);
+
+    var probs = std.StringHashMap(f64).init(allocator);
+    defer probs.deinit();
+    try probs.put("A", 0.7);
+    try probs.put("C", 0.1);
+    try probs.put("G", 0.1);
+    try probs.put("T", 0.1);
+
+    var em = Emission.init();
+    defer em.deinit(allocator);
+
+    try em.parse(allocator, probs, &track);
+    try std.testing.expectApproxEqAbs(@log(0.7), em.scoreIndex(0), 1e-9);
+    try std.testing.expectApproxEqAbs(@log(0.1), em.scoreIndex(1), 1e-9);
+}
+
+test "Emission: parse rejects bad normalization" {
+    const allocator = std.testing.allocator;
+    const sym_list = [_][]const u8{ "A", "C", "G", "T" };
+    var track = try Track.initWithSymbols(allocator, "nucs", &sym_list, "N");
+    defer track.deinit(allocator);
+
+    var probs = std.StringHashMap(f64).init(allocator);
+    defer probs.deinit();
+    try probs.put("A", 0.3);
+    try probs.put("C", 0.3);
+    try probs.put("G", 0.2);
+    try probs.put("T", 0.1); // sums to 0.9
+
+    var em = Emission.init();
+    defer em.deinit(allocator);
+
+    const result = em.parse(allocator, probs, &track);
+    try std.testing.expectError(error.BadNormalization, result);
+}
+
+test "Emission: scoreSeq" {
+    const allocator = std.testing.allocator;
+    const sym_list = [_][]const u8{ "A", "C", "G", "T" };
+    var track = try Track.initWithSymbols(allocator, "nucs", &sym_list, "N");
+    defer track.deinit(allocator);
+
+    var probs = std.StringHashMap(f64).init(allocator);
+    defer probs.deinit();
+    try probs.put("A", 0.1);
+    try probs.put("C", 0.2);
+    try probs.put("G", 0.3);
+    try probs.put("T", 0.4);
+
+    var em = Emission.init();
+    defer em.deinit(allocator);
+    try em.parse(allocator, probs, &track);
+
+    var seq = try @import("sequences.zig").Sequence.initFromString(allocator, &track, "s1", "ACGT");
+    defer seq.deinit(allocator);
+
+    // A at pos 0 → log(0.1)
+    try std.testing.expectApproxEqAbs(@log(0.1), em.scoreSeq(&seq, 0), 1e-9);
+    // T at pos 3 → log(0.4)
+    try std.testing.expectApproxEqAbs(@log(0.4), em.scoreSeq(&seq, 3), 1e-9);
+}

--- a/packages/zig-core/src/ham/fast_math.c
+++ b/packages/zig-core/src/ham/fast_math.c
@@ -1,0 +1,88 @@
+/* fast_math.c — fast log-sum-exp via tabulated softplus.
+ *
+ * Drop-in replacement for the `log(1 + exp(d))` work in AddInLogSpace
+ * (mathutils.h:98). Replaces 1 log + 1 exp glibc call (~5–17 ns combined,
+ * arch-dependent) with a single 65 K-entry linear-interpolation lookup
+ * (~3.5–10 ns per call).
+ *
+ * Pre-flight measurements at issue #366 item 3.2:
+ *   - Zen 5 (glibc 2.39): glibc 9.6 ns → LUT64K 7.3 ns per addInLogSpace
+ *   - Broadwell:          glibc 16.7 ns → LUT64K 10.0 ns
+ *   - LUT64K accuracy: max abs error 6.5e-9 over [-30, 0] (5 orders under
+ *     the partis-test 1e-5 gate).
+ *
+ * Why a 65 K linear-interp table:
+ *   The Cephes scalar polynomial alternative (~7-15 ns) loses to modern
+ *   glibc's FMA-optimized scalar log/exp on every CPU we tested. LUT
+ *   wins because it replaces ~10 ALU ops + branches with a single load
+ *   + 1 multiply + 1 fma. Smaller LUTs (256, 4 K, 16 K) fail the worst-
+ *   case error budget; LUT64K passes by 4×. Cubic interp at 1 K entries
+ *   would also pass speed-wise but not accuracy-wise.
+ *
+ * The linear-interp arithmetic dominates over the table size in cycle
+ * count (LUT256 ≈ LUT64K on every benchmarked CPU), so going larger is
+ * effectively free as long as the hot region stays cache-resident — and
+ * it does, because real DP traffic concentrates near d = 0.
+ *
+ * Built with -O3 -ffp-contract=off so that the linear-interp arithmetic
+ * is bit-deterministic across g++/clang/zig from the same C source.
+ * (Without that flag, cross-compiler drift would be 1–2 ULP — far under
+ * the partis-test gate, but bit-equality between backends is cheap to
+ * keep so we keep it.)
+ *
+ * Mirrored on the Zig side at packages/zig-core/src/ham/fast_math.c.
+ * Both sides MUST stay in sync; the table is data so cross-backend
+ * parity is trivial as long as the same source compiles to both.
+ */
+#include <math.h>
+
+/* Range of d for which the table covers softplus(d) = log(1 + exp(d))
+ * directly. Outside this range, we use the closed-form fall-throughs:
+ *   d < LUT_LO:  exp(d) is well under double precision, softplus ≈ 0.
+ *   d > 0:       use the symmetry softplus(d) = d + softplus(-d).
+ *
+ * Within addInLogSpace's standard form (see mathutils.h AddInLogSpace),
+ * the argument is always (smaller - larger) ≤ 0. The d > 0 branch is
+ * defensive — should not be exercised in practice, but keeps the
+ * function safe to call independently.
+ */
+#define LUT_N  65536
+#define LUT_LO -30.0
+#define LUT_HI 0.0
+
+static double softplus_lut[LUT_N + 1];
+
+/* (LUT_N / |LUT_LO|) precomputed for the index calculation. Using a
+ * macro keeps it a compile-time constant, which the compiler can fold
+ * into the multiply at the call site. */
+#define LUT_SCALE ((double) LUT_N / -(LUT_LO))
+
+__attribute__((constructor))
+static void init_softplus_lut(void) {
+    /* log1p(exp(d)) is the numerically stable form of log(1 + exp(d))
+     * for the table-build phase. Build is one-shot at process start. */
+    for (int i = 0; i <= LUT_N; ++i) {
+        double d = LUT_LO + (LUT_HI - LUT_LO) * (double) i / (double) LUT_N;
+        softplus_lut[i] = log1p(exp(d));
+    }
+}
+
+double fast_softplus(double d) {
+    if (d < LUT_LO) return 0.0;
+    if (d > 0.0)    return d + fast_softplus(-d);   /* symmetry */
+    /* d ∈ [LUT_LO, 0] — index in [0, LUT_N] */
+    double t = (d - LUT_LO) * LUT_SCALE;
+    int i = (int) t;
+    /* Clamp `i` so `i+1` stays in bounds. At d == 0 (or d so close to 0
+     * that float rounding gives t == LUT_N), the unclamped i would equal
+     * LUT_N and the `softplus_lut[i+1]` read would be one past the array.
+     * The production result was correct only because `frac == 0` masked
+     * the OOB read; Debug-mode bounds checks fired. With the clamp,
+     * frac becomes 1.0 at the boundary and y0 + 1.0*(y1-y0) = y1 =
+     * softplus_lut[LUT_N], identical to the unclamped value. */
+    if (i >= LUT_N) i = LUT_N - 1;
+    double frac = t - (double) i;
+    double y0 = softplus_lut[i];
+    double y1 = softplus_lut[i + 1];
+    return y0 + frac * (y1 - y0);
+}

--- a/packages/zig-core/src/ham/glibc_math.c
+++ b/packages/zig-core/src/ham/glibc_math.c
@@ -1,0 +1,54 @@
+/* glibc_math.c — Force glibc log/exp, bypassing Zig's compiler-rt.
+ *
+ * Zig's compiler-rt bundles its own log/exp as local text symbols ('t')
+ * that may differ from glibc by ~1 ULP on some CPUs.  C++ bcrham always
+ * uses glibc, so we must match.
+ *
+ * We dlopen libm.so.6 and resolve log/exp from it directly, bypassing
+ * any compiler-rt symbols in the binary.
+ *
+ * macOS has no libm.so.6 (no glibc), so there we just use the system libm's
+ * log/exp.  Results won't be bit-identical to the Linux glibc reference, but
+ * that's fine: the C++ backend (ig-sw/bcrham) can't be built on macOS anyway
+ * (SSE2/emmintrin), so there is no Linux-parity requirement on that platform.
+ */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef __APPLE__
+
+#include <math.h>
+
+double glibc_log(double x) { return log(x); }
+double glibc_exp(double x) { return exp(x); }
+
+#else
+
+#include <dlfcn.h>
+
+typedef double (*math_fn)(double);
+
+static math_fn real_log;
+static math_fn real_exp;
+
+__attribute__((constructor))
+static void init_glibc_math(void) {
+    void *libm = dlopen("libm.so.6", RTLD_LAZY);
+    if (!libm) {
+        fprintf(stderr, "glibc_math: dlopen libm.so.6 failed: %s\n", dlerror());
+        abort();
+    }
+    real_log = (math_fn)dlsym(libm, "log");
+    real_exp = (math_fn)dlsym(libm, "exp");
+    if (!real_log || !real_exp) {
+        fprintf(stderr, "glibc_math: dlsym failed: %s\n", dlerror());
+        abort();
+    }
+    /* don't dlclose — keep libm loaded for the process lifetime */
+}
+
+double glibc_log(double x) { return real_log(x); }
+double glibc_exp(double x) { return real_exp(x); }
+
+#endif

--- a/packages/zig-core/src/ham/glomerator/glomerator.zig
+++ b/packages/zig-core/src/ham/glomerator/glomerator.zig
@@ -1,0 +1,1981 @@
+/// ham/glomerator/glomerator.zig — Zig port of ham/src/glomerator.cc
+///
+/// Hierarchical clustering (glomerating) of BCR sequences.
+///
+/// C++ source: packages/ham/src/glomerator.cc, packages/ham/include/glomerator.h
+/// C++ author: psathyrella/ham
+
+const std = @import("std");
+const Args = @import("../args.zig").Args;
+const DPHandler = @import("../dp_handler.zig").DPHandler;
+const track_mod = @import("../track.zig");
+const Track = track_mod.Track;
+const ClusterPath = @import("../cluster_path.zig").ClusterPath;
+const Partition = @import("../cluster_path.zig").Partition;
+const Sequence = @import("../sequences.zig").Sequence;
+const mathutils = @import("../mathutils.zig");
+const ham_text = @import("../text.zig");
+const perf_counters = @import("../perf_counters.zig");
+const bcr = @import("../bcr_utils/root.zig");
+const GermLines = bcr.GermLines;
+const HMMHolder = bcr.HMMHolder;
+const KSet = bcr.KSet;
+const KBounds = bcr.KBounds;
+const RecoEvent = bcr.RecoEvent;
+const Result = bcr.Result;
+const Query = @import("query.zig").Query;
+
+fn sortPartition(part: *Partition) void {
+    std.mem.sort([]u8, part.items, {}, struct {
+        fn lessThan(_: void, a: []u8, b: []u8) bool {
+            return std.mem.order(u8, a, b) == .lt;
+        }
+    }.lessThan);
+}
+
+/// Phase-B': emit one `PERFCOUNTER_GLOMERATOR` line to `PARTIS_ZIG_PERF_LOG`
+/// at the end of `cluster()` / `cacheNaiveSeqs()`. Pairs with the per-query
+/// `PERFCOUNTER_TIMING` lines from `DPHandler.run()` to expose Glomerator
+/// driver overhead. `kind` is `"cluster"` or `"cacheNaiveSeqs"` so the
+/// aggregator can keep the two modes separate. No-op when counters off or
+/// when the env var is unset (same gate as `dumpPerfCounters`).
+///
+/// Returns `!void` so the caller can choose how to handle failure. Callers
+/// in this module use a defer with `catch reportGlomeratorCountersError`
+/// (below) — they can't propagate via `defer` anyway, so the lowest-noise
+/// useful behavior is to print a one-line diagnostic to stderr instead of
+/// silently dropping the dump. (Advisory from PR #383 review.)
+fn dumpGlomeratorCounters(allocator: std.mem.Allocator, kind: []const u8) !void {
+    if (!perf_counters.enabled) return;
+    const log_path = std.process.getEnvVarOwned(allocator, "PARTIS_ZIG_PERF_LOG") catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => return,
+        else => return err,
+    };
+    defer allocator.free(log_path);
+
+    const line = try std.fmt.allocPrint(
+        allocator,
+        "PERFCOUNTER_GLOMERATOR kind={s} glomerator_total_ns={d} cumul_dpHandler_run_ns={d}\n",
+        .{ kind, perf_counters.glomerator_ns, perf_counters.cumul_dpHandler_run_ns },
+    );
+    defer allocator.free(line);
+
+    const log_path_z = try allocator.dupeZ(u8, log_path);
+    defer allocator.free(log_path_z);
+    const flags: std.posix.O = .{ .ACCMODE = .WRONLY, .APPEND = true, .CREAT = true };
+    const fd = try std.posix.openZ(log_path_z, flags, 0o644);
+    const file = std.fs.File{ .handle = fd };
+    defer file.close();
+    try file.writeAll(line);
+}
+
+/// Stderr-only diagnostic for the defer-catch path. We can't surface
+/// errors via `defer` so the best we can do is leave a breadcrumb when
+/// the perf log was requested but unwritable (wrong path, permissions,
+/// disk full). Silent under the env-var-unset path because that case
+/// returns early from `dumpGlomeratorCounters` itself.
+fn reportGlomeratorCountersError(err: anyerror) void {
+    std.debug.print(
+        "warning: failed to write PERFCOUNTER_GLOMERATOR line to $PARTIS_ZIG_PERF_LOG: {s}\n",
+        .{@errorName(err)},
+    );
+}
+
+/// Corresponds to C++ `ham::Glomerator`.
+pub const Glomerator = struct {
+    track: *Track,
+    args: *Args,
+    gl: *GermLines,
+    hmms: *HMMHolder,
+    allocator: std.mem.Allocator,
+
+    /// The starting partition (one cluster per input query).
+    initial_partition: Partition,
+
+    /// All actual sequences, keyed by sequence name.
+    ///
+    /// Write-once during `init`; **frozen** thereafter (no inserts, no
+    /// removals, no replacements). Per issue #342 items 6 and 16, every
+    /// other `Query.seqs` in the glomerator stores `*const Sequence`
+    /// pointers into this map's value slots. Mutating this map post-init
+    /// (or growing it past its `ensureTotalCapacity` bound during init)
+    /// can rehash and invalidate those pointers — `init` populates this
+    /// map fully in a first pass before any cachefo Query is built.
+    /// Adding any write to this map outside `init` requires reworking
+    /// the borrowed-Sequence contract (see Query struct doc).
+    single_seqs: std.StringHashMapUnmanaged(Sequence),
+    /// Single-sequence cache entries.
+    single_seq_cachefo: std.StringHashMapUnmanaged(Query),
+    /// Permanent cache entries for clusters we've actually merged.
+    cachefo: std.StringHashMapUnmanaged(Query),
+    /// Temporary cache entries for clusters we're considering merging.
+    tmp_cachefo: std.StringHashMapUnmanaged(Query),
+
+    /// Cached log-probabilities.
+    log_probs: std.StringHashMapUnmanaged(f64),
+    /// Cached naive hamming fractions (joint key).
+    naive_hfracs: std.StringHashMapUnmanaged(f64),
+    /// Cached log-probability ratios.
+    lratios: std.StringHashMapUnmanaged(f64),
+    /// Cached naive sequences.
+    naive_seqs: std.StringHashMapUnmanaged([]u8),
+    /// Error strings.
+    errors: std.StringHashMapUnmanaged([]u8),
+
+    /// Queries that failed with no valid path.
+    failed_queries: std.StringHashMapUnmanaged(void),
+
+    /// Keys present in the initial cache file.
+    initial_log_probs: std.StringHashMapUnmanaged(void),
+    initial_naive_hfracs: std.StringHashMapUnmanaged(void),
+    initial_naive_seqs: std.StringHashMapUnmanaged(void),
+
+    /// Name translation maps.
+    naive_seq_name_translations: std.StringHashMapUnmanaged([]u8),
+    logprob_name_translations: std.StringHashMapUnmanaged([2][]u8),
+    logprob_asymetric_translations: std.StringHashMapUnmanaged([]u8),
+    name_subsets: std.StringHashMapUnmanaged([]u8),
+
+    /// Counters.
+    n_fwd_calculated: i32,
+    n_vtb_calculated: i32,
+    n_hfrac_calculated: i32,
+    n_hfrac_merges: i32,
+    n_lratio_merges: i32,
+
+    asym_factor: f64,
+    force_merge: bool,
+
+    /// Asymmetry scaling factor (C++ asym_factor_ = 4.0).
+    const ASYM_FACTOR: f64 = 4.0;
+
+    /// C++: Glomerator::Glomerator() — glomerator.cc:6
+    pub fn init(
+        allocator: std.mem.Allocator,
+        hmms: *HMMHolder,
+        gl: *GermLines,
+        qry_seq_lists: []const []Sequence,
+        args: *Args,
+        track: *Track,
+    ) !Glomerator {
+        var self = Glomerator{
+            .track = track,
+            .args = args,
+            .gl = gl,
+            .hmms = hmms,
+            .allocator = allocator,
+            .initial_partition = .{},
+            .single_seqs = .{},
+            .single_seq_cachefo = .{},
+            .cachefo = .{},
+            .tmp_cachefo = .{},
+            .log_probs = .{},
+            .naive_hfracs = .{},
+            .lratios = .{},
+            .naive_seqs = .{},
+            .errors = .{},
+            .failed_queries = .{},
+            .initial_log_probs = .{},
+            .initial_naive_hfracs = .{},
+            .initial_naive_seqs = .{},
+            .naive_seq_name_translations = .{},
+            .logprob_name_translations = .{},
+            .logprob_asymetric_translations = .{},
+            .name_subsets = .{},
+            .n_fwd_calculated = 0,
+            .n_vtb_calculated = 0,
+            .n_hfrac_calculated = 0,
+            .n_hfrac_merges = 0,
+            .n_lratio_merges = 0,
+            .asym_factor = ASYM_FACTOR,
+            .force_merge = false,
+        };
+        errdefer self.deinit();
+
+        try self.readCacheFile();
+
+        // Pass 1: populate `single_seqs` fully. Item 16 stores `*const Sequence`
+        // pointers into this map's value slots in `single_seq_cachefo` and
+        // `cachefo` `Query.seqs`; those pointers must be taken only after the
+        // map is stable, since `put` on a growing map can rehash and invalidate
+        // pointers returned by earlier `getPtr` calls.
+        var total_seqs: usize = 0;
+        for (qry_seq_lists) |seq_list| total_seqs += seq_list.len;
+        try self.single_seqs.ensureTotalCapacity(allocator, @intCast(total_seqs));
+        for (qry_seq_lists) |seq_list| {
+            for (seq_list) |*sq| {
+                if (self.single_seqs.contains(sq.name)) continue;
+                const name_key = try allocator.dupe(u8, sq.name);
+                errdefer allocator.free(name_key);
+                var cloned = try sq.clone(allocator);
+                errdefer cloned.deinit(allocator);
+                try self.single_seqs.put(allocator, name_key, cloned);
+            }
+        }
+
+        // Pass 2: build cachefo / single_seq_cachefo / initial_partition.
+        // `single_seqs` is now frozen; `getPtr` results are stable for the
+        // remaining lifetime of the Glomerator.
+        for (qry_seq_lists, 0..) |seq_list, iqry| {
+            // Build the colon-separated key for this query group
+            var names: std.ArrayListUnmanaged([]const u8) = .{};
+            defer names.deinit(allocator);
+            for (seq_list) |*sq| {
+                try names.append(allocator, sq.name);
+            }
+            const key = try ham_text.joinStrings(allocator, names.items, ":");
+            defer allocator.free(key);
+
+            // Build bounds from args queries
+            const qrow = &args.queries.items[iqry];
+            const kmin = KSet{ .v = @intCast(@max(0, qrow.k_v_min)), .d = @intCast(@max(0, qrow.k_d_min)) };
+            const kmax = KSet{ .v = @intCast(@max(1, qrow.k_v_max)), .d = @intCast(@max(1, qrow.k_d_max)) };
+            const kbounds = KBounds.initFromSets(kmin, kmax);
+
+            // Add to initial partition
+            const key_owned = try allocator.dupe(u8, key);
+            errdefer allocator.free(key_owned);
+            try self.initial_partition.append(allocator, key_owned);
+
+            // Build only_genes list
+            var only_genes: std.ArrayListUnmanaged([]const u8) = .{};
+            defer only_genes.deinit(allocator);
+            for (qrow.only_genes.items) |g| {
+                try only_genes.append(allocator, g);
+            }
+
+            // Build single_seq_cachefo entries. `key` outlives this block, so
+            // we iterate splitScalar without duping the names (item 16).
+            var key_iter = std.mem.splitScalar(u8, key, ':');
+            while (key_iter.next()) |uid| {
+                if (uid.len == 0) continue;
+                if (self.single_seq_cachefo.contains(uid)) continue;
+                const sq_ptr = self.single_seqs.getPtr(uid) orelse return error.SequenceNotFound;
+                const uid_seq_ptrs = [_]*const Sequence{sq_ptr};
+                const is_seed_missing = !ham_text.inString(args.seed_unique_id, uid, ":");
+                var uid_q = try Query.create(
+                    allocator,
+                    uid,
+                    &uid_seq_ptrs,
+                    is_seed_missing,
+                    only_genes.items,
+                    kbounds,
+                    qrow.mut_freq,
+                    @intCast(@max(0, qrow.cdr3_length)),
+                    null, null,
+                );
+                errdefer uid_q.deinit(allocator);
+                const uid_key = try allocator.dupe(u8, uid);
+                errdefer allocator.free(uid_key);
+                try self.single_seq_cachefo.put(allocator, uid_key, uid_q);
+            }
+
+            // Build cachefo entry for the full query group
+            var key_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
+            defer key_seq_ptrs.deinit(allocator);
+            try self.appendSeqPtrsForQuery(&key_seq_ptrs, allocator, key);
+            const is_seed_missing = !ham_text.inString(args.seed_unique_id, key, ":");
+            var q = try Query.create(
+                allocator,
+                key,
+                key_seq_ptrs.items,
+                is_seed_missing,
+                only_genes.items,
+                kbounds,
+                qrow.mut_freq,
+                @intCast(@max(0, qrow.cdr3_length)),
+                null, null,
+            );
+            errdefer q.deinit(allocator);
+            const cf_key = try allocator.dupe(u8, key);
+            errdefer allocator.free(cf_key);
+            try self.cachefo.put(allocator, cf_key, q);
+        }
+
+        return self;
+    }
+
+    /// C++: ~Glomerator() — glomerator.cc:58 (cache write + stats moved to cluster())
+    pub fn deinit(self: *Glomerator) void {
+        const allocator = self.allocator;
+
+        // Free initial_partition
+        for (self.initial_partition.items) |s| allocator.free(s);
+        self.initial_partition.deinit(allocator);
+
+        // Free Query maps before single_seqs: Query.seqs borrows from
+        // single_seqs (items 6 and 16 — `*const Sequence` pointers into the
+        // map's value slots). Query.deinit no longer touches Sequence values,
+        // so the order is not load-bearing for correctness, but freeing
+        // borrowers before owners keeps the invariant explicit.
+        freeQueryMap(allocator, &self.single_seq_cachefo);
+        freeQueryMap(allocator, &self.cachefo);
+        freeQueryMap(allocator, &self.tmp_cachefo);
+
+        // Free single_seqs (the unique owner of Sequence buffers).
+        var ssit = self.single_seqs.iterator();
+        while (ssit.next()) |e| {
+            allocator.free(e.key_ptr.*);
+            e.value_ptr.deinit(allocator);
+        }
+        self.single_seqs.deinit(allocator);
+
+        freeStringF64Map(allocator, &self.log_probs);
+        freeStringF64Map(allocator, &self.naive_hfracs);
+        freeStringF64Map(allocator, &self.lratios);
+
+        var nsit = self.naive_seqs.iterator();
+        while (nsit.next()) |e| {
+            allocator.free(e.key_ptr.*);
+            allocator.free(e.value_ptr.*);
+        }
+        self.naive_seqs.deinit(allocator);
+
+        var eit = self.errors.iterator();
+        while (eit.next()) |e| {
+            allocator.free(e.key_ptr.*);
+            allocator.free(e.value_ptr.*);
+        }
+        self.errors.deinit(allocator);
+
+        freeStringVoidMap(allocator, &self.failed_queries);
+        freeStringVoidMap(allocator, &self.initial_log_probs);
+        freeStringVoidMap(allocator, &self.initial_naive_hfracs);
+        freeStringVoidMap(allocator, &self.initial_naive_seqs);
+
+        freeStringStringMap(allocator, &self.naive_seq_name_translations);
+        freeStringStringMap(allocator, &self.logprob_asymetric_translations);
+        freeStringStringMap(allocator, &self.name_subsets);
+
+        var lntit = self.logprob_name_translations.iterator();
+        while (lntit.next()) |e| {
+            allocator.free(e.key_ptr.*);
+            allocator.free(e.value_ptr[0]);
+            allocator.free(e.value_ptr[1]);
+        }
+        self.logprob_name_translations.deinit(allocator);
+    }
+
+    // ── Helper free functions ─────────────────────────────────────────────────
+
+    fn freeQueryMap(allocator: std.mem.Allocator, map: *std.StringHashMapUnmanaged(Query)) void {
+        var it = map.iterator();
+        while (it.next()) |e| {
+            allocator.free(e.key_ptr.*);
+            e.value_ptr.deinit(allocator);
+        }
+        map.deinit(allocator);
+    }
+
+    fn freeStringF64Map(allocator: std.mem.Allocator, map: *std.StringHashMapUnmanaged(f64)) void {
+        var it = map.iterator();
+        while (it.next()) |e| allocator.free(e.key_ptr.*);
+        map.deinit(allocator);
+    }
+
+    fn freeStringVoidMap(allocator: std.mem.Allocator, map: *std.StringHashMapUnmanaged(void)) void {
+        var it = map.iterator();
+        while (it.next()) |e| allocator.free(e.key_ptr.*);
+        map.deinit(allocator);
+    }
+
+    fn freeStringStringMap(allocator: std.mem.Allocator, map: *std.StringHashMapUnmanaged([]u8)) void {
+        var it = map.iterator();
+        while (it.next()) |e| {
+            allocator.free(e.key_ptr.*);
+            allocator.free(e.value_ptr.*);
+        }
+        map.deinit(allocator);
+    }
+
+    // ── Main clustering entry points ──────────────────────────────────────────
+
+    /// Run full hierarchical clustering and write output.
+    /// Corresponds to C++ `Glomerator::Cluster`.
+    pub fn cluster(self: *Glomerator) !void {
+        // Phase-B' outer-most timer: total wall in Glomerator.cluster(),
+        // including the merge loop, writePartitions, writeCacheFile, and
+        // setup. Pairs with `cumul_dpHandler_run_ns` to expose Glomerator
+        // driver overhead (merge decisions, partition I/O) as the
+        // residual. Dumped at end of this function via dumpGlomeratorCounters.
+        //
+        // Defer order is LIFO: the dump (registered first) runs LAST, so
+        // it sees the addElapsed-updated counter. Reversing these two
+        // defers would dump a stale 0.
+        const t_glom = perf_counters.tick();
+        defer dumpGlomeratorCounters(self.allocator, "cluster") catch |err| reportGlomeratorCountersError(err);
+        defer perf_counters.addElapsed(&perf_counters.glomerator_ns, t_glom);
+        if (self.args.logprob_ratio_threshold == -std.math.inf(f64)) {
+            return error.LogprobRatioThresholdNotSet;
+        }
+
+        if (self.args.debug > 0) {
+            var n_seeded: usize = 0;
+            if (self.args.seed_unique_id.len > 0) {
+                for (self.initial_partition.items) |cl| {
+                    if (ham_text.inString(self.args.seed_unique_id, cl, ":")) n_seeded += 1;
+                }
+            }
+            const seeded_str = if (self.args.seed_unique_id.len > 0)
+                try std.fmt.allocPrint(self.allocator, "  ({d} seeded)", .{n_seeded})
+            else
+                try std.fmt.allocPrint(self.allocator, "", .{});
+            defer self.allocator.free(seeded_str);
+            const s = try std.fmt.allocPrint(self.allocator, "   hieragloming {d} clusters{s}\n", .{ self.initial_partition.items.len, seeded_str });
+            defer self.allocator.free(s);
+            try std.fs.File.stdout().writeAll(s);
+        }
+
+        // Clone partition entries and sort to match C++ set<string> ordering
+        var init_part: Partition = .{};
+        for (self.initial_partition.items) |name| {
+            try init_part.append(self.allocator, try self.allocator.dupe(u8, name));
+        }
+        sortPartition(&init_part);
+        var cp = try ClusterPath.initWithPartition(self.allocator, init_part, mathutils.NEG_INF);
+        defer cp.deinit(self.allocator);
+
+        while (!cp.finished) {
+            try self.merge(&cp);
+        }
+
+        try self.writePartitions(&cp);
+        try self.writeCacheFile();
+        if (self.args.annotationfile.len > 0) {
+            // WriteAnnotations is deprecated in C++; skip
+        }
+        {
+            var buf: [256]u8 = undefined;
+            const s = try std.fmt.bufPrint(&buf,
+                "        calcd:   vtb {: <4}  fwd {: <4}  hfrac {: <8}\n        merged:  hfrac {: <4} lratio {: <4}\n",
+                .{ @as(u32, @intCast(self.n_vtb_calculated)), @as(u32, @intCast(self.n_fwd_calculated)), @as(u32, @intCast(self.n_hfrac_calculated)), @as(u32, @intCast(self.n_hfrac_merges)), @as(u32, @intCast(self.n_lratio_merges)) },
+            );
+            try std.fs.File.stdout().writeAll(s);
+        }
+    }
+
+    /// Cache all naive sequences.
+    /// Corresponds to C++ `Glomerator::CacheNaiveSeqs`.
+    pub fn cacheNaiveSeqs(self: *Glomerator) !void {
+        // Phase-B' outer-most timer (same as cluster() above): cover the
+        // whole CacheNaiveSeqs path, including writeCacheFile. Defer
+        // order is LIFO — dump registered first runs last, so it sees the
+        // updated counter (see cluster() above for the rationale).
+        const t_glom = perf_counters.tick();
+        defer dumpGlomeratorCounters(self.allocator, "cacheNaiveSeqs") catch |err| reportGlomeratorCountersError(err);
+        defer perf_counters.addElapsed(&perf_counters.glomerator_ns, t_glom);
+        try std.fs.File.stdout().writeAll("      caching all naive sequences\n");
+        // Sort keys to match C++ map<string,...> iteration order
+        const sorted_keys = try self.allocator.alloc([]const u8, self.cachefo.count());
+        defer self.allocator.free(sorted_keys);
+        {
+            var it = self.cachefo.iterator();
+            var idx: usize = 0;
+            while (it.next()) |e| : (idx += 1) sorted_keys[idx] = e.key_ptr.*;
+        }
+        std.mem.sort([]const u8, sorted_keys, {}, struct {
+            fn lessThan(_: void, a: []const u8, b: []const u8) bool {
+                return std.mem.order(u8, a, b) == .lt;
+            }
+        }.lessThan);
+        for (sorted_keys) |key| {
+            _ = try self.getNaiveSeq(key, null);
+        }
+        try self.writeCacheFile();
+        // Signal completion by opening and closing the outfile
+        const f = try std.fs.cwd().createFile(self.args.outfile, .{});
+        f.close();
+        {
+            var buf: [256]u8 = undefined;
+            const s = try std.fmt.bufPrint(&buf,
+                "        calcd:   vtb {: <4}  fwd {: <4}  hfrac {: <8}\n        merged:  hfrac {: <4} lratio {: <4}\n",
+                .{ @as(u32, @intCast(self.n_vtb_calculated)), @as(u32, @intCast(self.n_fwd_calculated)), @as(u32, 0), @as(u32, 0), @as(u32, 0) },
+            );
+            try std.fs.File.stdout().writeAll(s);
+        }
+    }
+
+    // ── Cache file I/O ────────────────────────────────────────────────────────
+
+    /// C++: Glomerator::ReadCacheFile() — glomerator.cc:114
+    fn readCacheFile(self: *Glomerator) !void {
+        const allocator = self.allocator;
+        if (self.args.input_cachefname.len == 0) {
+            try std.fs.File.stdout().writeAll("        read-cache:  logprobs 0   naive-seqs 0\n");
+            return;
+        }
+
+        // 4 GiB cap accommodates collision-heavy paired runs (e.g. 50k all-singleton
+        // events) where the partition cache grows past 256 MiB. Not a memory guard —
+        // if RSS is genuinely tight the program will OOM regardless.
+        const content = try std.fs.cwd().readFileAlloc(allocator, self.args.input_cachefname, 4 * 1024 * 1024 * 1024);
+        defer allocator.free(content);
+
+        var line_iter = std.mem.splitScalar(u8, content, '\n');
+        const header = line_iter.next() orelse {
+            try std.fs.File.stdout().writeAll("        empty cachefile\n");
+            return;
+        };
+        _ = header; // just skip it
+
+        while (line_iter.next()) |raw| {
+            const line = std.mem.trim(u8, raw, " \t\r");
+            if (line.len == 0) continue;
+
+            var fields = std.mem.splitScalar(u8, line, ',');
+            const query = fields.next() orelse continue;
+            const logprob_str = fields.next() orelse "";
+            const naive_seq = fields.next() orelse "";
+            const naive_hfrac_str = fields.next() orelse "";
+            const errors_str = fields.next() orelse "";
+
+            if (std.mem.indexOf(u8, errors_str, "no_path") != null) {
+                const fq_key = try allocator.dupe(u8, query);
+                try self.failed_queries.put(allocator, fq_key, {});
+                continue;
+            }
+
+            if (logprob_str.len > 0) {
+                // C++ uses stod() (since ham f41e055 "fix precision: stof→stod for cache reads"):
+                // log_probs_ is map<string,double> and the cache file is written with setprecision(20).
+                // Parse as f64 to preserve full precision (the previous f32 truncation drove the
+                // 30k Zig-vs-C++ partition divergence — issue #375).
+                // `catch` warns and skips: a corrupted/truncated cache line shouldn't kill the
+                // run, but it should be visible. Cache files written with setprecision(20) are
+                // valid ASCII decimal so this should not fire under normal operation.
+                const val: f64 = std.fmt.parseFloat(f64, logprob_str) catch |e| {
+                    std.debug.print("WARN cache logprob parse failed for {s}: {} (skipping)\n", .{ query, e });
+                    continue;
+                };
+                const gop_lp = try self.log_probs.getOrPut(allocator, query);
+                if (!gop_lp.found_existing) gop_lp.key_ptr.* = try allocator.dupe(u8, query);
+                gop_lp.value_ptr.* = val;
+                const gop_ilp = try self.initial_log_probs.getOrPut(allocator, query);
+                if (!gop_ilp.found_existing) gop_ilp.key_ptr.* = try allocator.dupe(u8, query);
+            }
+
+            if (naive_hfrac_str.len > 0) {
+                // C++ uses stod() (see logprob branch above).
+                const val: f64 = std.fmt.parseFloat(f64, naive_hfrac_str) catch |e| {
+                    std.debug.print("WARN cache naive_hfrac parse failed for {s}: {} (skipping)\n", .{ query, e });
+                    continue;
+                };
+                const gop_nh = try self.naive_hfracs.getOrPut(allocator, query);
+                if (!gop_nh.found_existing) gop_nh.key_ptr.* = try allocator.dupe(u8, query);
+                gop_nh.value_ptr.* = val;
+                const gop_inh = try self.initial_naive_hfracs.getOrPut(allocator, query);
+                if (!gop_inh.found_existing) gop_inh.key_ptr.* = try allocator.dupe(u8, query);
+            }
+
+            if (naive_seq.len > 0) {
+                const gop_ns = try self.naive_seqs.getOrPut(allocator, query);
+                if (gop_ns.found_existing) {
+                    allocator.free(gop_ns.value_ptr.*);
+                } else {
+                    gop_ns.key_ptr.* = try allocator.dupe(u8, query);
+                }
+                gop_ns.value_ptr.* = try allocator.dupe(u8, naive_seq);
+                const gop_ins = try self.initial_naive_seqs.getOrPut(allocator, query);
+                if (!gop_ins.found_existing) gop_ins.key_ptr.* = try allocator.dupe(u8, query);
+            }
+        }
+
+        {
+            var buf: [128]u8 = undefined;
+            const s = try std.fmt.bufPrint(&buf, "        read-cache:  logprobs {d}   naive-seqs {d}\n", .{ self.log_probs.count(), self.naive_seqs.count() });
+            try std.fs.File.stdout().writeAll(s);
+        }
+    }
+
+    /// C++: Glomerator::WriteCacheFile() — glomerator.cc:190
+    fn writeCacheFile(self: *Glomerator) !void {
+        if (self.args.output_cachefname.len == 0) return;
+
+        const f = try std.fs.cwd().createFile(self.args.output_cachefname, .{});
+        defer f.close();
+        var wr_buf: [65536]u8 = undefined;
+        var wr = f.writer(&wr_buf);
+        const writer = &wr.interface;
+
+        try writer.writeAll("unique_ids,logprob,naive_seq,naive_hfrac,errors\n");
+
+        var keys_to_cache: std.StringHashMapUnmanaged(void) = .{};
+        defer {
+            var it = keys_to_cache.iterator();
+            while (it.next()) |e| self.allocator.free(e.key_ptr.*);
+            keys_to_cache.deinit(self.allocator);
+        }
+
+        {
+            var it = self.log_probs.iterator();
+            while (it.next()) |e| {
+                if (self.args.only_cache_new_vals and self.initial_log_probs.contains(e.key_ptr.*)) continue;
+                if (!keys_to_cache.contains(e.key_ptr.*))
+                    try keys_to_cache.put(self.allocator, try self.allocator.dupe(u8, e.key_ptr.*), {});
+            }
+        }
+        {
+            var it = self.naive_seqs.iterator();
+            while (it.next()) |e| {
+                if (self.args.only_cache_new_vals and self.initial_naive_seqs.contains(e.key_ptr.*)) continue;
+                if (!keys_to_cache.contains(e.key_ptr.*))
+                    try keys_to_cache.put(self.allocator, try self.allocator.dupe(u8, e.key_ptr.*), {});
+            }
+        }
+        if (self.args.cache_naive_hfracs) {
+            var it = self.naive_hfracs.iterator();
+            while (it.next()) |e| {
+                if (self.args.only_cache_new_vals and self.initial_naive_hfracs.contains(e.key_ptr.*)) continue;
+                if (!keys_to_cache.contains(e.key_ptr.*))
+                    try keys_to_cache.put(self.allocator, try self.allocator.dupe(u8, e.key_ptr.*), {});
+            }
+        }
+
+        // Sort cache keys to match C++ map<string,...> iteration order
+        const sorted_cache_keys = try self.allocator.alloc([]const u8, keys_to_cache.count());
+        defer self.allocator.free(sorted_cache_keys);
+        {
+            var kit = keys_to_cache.iterator();
+            var kidx: usize = 0;
+            while (kit.next()) |e| : (kidx += 1) sorted_cache_keys[kidx] = e.key_ptr.*;
+        }
+        std.mem.sort([]const u8, sorted_cache_keys, {}, struct {
+            fn lessThan(_: void, a: []const u8, b: []const u8) bool {
+                return std.mem.order(u8, a, b) == .lt;
+            }
+        }.lessThan);
+        for (sorted_cache_keys) |key| {
+            try writer.writeAll(key);
+            try writer.writeByte(',');
+            if (self.log_probs.get(key)) |lp| try writer.print("{d}", .{lp});
+            try writer.writeByte(',');
+            if (self.naive_seqs.get(key)) |ns| try writer.writeAll(ns);
+            try writer.writeByte(',');
+            if (self.args.cache_naive_hfracs) {
+                if (self.naive_hfracs.get(key)) |nh| try writer.print("{d}", .{nh});
+            }
+            try writer.writeByte(',');
+            if (self.errors.get(key)) |err| try writer.writeAll(err);
+            try writer.writeByte('\n');
+        }
+        try wr.interface.flush();
+    }
+
+    // ── Partition I/O ─────────────────────────────────────────────────────────
+
+    /// C++: Glomerator::WritePartitions() — glomerator.cc:227
+    fn writePartitions(self: *Glomerator, cp: *ClusterPath) !void {
+        const run_start = std.time.milliTimestamp();
+        if (self.args.debug > 0) {
+            try std.fs.File.stdout().writeAll("        writing partitions\n");
+        }
+        const f = try std.fs.cwd().createFile(self.args.outfile, .{});
+        defer f.close();
+        var wr_buf: [65536]u8 = undefined;
+        var wr = f.writer(&wr_buf);
+        const writer = &wr.interface;
+
+        try writer.writeAll("partition,logprob\n");
+
+        const n_parts = cp.partitions.items.len;
+        const istart: usize = if (n_parts > @as(usize, @intCast(self.args.n_partitions_to_write)))
+            n_parts - @as(usize, @intCast(self.args.n_partitions_to_write))
+        else
+            0;
+
+        for (istart..n_parts) |ipart| {
+            if (self.args.write_logprob_for_each_partition) {
+                const lp = try self.logProbOfPartition(&cp.partitions.items[ipart]);
+                cp.setLogprob(ipart, lp);
+            }
+
+            var first_cluster = true;
+            for (cp.partitions.items[ipart].items) |cl| {
+                if (!first_cluster) try writer.writeByte(';');
+                try writer.writeAll(cl);
+                first_cluster = false;
+            }
+            try writer.print(",{d}\n", .{cp.logprobs.items[ipart]});
+        }
+
+        try writer.flush();
+
+        if (self.args.write_logprob_for_each_partition) {
+            const elapsed = @as(f64, @floatFromInt(std.time.milliTimestamp() - run_start)) / 1000.0;
+            const s = try std.fmt.allocPrint(self.allocator, "        partition writing time (probably includes calculating a bunch of new logprobs) {d:.1}\n", .{elapsed});
+            defer self.allocator.free(s);
+            try std.fs.File.stdout().writeAll(s);
+        }
+    }
+
+    // ── Merge step ────────────────────────────────────────────────────────────
+
+    /// Perform one merge step.
+    /// Corresponds to C++ `Glomerator::Merge`.
+    pub fn merge(self: *Glomerator, path: *ClusterPath) !void {
+        var qpair = try self.findHfracMerge(path);
+        defer if (qpair) |*qp| qp.deinit(self.allocator);
+
+        // if no hfrac merge, try lratio
+        if (qpair == null) {
+            qpair = try self.findLRatioMerge(path);
+        }
+
+        // max_cluster_size check
+        if (self.args.max_cluster_size > 0) {
+            const cur_part = path.currentPartition();
+            for (cur_part.items) |cl| {
+                if (countMembers(cl) > self.args.max_cluster_size) {
+                    const s = try std.fmt.allocPrint(self.allocator, "    --max-cluster-size: stopping with a cluster of size {d} (> {d})\n", .{ @as(u32, @intCast(countMembers(cl))), self.args.max_cluster_size });
+                    defer self.allocator.free(s);
+                    try std.fs.File.stdout().writeAll(s);
+                    path.finished = true;
+                }
+            }
+            if (path.finished) return;
+        }
+
+        if (qpair == null) {
+            // No valid merge found
+            if (self.args.n_final_clusters == 0 and self.args.min_largest_cluster_size == 0) {
+                path.finished = true;
+            } else {
+                const cur_size = path.currentPartition().items.len;
+                const largest = largestClusterSize(path.currentPartition());
+                const need_more = (self.args.n_final_clusters > 0 and cur_size > self.args.n_final_clusters) or
+                    (self.args.min_largest_cluster_size > 0 and largest < self.args.min_largest_cluster_size);
+                if (need_more) {
+                    if (self.force_merge) {
+                        path.finished = true;
+                        // C++ always prints these (no debug check)
+                        if (self.args.n_final_clusters > 0) {
+                            const s = try std.fmt.allocPrint(self.allocator, "    couldn't merge beyond {d} clusters despite setting force merge\n", .{cur_size});
+                            defer self.allocator.free(s);
+                            try std.fs.File.stdout().writeAll(s);
+                        }
+                        if (self.args.min_largest_cluster_size > 0) {
+                            const s = try std.fmt.allocPrint(self.allocator, "    couldn't merge past a biggest cluster of {d} despite setting force merge\n", .{largest});
+                            defer self.allocator.free(s);
+                            try std.fs.File.stdout().writeAll(s);
+                        }
+                    } else {
+                        self.force_merge = true;
+                        // C++ always prints these (no debug check)
+                        if (self.args.n_final_clusters > 0) {
+                            const s = try std.fmt.allocPrint(self.allocator, "    setting force merge (currently have {d} clusters, requested {d})\n", .{ cur_size, self.args.n_final_clusters });
+                            defer self.allocator.free(s);
+                            try std.fs.File.stdout().writeAll(s);
+                        }
+                        if (self.args.min_largest_cluster_size > 0) {
+                            const s = try std.fmt.allocPrint(self.allocator, "    setting force merge (current biggest cluster {d}, requested {d})\n", .{ largest, self.args.min_largest_cluster_size });
+                            defer self.allocator.free(s);
+                            try std.fs.File.stdout().writeAll(s);
+                        }
+                    }
+                } else {
+                    path.finished = true;
+                }
+            }
+            return;
+        }
+
+        const chosen = qpair.?;
+        const parents = chosen.parents orelse return;
+        const p1 = parents[0];
+        const p2 = parents[1];
+
+        // Move to permanent cache
+        {
+            const key = try self.allocator.dupe(u8, chosen.name);
+            errdefer self.allocator.free(key);
+            var q_copy = try cloneQuery(self.allocator, &chosen);
+            errdefer q_copy.deinit(self.allocator);
+            try self.cachefo.put(self.allocator, key, q_copy);
+        }
+
+        _ = try self.getNaiveSeq(chosen.name, if (chosen.parents != null) &[2][]const u8{ p1, p2 } else null);
+        try self.updateLogProbTranslationsForAsymetrics(&chosen);
+        try self.moveSubsetsFromTmpCache(chosen.name);
+
+        // Build new partition
+        var new_partition: Partition = .{};
+        errdefer {
+            for (new_partition.items) |s| self.allocator.free(s);
+            new_partition.deinit(self.allocator);
+        }
+        const cur_part = path.currentPartition();
+        for (cur_part.items) |cl| {
+            if (!std.mem.eql(u8, cl, p1) and !std.mem.eql(u8, cl, p2)) {
+                try new_partition.append(self.allocator, try self.allocator.dupe(u8, cl));
+            }
+        }
+        try new_partition.append(self.allocator, try self.allocator.dupe(u8, chosen.name));
+        sortPartition(&new_partition);
+        try path.addPartition(self.allocator, new_partition, mathutils.NEG_INF, @intCast(self.args.n_partitions_to_write));
+
+        if (self.args.debug > 0) {
+            const s = try std.fmt.allocPrint(self.allocator, "       merged   {s}  {s}\n          removing {d} entries from tmp cache\n", .{ p1, p2, self.tmp_cachefo.count() });
+            defer self.allocator.free(s);
+            try std.fs.File.stdout().writeAll(s);
+        }
+
+        // Clear tmp cache
+        var tcit = self.tmp_cachefo.iterator();
+        while (tcit.next()) |e| {
+            self.allocator.free(e.key_ptr.*);
+            e.value_ptr.deinit(self.allocator);
+        }
+        self.tmp_cachefo.clearRetainingCapacity();
+
+        // Issue #342 item 7: parents p1 and p2 are no longer in the partition;
+        // drop their entries from the pair-keyed lratios cache. Narrowed to
+        // lratios only in #387 to preserve zig/cpp cache-file parity — cpp
+        // keeps log_probs, naive_seqs, errors, and naive_hfracs until process
+        // exit and writes them to hmm_cached_info.csv.
+        try self.pruneMergedLratios(p1, p2);
+
+        // Check if we're done
+        const new_size = path.currentPartition().items.len;
+        const new_largest = largestClusterSize(path.currentPartition());
+        if ((self.args.n_final_clusters > 0 and new_size <= self.args.n_final_clusters) or
+            (self.args.min_largest_cluster_size > 0 and new_largest >= self.args.min_largest_cluster_size))
+        {
+            path.finished = true;
+            if (self.args.n_final_clusters > 0) {
+                const s = try std.fmt.allocPrint(self.allocator, "    finished glomerating to {d} clusters (requested {d}), force merge status {d}\n", .{ new_size, self.args.n_final_clusters, @as(u8, if (self.force_merge) 1 else 0) });
+                defer self.allocator.free(s);
+                try std.fs.File.stdout().writeAll(s);
+            }
+            if (self.args.min_largest_cluster_size > 0) {
+                const s = try std.fmt.allocPrint(self.allocator, "    finished glomerating to a biggest cluster of {d} (requested {d}), force merge status {d}\n", .{ new_largest, self.args.min_largest_cluster_size, @as(u8, if (self.force_merge) 1 else 0) });
+                defer self.allocator.free(s);
+                try std.fs.File.stdout().writeAll(s);
+            }
+        }
+    }
+
+    // ── Log-probability calculation ───────────────────────────────────────────
+
+    /// C++: Glomerator::LogProbOfPartition() — glomerator.cc:282
+    fn logProbOfPartition(self: *Glomerator, partition: *const Partition) !f64 {
+        var total: f64 = 0.0;
+        for (partition.items) |key| {
+            const lp = try self.getLogProb(key);
+            total = mathutils.addWithMinusInfinities(total, lp);
+        }
+        return total;
+    }
+
+    /// C++: Glomerator::GetLogProb() — glomerator.cc:681
+    fn getLogProb(self: *Glomerator, queries: []const u8) !f64 {
+        if (self.log_probs.get(queries)) |lp| return lp;
+        const lp = try self.calculateLogProb(queries);
+        const key = try self.allocator.dupe(u8, queries);
+        try self.log_probs.put(self.allocator, key, lp);
+        return lp;
+    }
+
+    /// C++: Glomerator::CalculateLogProb() — glomerator.cc:754
+    fn calculateLogProb(self: *Glomerator, queries: []const u8) !f64 {
+        std.debug.assert(!self.log_probs.contains(queries));
+        self.n_fwd_calculated += 1;
+
+        var dph = try DPHandler.init(self.allocator, "forward", self.args, self.gl, self.hmms);
+        defer dph.deinit();
+
+        const cacheref = try self.getCachefo(queries);
+        const only_genes_slice = try self.geneListToSlice(cacheref.only_genes.items);
+        defer self.allocator.free(only_genes_slice);
+
+        var result = try dph.run(cacheref.seqs, cacheref.kbounds, only_genes_slice, cacheref.mute_freq, true);
+        defer result.deinit();
+
+        if (result.no_path) {
+            try self.addFailedQuery(queries, "no_path");
+            return mathutils.NEG_INF;
+        }
+        return result.total_score;
+    }
+
+    /// C++: Glomerator::GetLogProbRatio() — glomerator.cc:692
+    fn getLogProbRatio(self: *Glomerator, key_a: []const u8, key_b: []const u8) !f64 {
+        const joint_name = try self.joinNames(key_a, key_b);
+        defer self.allocator.free(joint_name);
+
+        if (self.lratios.get(joint_name)) |lr| return lr;
+
+        var full_qmerged = try self.getMergedQuery(key_a, key_b);
+        defer full_qmerged.deinit(self.allocator);
+        const parents_to_calc = try self.getLogProbPairOfNamesToCalculate(joint_name, if (full_qmerged.parents != null) &full_qmerged.parents.? else null);
+        defer {
+            self.allocator.free(parents_to_calc[0]);
+            self.allocator.free(parents_to_calc[1]);
+        }
+
+        const lp_a = try self.getLogProb(parents_to_calc[0]);
+        const lp_b = try self.getLogProb(parents_to_calc[1]);
+
+        var qmerged_calc = try self.getMergedQuery(parents_to_calc[0], parents_to_calc[1]);
+        defer qmerged_calc.deinit(self.allocator);
+        const lp_ab = try self.getLogProb(qmerged_calc.name);
+
+        const lratio = lp_ab - lp_a - lp_b;
+
+        if (self.args.debug > 0) {
+            const dbg = try std.fmt.allocPrint(self.allocator, "             {d: >8.3} = {s} - {s} - {s}", .{ lratio, joint_name, key_a, key_b });
+            defer self.allocator.free(dbg);
+            if (!std.mem.eql(u8, qmerged_calc.name, joint_name) or !std.mem.eql(u8, parents_to_calc[0], key_a) or !std.mem.eql(u8, parents_to_calc[1], key_b)) {
+                const calcd = try std.fmt.allocPrint(self.allocator, " (calcd  {s} - {s} - {s})", .{ qmerged_calc.name, parents_to_calc[0], parents_to_calc[1] });
+                defer self.allocator.free(calcd);
+                const combined = try std.fmt.allocPrint(self.allocator, "{s}{s}\n", .{ dbg, calcd });
+                defer self.allocator.free(combined);
+                try std.fs.File.stdout().writeAll(combined);
+            } else {
+                const with_nl = try std.fmt.allocPrint(self.allocator, "{s}\n", .{dbg});
+                defer self.allocator.free(with_nl);
+                try std.fs.File.stdout().writeAll(with_nl);
+            }
+        }
+
+        const lr_key = try self.allocator.dupe(u8, joint_name);
+        errdefer self.allocator.free(lr_key);
+        try self.lratios.put(self.allocator, lr_key, lratio);
+        return lratio;
+    }
+
+    // ── Naive sequence calculation ────────────────────────────────────────────
+
+    /// C++: Glomerator::GetNaiveSeq() — glomerator.cc:641
+    fn getNaiveSeq(self: *Glomerator, queries: []const u8, parents: ?*const [2][]const u8) anyerror![]const u8 {
+        if (self.naive_seqs.get(queries)) |ns| return ns;
+
+        // maybe use parent naive seq directly
+        if (parents != null) {
+            const replace = try self.findNaiveSeqNameReplace(parents.?);
+            if (replace) |rep| {
+                defer self.allocator.free(rep);
+                const parent_ns = try self.getNaiveSeq(rep, null);
+                const key = try self.allocator.dupe(u8, queries);
+                const val = try self.allocator.dupe(u8, parent_ns);
+                try self.naive_seqs.put(self.allocator, key, val);
+                return self.naive_seqs.get(queries).?;
+            }
+        }
+
+        const queries_to_calc = try self.getNaiveSeqNameToCalculate(queries);
+        defer self.allocator.free(queries_to_calc);
+
+        if (!self.naive_seqs.contains(queries_to_calc)) {
+            const tmp_ns = try self.calculateNaiveSeq(queries_to_calc, null);
+            if (tmp_ns.len == 0) {
+                self.allocator.free(tmp_ns);
+                {
+                    const warn = try std.fmt.allocPrint(self.allocator, "  warning: zero length naive sequence for {s}\n", .{queries_to_calc});
+                    defer self.allocator.free(warn);
+                    try std.fs.File.stdout().writeAll(warn);
+                }
+                return "";
+            }
+            const key = try self.allocator.dupe(u8, queries_to_calc);
+            errdefer self.allocator.free(key);
+            // tmp_ns is already an owned allocation from calculateNaiveSeq; store directly
+            errdefer self.allocator.free(tmp_ns);
+            try self.naive_seqs.put(self.allocator, key, tmp_ns);
+        }
+
+        if (!std.mem.eql(u8, queries_to_calc, queries)) {
+            const translated_ns = self.naive_seqs.get(queries_to_calc).?;
+            const key = try self.allocator.dupe(u8, queries);
+            const val = try self.allocator.dupe(u8, translated_ns);
+            try self.naive_seqs.put(self.allocator, key, val);
+        }
+
+        return self.naive_seqs.get(queries).?;
+    }
+
+    /// C++: Glomerator::CalculateNaiveSeq() — glomerator.cc:727
+    fn calculateNaiveSeq(self: *Glomerator, queries: []const u8, event_out: ?*RecoEvent) ![]u8 {
+        std.debug.assert(!self.naive_seqs.contains(queries));
+        self.n_vtb_calculated += 1;
+
+        var dph = try DPHandler.init(self.allocator, "viterbi", self.args, self.gl, self.hmms);
+        defer dph.deinit();
+
+        const cacheref = try self.getCachefo(queries);
+        const only_genes_slice = try self.geneListToSlice(cacheref.only_genes.items);
+        defer self.allocator.free(only_genes_slice);
+
+        var result = try dph.run(cacheref.seqs, cacheref.kbounds, only_genes_slice, cacheref.mute_freq, true);
+        defer result.deinit();
+
+        if (result.no_path) {
+            try self.addFailedQuery(queries, "no_path");
+            return self.allocator.dupe(u8, "");
+        }
+
+        if (event_out != null and result.best_event != null) {
+            event_out.?.* = result.best_event.?;
+        }
+
+        // Must dupe before defer result.deinit() frees the memory
+        return self.allocator.dupe(u8, result.best_event.?.naive_seq);
+    }
+
+    // ── Hamming fraction ──────────────────────────────────────────────────────
+
+    /// C++: Glomerator::CalculateHfrac() — glomerator.cc:455
+    fn calculateHfrac(self: *Glomerator, seq_a: []const u8, seq_b: []const u8) !f64 {
+        self.n_hfrac_calculated += 1;
+        if (seq_a.len != seq_b.len) return error.SequenceLengthMismatch;
+
+        var distance: usize = 0;
+        var len_excl_ambig: usize = 0;
+        const ambig_idx = track_mod.AMBIGUOUS_INDEX;
+
+        for (seq_a, seq_b) |ca, cb| {
+            const ia = self.track.symbolIndex(&[_]u8{ca}) catch ambig_idx;
+            const ib = self.track.symbolIndex(&[_]u8{cb}) catch ambig_idx;
+            if (ia == ambig_idx or ib == ambig_idx) continue;
+            len_excl_ambig += 1;
+            if (ia != ib) distance += 1;
+        }
+
+        if (len_excl_ambig == 0) return std.math.inf(f64);
+        return @as(f64, @floatFromInt(distance)) / @as(f64, @floatFromInt(len_excl_ambig));
+    }
+
+    /// C++: Glomerator::NaiveHfrac() — glomerator.cc:474
+    fn naiveHfrac(self: *Glomerator, key_a: []const u8, key_b: []const u8) !f64 {
+        const joint_key = try self.joinNames(key_a, key_b);
+        defer self.allocator.free(joint_key);
+
+        if (self.naive_hfracs.get(joint_key)) |hf| return hf;
+
+        const ns_a = try self.getNaiveSeq(key_a, null);
+        const ns_b = try self.getNaiveSeq(key_b, null);
+
+        if (ns_a.len == 0 or ns_b.len == 0 or
+            self.failed_queries.contains(key_a) or self.failed_queries.contains(key_b))
+            return std.math.inf(f64);
+
+        const hf = try self.calculateHfrac(ns_a, ns_b);
+        const jk = try self.allocator.dupe(u8, joint_key);
+        errdefer self.allocator.free(jk);
+        try self.naive_hfracs.put(self.allocator, jk, hf);
+        return hf;
+    }
+
+    // ── Merge finders ────────────────────────────────────────────────────────
+
+    /// C++: Glomerator::FindHfracMerge() — glomerator.cc:1000
+    fn findHfracMerge(self: *Glomerator, path: *ClusterPath) !?Query {
+        var min_hf: f64 = std.math.inf(f64);
+        var found = false;
+        var best_query: ?Query = null;
+
+        const cur_part = path.currentPartition();
+        const has_seed = self.args.seed_unique_id.len > 0;
+
+        var ia: usize = 0;
+        while (ia < cur_part.items.len) : (ia += 1) {
+            const key_a = cur_part.items[ia];
+            // C++: when seed is set, outer loop only covers seeded clusters (GetSeededClusters)
+            if (has_seed) {
+                const ca = try self.getCachefo(key_a);
+                if (ca.seed_missing) continue;
+            }
+
+            // C++: without seed, inner starts at ia+1; with seed, inner starts at 0 (all clusters)
+            var ib: usize = if (has_seed) 0 else ia + 1;
+            while (ib < cur_part.items.len) : (ib += 1) {
+                const key_b = cur_part.items[ib];
+
+                if (std.mem.eql(u8, key_a, key_b)) continue; // skip self-pairs (needed with seed)
+                if (self.failed_queries.contains(key_a) or self.failed_queries.contains(key_b)) continue;
+
+                _ = try self.getCachefo(key_a);
+                _ = try self.getCachefo(key_b);
+                const ca = self.cachefo.getPtr(key_a) orelse self.tmp_cachefo.getPtr(key_a) orelse return error.MissingSeqCache;
+                const cb = self.cachefo.getPtr(key_b) orelse self.tmp_cachefo.getPtr(key_b) orelse return error.MissingSeqCache;
+                if (ca.cdr3_length != cb.cdr3_length) continue;
+
+                const hf = try self.naiveHfrac(key_a, key_b);
+                if (hf > self.args.hamming_fraction_bound_hi) continue;
+                if (self.args.hamming_fraction_bound_lo <= 0.0 or hf >= self.args.hamming_fraction_bound_lo) continue;
+
+                if (hf < min_hf) {
+                    min_hf = hf;
+                    if (best_query) |*bq| bq.deinit(self.allocator);
+                    var merged = try self.getMergedQuery(key_a, key_b);
+                    defer merged.deinit(self.allocator);
+                    best_query = try cloneQuery(self.allocator, &merged);
+                    found = true;
+                }
+            }
+        }
+
+        if (found) {
+            self.n_hfrac_merges += 1;
+            if (self.args.debug > 0) {
+                if (best_query) |bq| {
+                    if (bq.parents) |parents| {
+                        const s = try std.fmt.allocPrint(self.allocator, "          hfrac merge  {d:.3}   {s}  {s}\n", .{ min_hf, printStr(parents[0]), printStr(parents[1]) });
+                        defer self.allocator.free(s);
+                        try std.fs.File.stdout().writeAll(s);
+                    }
+                }
+            }
+            return best_query;
+        }
+        return null;
+    }
+
+    /// C++: Glomerator::FindLRatioMerge() — glomerator.cc:1063
+    fn findLRatioMerge(self: *Glomerator, path: *ClusterPath) !?Query {
+        var max_lratio: f64 = mathutils.NEG_INF;
+        var best_query: ?Query = null;
+
+        const cur_part = path.currentPartition();
+        const has_seed = self.args.seed_unique_id.len > 0;
+
+        var ia: usize = 0;
+        while (ia < cur_part.items.len) : (ia += 1) {
+            const key_a = cur_part.items[ia];
+            // C++: when seed is set, outer loop only covers seeded clusters (GetSeededClusters)
+            if (has_seed) {
+                const ca = try self.getCachefo(key_a);
+                if (ca.seed_missing) continue;
+            }
+
+            // C++: without seed, inner starts at ia+1; with seed, inner starts at 0 (all clusters)
+            var ib: usize = if (has_seed) 0 else ia + 1;
+            while (ib < cur_part.items.len) : (ib += 1) {
+                const key_b = cur_part.items[ib];
+
+                if (std.mem.eql(u8, key_a, key_b)) continue; // skip self-pairs (needed with seed)
+                if (self.failed_queries.contains(key_a) or self.failed_queries.contains(key_b)) continue;
+
+                _ = try self.getCachefo(key_a);
+                _ = try self.getCachefo(key_b);
+                const ca = self.cachefo.getPtr(key_a) orelse self.tmp_cachefo.getPtr(key_a) orelse return error.MissingSeqCache;
+                const cb = self.cachefo.getPtr(key_b) orelse self.tmp_cachefo.getPtr(key_b) orelse return error.MissingSeqCache;
+                if (ca.cdr3_length != cb.cdr3_length) continue;
+
+                const hf = try self.naiveHfrac(key_a, key_b);
+                if (hf > self.args.hamming_fraction_bound_hi) continue;
+
+                const lratio = try self.getLogProbRatio(key_a, key_b);
+                const cluster_size: i32 = @intCast(countMembers(key_a) + countMembers(key_b));
+                if (!self.force_merge and self.likelihoodRatioTooSmall(lratio, cluster_size)) continue;
+
+                if (lratio > max_lratio) {
+                    max_lratio = lratio;
+                    if (best_query) |*bq| bq.deinit(self.allocator);
+                    var merged = try self.getMergedQuery(key_a, key_b);
+                    defer merged.deinit(self.allocator);
+                    best_query = try cloneQuery(self.allocator, &merged);
+                }
+            }
+        }
+
+        if (max_lratio != mathutils.NEG_INF) {
+            self.n_lratio_merges += 1;
+            if (self.args.debug > 0) {
+                if (best_query) |bq| {
+                    if (bq.parents) |parents| {
+                        const s = try std.fmt.allocPrint(self.allocator, "          lratio merge  {d:.3}   {s}  {s}\n", .{ max_lratio, printStr(parents[0]), printStr(parents[1]) });
+                        defer self.allocator.free(s);
+                        try std.fs.File.stdout().writeAll(s);
+                    }
+                }
+            }
+            return best_query;
+        }
+        return null;
+    }
+
+    /// Check whether the log-likelihood ratio is below a cluster-size-dependent threshold.
+    /// Ported from C++ `Glomerator::LikelihoodRatioTooSmall()`.
+    /// The threshold loosens by 1.0 for each additional sequence beyond 2, capped at ccs>=6.
+    /// `ccs` is the combined cluster size (number of sequences in the merged cluster).
+    fn likelihoodRatioTooSmall(self: *Glomerator, lratio: f64, combined_cluster_size: i32) bool {
+        const threshold = self.args.logprob_ratio_threshold;
+        if (combined_cluster_size == 2) return lratio < threshold;
+        if (combined_cluster_size == 3) return lratio < threshold - 2.0;
+        if (combined_cluster_size == 4) return lratio < threshold - 3.0;
+        if (combined_cluster_size == 5) return lratio < threshold - 4.0;
+        return lratio < threshold - 5.0;
+    }
+
+    // ── Cache utilities ───────────────────────────────────────────────────────
+
+    /// C++: Glomerator::cachefo() — glomerator.cc:782
+    fn getCachefo(self: *Glomerator, queries: []const u8) !*Query {
+        if (self.cachefo.getPtr(queries)) |q| return q;
+        if (self.tmp_cachefo.getPtr(queries)) |q| return q;
+
+        // Build on the fly from single_seq_cachefo. Single splitScalar pass
+        // over `queries` (item 16): the same iteration drives only_gene_set
+        // / kbounds / mute_freq and the seqs-pointer list, with no name dupes
+        // and no intermediate ArrayList from a separate getSeqs call.
+        var only_gene_set: std.StringHashMapUnmanaged(void) = .{};
+        defer {
+            var it = only_gene_set.iterator();
+            while (it.next()) |e| self.allocator.free(e.key_ptr.*);
+            only_gene_set.deinit(self.allocator);
+        }
+
+        var kbounds = KBounds{};
+        var mute_freq_total: f64 = 0.0;
+        var cdr3_length: usize = 0;
+
+        var key_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
+        defer key_seq_ptrs.deinit(self.allocator);
+        try key_seq_ptrs.ensureUnusedCapacity(self.allocator, @intCast(countMembers(queries)));
+
+        var n_names: usize = 0;
+        var name_it = std.mem.splitScalar(u8, queries, ':');
+        while (name_it.next()) |uid| {
+            if (uid.len == 0) continue;
+            const scache = self.single_seq_cachefo.getPtr(uid) orelse return error.MissingSeqCache;
+            for (scache.only_genes.items) |g| {
+                if (!only_gene_set.contains(g)) {
+                    try only_gene_set.put(self.allocator, try self.allocator.dupe(u8, g), {});
+                }
+            }
+            if (n_names == 0) {
+                kbounds = scache.kbounds;
+                cdr3_length = scache.cdr3_length;
+            } else {
+                kbounds = kbounds.logicalOr(scache.kbounds);
+                if (cdr3_length != scache.cdr3_length) return error.Cdr3LengthMismatch;
+            }
+            mute_freq_total += scache.mute_freq;
+
+            const sq_ptr = self.single_seqs.getPtr(uid) orelse return error.SequenceNotFound;
+            key_seq_ptrs.appendAssumeCapacity(sq_ptr);
+            n_names += 1;
+        }
+        // Defensive: an all-colon `queries` would yield no non-empty parts and
+        // would otherwise produce NaN from the mute_freq division below. Real
+        // cluster keys derive from non-empty UIDs, so this is not reachable on
+        // valid input — but the explicit error is cheaper than tracing NaN.
+        if (n_names == 0) return error.MissingSeqCache;
+
+        var only_genes_list: std.ArrayListUnmanaged([]const u8) = .{};
+        defer only_genes_list.deinit(self.allocator);
+        {
+            var ogit = only_gene_set.iterator();
+            while (ogit.next()) |e| {
+                try only_genes_list.append(self.allocator, e.key_ptr.*);
+            }
+        }
+        // Sort to match C++ set<string> iteration order
+        std.mem.sort([]const u8, only_genes_list.items, {}, struct {
+            fn lessThan(_: void, a: []const u8, b: []const u8) bool {
+                return std.mem.order(u8, a, b) == .lt;
+            }
+        }.lessThan);
+
+        const is_seed_missing = !ham_text.inString(self.args.seed_unique_id, queries, ":");
+        var new_q = try Query.create(
+            self.allocator,
+            queries,
+            key_seq_ptrs.items,
+            is_seed_missing,
+            only_genes_list.items,
+            kbounds,
+            mute_freq_total / @as(f64, @floatFromInt(n_names)),
+            cdr3_length,
+            null, null,
+        );
+        errdefer new_q.deinit(self.allocator);
+
+        const cf_key = try self.allocator.dupe(u8, queries);
+        errdefer self.allocator.free(cf_key);
+        try self.tmp_cachefo.put(self.allocator, cf_key, new_q);
+        return self.tmp_cachefo.getPtr(queries).?;
+    }
+
+    /// C++: Glomerator::GetMergedQuery() — glomerator.cc:908
+    fn getMergedQuery(self: *Glomerator, name_a: []const u8, name_b: []const u8) !Query {
+        const joint_name = try self.joinNames(name_a, name_b);
+        defer self.allocator.free(joint_name);
+
+        if (self.cachefo.getPtr(joint_name)) |q| return try cloneQuery(self.allocator, q);
+        if (self.tmp_cachefo.getPtr(joint_name)) |q| return try cloneQuery(self.allocator, q);
+
+        // NOTE: getCachefo returns a pointer into tmp_cachefo; the second call
+        // may insert and resize the map, invalidating the first pointer.
+        // So we must call both first, then re-lookup to get stable pointers.
+        _ = try self.getCachefo(name_a);
+        _ = try self.getCachefo(name_b);
+        const ref_a = self.cachefo.getPtr(name_a) orelse self.tmp_cachefo.getPtr(name_a) orelse return error.MissingSeqCache;
+        const ref_b = self.cachefo.getPtr(name_b) orelse self.tmp_cachefo.getPtr(name_b) orelse return error.MissingSeqCache;
+
+        if (ref_a.cdr3_length != ref_b.cdr3_length)
+            return error.Cdr3LengthMismatch;
+
+        // Union of only_genes
+        var joint_genes: std.StringHashMapUnmanaged(void) = .{};
+        defer {
+            var it = joint_genes.iterator();
+            while (it.next()) |e| self.allocator.free(e.key_ptr.*);
+            joint_genes.deinit(self.allocator);
+        }
+        for (ref_a.only_genes.items) |g| {
+            if (!joint_genes.contains(g))
+                try joint_genes.put(self.allocator, try self.allocator.dupe(u8, g), {});
+        }
+        for (ref_b.only_genes.items) |g| {
+            if (!joint_genes.contains(g))
+                try joint_genes.put(self.allocator, try self.allocator.dupe(u8, g), {});
+        }
+        var genes_list: std.ArrayListUnmanaged([]const u8) = .{};
+        defer genes_list.deinit(self.allocator);
+        {
+            var git = joint_genes.iterator();
+            while (git.next()) |e| {
+                try genes_list.append(self.allocator, e.key_ptr.*);
+            }
+        }
+        // Sort to match C++ set<string> iteration order
+        std.mem.sort([]const u8, genes_list.items, {}, struct {
+            fn lessThan(_: void, a: []const u8, b: []const u8) bool {
+                return std.mem.order(u8, a, b) == .lt;
+            }
+        }.lessThan);
+
+        const joint_kbounds = ref_a.kbounds.logicalOr(ref_b.kbounds);
+        const n_a_f64: f64 = @floatFromInt(ref_a.nSeqs());
+        const n_b_f64: f64 = @floatFromInt(ref_b.nSeqs());
+        const n_total_f64: f64 = n_a_f64 + n_b_f64;
+        const joint_mute_freq: f64 = (n_a_f64 * ref_a.mute_freq + n_b_f64 * ref_b.mute_freq) / n_total_f64;
+        const is_seed_missing = !ham_text.inString(self.args.seed_unique_id, joint_name, ":");
+
+        var key_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
+        defer key_seq_ptrs.deinit(self.allocator);
+        try self.appendSeqPtrsForQuery(&key_seq_ptrs, self.allocator, joint_name);
+
+        var q = try Query.create(
+            self.allocator,
+            joint_name,
+            key_seq_ptrs.items,
+            is_seed_missing,
+            genes_list.items,
+            joint_kbounds,
+            joint_mute_freq,
+            ref_a.cdr3_length,
+            name_a, name_b,
+        );
+        errdefer q.deinit(self.allocator);
+
+        const tmp_key = try self.allocator.dupe(u8, joint_name);
+        errdefer self.allocator.free(tmp_key);
+        const q_copy = try cloneQuery(self.allocator, &q);
+        try self.tmp_cachefo.put(self.allocator, tmp_key, q);
+
+        return q_copy;
+    }
+
+    // ── Name translation helpers ─────────────────────────────────────────────
+
+    /// C++: Glomerator::GetNaiveSeqNameToCalculate() — glomerator.cc:549
+    fn getNaiveSeqNameToCalculate(self: *Glomerator, actual_queries: []const u8) ![]u8 {
+        if (self.naive_seq_name_translations.get(actual_queries)) |t| return try self.allocator.dupe(u8, t);
+
+        const n = countMembersWithExcludeSeeds(actual_queries, self.args.seed_unique_id);
+        const threshold = @as(i32, @intCast(self.args.biggest_naive_seq_cluster_to_calculate));
+        // C++: CountMembers(...) < 1.5 * biggest_naive_seq_cluster_to_calculate()
+        // Must use float comparison to match C++ behavior exactly.
+        if (@as(f64, @floatFromInt(n)) < 1.5 * @as(f64, @floatFromInt(threshold))) {
+            return try self.allocator.dupe(u8, actual_queries);
+        }
+
+        const sub = try self.chooseSubsetOfNames(actual_queries, threshold);
+        if (self.args.debug > 0) {
+            const dbg = try std.fmt.allocPrint(self.allocator, "                translate for naive seq  {s}  -->  {s}\n", .{ actual_queries, sub });
+            defer self.allocator.free(dbg);
+            try std.fs.File.stdout().writeAll(dbg);
+        }
+        const key = try self.allocator.dupe(u8, actual_queries);
+        errdefer self.allocator.free(key);
+        const val = try self.allocator.dupe(u8, sub);
+        try self.naive_seq_name_translations.put(self.allocator, key, val);
+        return try self.allocator.dupe(u8, sub);
+    }
+
+    /// C++: Glomerator::GetLogProbPairOfNamesToCalculate() — glomerator.cc:584
+    fn getLogProbPairOfNamesToCalculate(self: *Glomerator, actual_queries: []const u8, actual_parents: ?*const [2][]u8) ![2][]u8 {
+        if (self.logprob_name_translations.get(actual_queries)) |t| {
+            return .{
+                try self.allocator.dupe(u8, t[0]),
+                try self.allocator.dupe(u8, t[1]),
+            };
+        }
+
+        const n_max: i32 = @intCast(self.args.biggest_logprob_cluster_to_calculate);
+        if (countMembers(actual_queries) <= 2 * n_max) {
+            if (actual_parents) |parents| {
+                return .{
+                    try self.allocator.dupe(u8, parents[0]),
+                    try self.allocator.dupe(u8, parents[1]),
+                };
+            }
+            return .{
+                try self.allocator.dupe(u8, actual_queries),
+                try self.allocator.dupe(u8, actual_queries),
+            };
+        }
+
+        const ap1 = if (actual_parents) |p| p[0] else actual_queries;
+        const ap2 = if (actual_parents) |p| p[1] else actual_queries;
+        const p1 = if (actual_parents) |p| try self.getLogProbNameToCalculate(p[0], n_max) else try self.allocator.dupe(u8, actual_queries);
+        const p2 = if (actual_parents) |p| try self.getLogProbNameToCalculate(p[1], n_max) else try self.allocator.dupe(u8, actual_queries);
+        const pair = [2][]u8{ p1, p2 };
+
+        if (self.args.debug > 0) {
+            const dbg = try std.fmt.allocPrint(self.allocator, "                translate for lratio ({s})   {s}  {s}  -->  {s}  {s}\n", .{ actual_queries, ap1, ap2, p1, p2 });
+            defer self.allocator.free(dbg);
+            try std.fs.File.stdout().writeAll(dbg);
+        }
+
+        const key = try self.allocator.dupe(u8, actual_queries);
+        errdefer self.allocator.free(key);
+        try self.logprob_name_translations.put(self.allocator, key, .{
+            try self.allocator.dupe(u8, p1),
+            try self.allocator.dupe(u8, p2),
+        });
+
+        return pair;
+    }
+
+    /// C++: Glomerator::GetLogProbNameToCalculate() — glomerator.cc:568
+    fn getLogProbNameToCalculate(self: *Glomerator, queries: []const u8, n_max: i32) ![]u8 {
+        var q = queries;
+        if (self.logprob_asymetric_translations.get(queries)) |t| {
+            if (self.args.debug > 0) {
+                const dbg = try std.fmt.allocPrint(self.allocator, "             using asymetric translation  {s}  -->  {s}\n", .{ queries, t });
+                defer self.allocator.free(dbg);
+                try std.fs.File.stdout().writeAll(dbg);
+            }
+            q = t;
+        }
+        if (countMembersWithExcludeSeeds(q, self.args.seed_unique_id) > n_max) {
+            return self.chooseSubsetOfNames(q, n_max);
+        }
+        return self.allocator.dupe(u8, q);
+    }
+
+    /// C++: Glomerator::ChooseSubsetOfNames() — glomerator.cc:490
+    fn chooseSubsetOfNames(self: *Glomerator, queries: []const u8, n_max_in: i32) ![]u8 {
+        if (self.name_subsets.get(queries)) |ns| return try self.allocator.dupe(u8, ns);
+
+        var namevec = try splitName(self.allocator, queries);
+        defer {
+            for (namevec.items) |n| self.allocator.free(n);
+            namevec.deinit(self.allocator);
+        }
+
+        // C++: set<string> nameset(namevector.begin(), namevector.end());
+        // Deduplicate names — with seed clustering you can get many duplicate seqs
+        var nameset = std.StringHashMapUnmanaged(void){};
+        defer nameset.deinit(self.allocator);
+        for (namevec.items) |name| try nameset.put(self.allocator, name, {});
+        var n_max: usize = @intCast(n_max_in);
+        if (nameset.count() < n_max) // C++: if(nameset.size() < unsigned(n_max))
+            n_max = nameset.count();
+
+        // C++: srand(hash<string>{}(queries)) — GCC's std::hash<string> is a 64-bit
+        // MurmurHash variant, and srand() truncates to unsigned int (32-bit)
+        const hash_val = gccStringHash(queries);
+        const seed_val: u32 = @truncate(hash_val);
+        var rand = GlibcRand.init(seed_val);
+
+        // C++ uses set<int> ichosen + set<string> chosen_strs for deduplication,
+        // plus vector<int> ichosen_vec for ordering
+        var ichosen = std.AutoHashMapUnmanaged(usize, void){};
+        defer ichosen.deinit(self.allocator);
+        var ichosen_vec = std.ArrayListUnmanaged(usize){};
+        defer ichosen_vec.deinit(self.allocator);
+        var chosen_strs = std.StringHashMapUnmanaged(void){};
+        defer chosen_strs.deinit(self.allocator);
+
+        for (0..n_max) |_| {
+            var n_tries: usize = 0;
+            while (true) {
+                // C++: ich = rand() % namevector.size()
+                const ich: usize = rand.next() % namevec.items.len;
+                n_tries += 1;
+                if (ichosen.contains(ich) or chosen_strs.contains(namevec.items[ich])) {
+                    if (n_tries > 1_000_000) return error.TooManyTriesInChooseSubset;
+                    continue;
+                }
+                try ichosen.put(self.allocator, ich, {});
+                try chosen_strs.put(self.allocator, namevec.items[ich], {});
+                try ichosen_vec.append(self.allocator, ich);
+                break;
+            }
+        }
+
+        // C++: sort(ichosen_vec.begin(), ichosen_vec.end())
+        std.mem.sort(usize, ichosen_vec.items, {}, std.sort.asc(usize));
+
+        var sub_names: std.ArrayListUnmanaged([]const u8) = .{};
+        defer sub_names.deinit(self.allocator);
+        for (ichosen_vec.items) |i| try sub_names.append(self.allocator, namevec.items[i]);
+
+        const subqueries = try ham_text.joinStrings(self.allocator, sub_names.items, ":");
+        errdefer self.allocator.free(subqueries);
+
+        // C++ caches the subset in tmp_cachefo_ using the parent cluster's attributes
+        // (only_genes, kbounds, mute_freq, cdr3_length). This is important because
+        // later getCachefo() calls for the subset will find this entry instead of
+        // rebuilding from singles, so the parent's mute_freq (the weighted-average
+        // value carried through the merge cascade) must be used for consistency
+        // with C++. Pre-#377 both backends stored mute_freq as f32, so the cascade
+        // also accumulated f32 truncation; #377 promoted both to f64.
+        const cacheref = try self.getCachefo(queries);
+        {
+            var sub_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
+            defer sub_seq_ptrs.deinit(self.allocator);
+            try self.appendSeqPtrsForQuery(&sub_seq_ptrs, self.allocator, subqueries);
+            const is_seed_missing = !ham_text.inString(self.args.seed_unique_id, subqueries, ":");
+            var sub_q = try Query.create(
+                self.allocator,
+                subqueries,
+                sub_seq_ptrs.items,
+                is_seed_missing,
+                cacheref.only_genes.items,
+                cacheref.kbounds,
+                cacheref.mute_freq,
+                cacheref.cdr3_length,
+                null, null,
+            );
+            errdefer sub_q.deinit(self.allocator);
+            const cf_key = try self.allocator.dupe(u8, subqueries);
+            errdefer self.allocator.free(cf_key);
+            try self.tmp_cachefo.put(self.allocator, cf_key, sub_q);
+        }
+
+        if (self.args.debug > 0) {
+            const dbg = try std.fmt.allocPrint(self.allocator, "                chose subset  {s}  -->  {s}\n", .{ queries, subqueries });
+            defer self.allocator.free(dbg);
+            try std.fs.File.stdout().writeAll(dbg);
+        }
+
+        const key = try self.allocator.dupe(u8, queries);
+        errdefer self.allocator.free(key);
+        try self.name_subsets.put(self.allocator, key, subqueries);
+
+        return try self.allocator.dupe(u8, subqueries);
+    }
+
+    /// C++: Glomerator::FindNaiveSeqNameReplace() — glomerator.cc:623
+    fn findNaiveSeqNameReplace(self: *Glomerator, parents: *const [2][]const u8) !?[]u8 {
+        const ns_a = try self.getNaiveSeq(parents[0], null);
+        const ns_b = try self.getNaiveSeq(parents[1], null);
+        if (std.mem.eql(u8, ns_a, ns_b)) return try self.allocator.dupe(u8, parents[0]);
+
+        const nmax: i32 = @intCast(@as(u64, @intCast(self.args.biggest_naive_seq_cluster_to_calculate)) * 3 / 2);
+        if (try self.firstParentMuchBigger(parents[0], parents[1], nmax)) return try self.allocator.dupe(u8, parents[0]);
+        if (try self.firstParentMuchBigger(parents[1], parents[0], nmax)) return try self.allocator.dupe(u8, parents[1]);
+        return null;
+    }
+
+    /// C++: Glomerator::FirstParentMuchBigger() — glomerator.cc:608
+    fn firstParentMuchBigger(self: *Glomerator, queries: []const u8, queries_other: []const u8, nmax: i32) !bool {
+        const nseq: i32 = countMembers(queries);
+        const nseq_other: i32 = countMembers(queries_other);
+        const result = nseq > nmax and @as(f64, @floatFromInt(nseq)) / @as(f64, @floatFromInt(nseq_other)) > self.asym_factor;
+        if (result and self.args.debug > 0) {
+            const joined = try self.joinNames(queries, queries_other);
+            defer self.allocator.free(joined);
+            const dbg = try std.fmt.allocPrint(self.allocator, "                asymetric  {d} {d}  use {s}  instead of {s}\n", .{ nseq, nseq_other, queries, joined });
+            defer self.allocator.free(dbg);
+            try std.fs.File.stdout().writeAll(dbg);
+            if (self.naive_seq_name_translations.get(queries)) |t| {
+                const dbg2 = try std.fmt.allocPrint(self.allocator, "                    naive seq translates to {s}\n", .{t});
+                defer self.allocator.free(dbg2);
+                try std.fs.File.stdout().writeAll(dbg2);
+            }
+        }
+        return result;
+    }
+
+    /// C++: Glomerator::UpdateLogProbTranslationsForAsymetrics() — glomerator.cc:1121
+    fn updateLogProbTranslationsForAsymetrics(self: *Glomerator, qmerge: *const Query) !void {
+        const parents = qmerge.parents orelse return;
+        const nmax: i32 = @intCast(@as(u64, @intCast(self.args.biggest_logprob_cluster_to_calculate)) * 3 / 2);
+
+        var big_parent: ?[]const u8 = null;
+        if (try self.firstParentMuchBigger(parents[0], parents[1], nmax))
+            big_parent = parents[0]
+        else if (try self.firstParentMuchBigger(parents[1], parents[0], nmax))
+            big_parent = parents[1];
+
+        if (big_parent == null) return;
+        const bp = big_parent.?;
+
+        // Follow chain of translations
+        var subqueries = bp;
+        while (self.logprob_asymetric_translations.get(subqueries)) |t| {
+            if (self.args.debug > 0) {
+                const dbg = try std.fmt.allocPrint(self.allocator, "                  turtles {s}  -->  {s}\n", .{ subqueries, t });
+                defer self.allocator.free(dbg);
+                try std.fs.File.stdout().writeAll(dbg);
+            }
+            subqueries = t;
+        }
+
+        const ratio = @as(f64, @floatFromInt(countMembers(bp))) /
+            @as(f64, @floatFromInt(countMembers(subqueries)));
+        if (ratio < 2.0) {
+            if (self.args.debug > 0) {
+                const dbg = try std.fmt.allocPrint(self.allocator, "                logprob asymetric translation  {s}  -->  {s}\n", .{ qmerge.name, subqueries });
+                defer self.allocator.free(dbg);
+                try std.fs.File.stdout().writeAll(dbg);
+            }
+            const key = try self.allocator.dupe(u8, qmerge.name);
+            errdefer self.allocator.free(key);
+            const val = try self.allocator.dupe(u8, subqueries);
+            errdefer self.allocator.free(val);
+            try self.logprob_asymetric_translations.put(self.allocator, key, val);
+        } else {
+            if (self.args.debug > 0) {
+                const dbg = try std.fmt.allocPrint(self.allocator, "                  ratio too big for asymetric {d} {d}\n", .{ countMembers(bp), countMembers(subqueries) });
+                defer self.allocator.free(dbg);
+                try std.fs.File.stdout().writeAll(dbg);
+            }
+        }
+    }
+
+    /// C++: Glomerator::MoveSubsetsFromTmpCache() — glomerator.cc:865
+    fn moveSubsetsFromTmpCache(self: *Glomerator, query: []const u8) !void {
+        if (self.naive_seq_name_translations.get(query)) |tq| {
+            try self.copyToPermanentCache(tq, query);
+        }
+        if (self.logprob_name_translations.get(query)) |tpair| {
+            try self.copyToPermanentCache(tpair[0], query);
+            try self.copyToPermanentCache(tpair[1], query);
+        }
+        if (self.logprob_asymetric_translations.get(query)) |tq| {
+            try self.copyToPermanentCache(tq, query);
+        }
+    }
+
+    /// C++: Glomerator::CopyToPermanentCache() — glomerator.cc:889
+    fn copyToPermanentCache(self: *Glomerator, translated_query: []const u8, superquery: []const u8) !void {
+        if (self.tmp_cachefo.getPtr(translated_query)) |tq| {
+            const key = try self.allocator.dupe(u8, translated_query);
+            errdefer self.allocator.free(key);
+            const val = try cloneQuery(self.allocator, tq);
+            try self.cachefo.put(self.allocator, key, val);
+        } else {
+            const supercache = try self.getCachefo(superquery);
+            var key_seq_ptrs: std.ArrayListUnmanaged(*const Sequence) = .{};
+            defer key_seq_ptrs.deinit(self.allocator);
+            try self.appendSeqPtrsForQuery(&key_seq_ptrs, self.allocator, translated_query);
+            const is_seed_missing = !ham_text.inString(self.args.seed_unique_id, translated_query, ":");
+            var q = try Query.create(
+                self.allocator,
+                translated_query,
+                key_seq_ptrs.items,
+                is_seed_missing,
+                supercache.only_genes.items,
+                supercache.kbounds,
+                supercache.mute_freq,
+                supercache.cdr3_length,
+                null, null,
+            );
+            errdefer q.deinit(self.allocator);
+            const cf_key = try self.allocator.dupe(u8, translated_query);
+            errdefer self.allocator.free(cf_key);
+            try self.cachefo.put(self.allocator, cf_key, q);
+        }
+    }
+
+    // ── Utility helpers ───────────────────────────────────────────────────────
+
+    /// Append `*const Sequence` pointers into `single_seqs` to `dst`, one per
+    /// colon-separated UID in `query`. Iterates `splitScalar` directly — no
+    /// per-name `dupe`, no intermediate ArrayList. The pointed-to Sequences
+    /// must outlive any consumer that holds these pointers.
+    /// C++: corresponds to the `Glomerator::GetSeqs()` callers' inline build
+    /// pattern (glomerator.cc:850 + the lookup loop in cachefo()).
+    /// Issue #342, items 6 + 16.
+    fn appendSeqPtrsForQuery(
+        self: *Glomerator,
+        dst: *std.ArrayListUnmanaged(*const Sequence),
+        allocator: std.mem.Allocator,
+        query: []const u8,
+    ) !void {
+        try dst.ensureUnusedCapacity(allocator, @intCast(countMembers(query)));
+        var it = std.mem.splitScalar(u8, query, ':');
+        while (it.next()) |uid| {
+            if (uid.len == 0) continue;
+            const sq = self.single_seqs.getPtr(uid) orelse return error.SequenceNotFound;
+            dst.appendAssumeCapacity(sq);
+        }
+    }
+
+    /// C++: Glomerator::AddFailedQuery() — glomerator.cc:776
+    fn addFailedQuery(self: *Glomerator, queries: []const u8, error_str: []const u8) !void {
+        // Reserve capacity up-front so the puts below are infallible. This lets
+        // every fallible allocation happen under errdefer protection, and the
+        // ownership transfer to the maps stays atomic.
+        try self.errors.ensureUnusedCapacity(self.allocator, 1);
+        try self.failed_queries.ensureUnusedCapacity(self.allocator, 1);
+
+        const fq_key = try self.allocator.dupe(u8, queries);
+        errdefer self.allocator.free(fq_key);
+
+        const errors_key = try self.allocator.dupe(u8, queries);
+        errdefer self.allocator.free(errors_key);
+
+        const old_err = self.errors.get(queries) orelse "";
+        const new_err = try std.fmt.allocPrint(self.allocator, "{s}:{s}", .{ old_err, error_str });
+        errdefer self.allocator.free(new_err);
+
+        if (self.errors.fetchRemove(queries)) |old| {
+            self.allocator.free(old.key);
+            self.allocator.free(old.value);
+        }
+        self.errors.putAssumeCapacity(errors_key, new_err);
+        self.failed_queries.putAssumeCapacity(fq_key, {});
+    }
+
+    // ── Cache pruning after merge (issue #342, item 7) ────────────────────────
+
+    /// True iff `key` is a pair-key (joinNames result, "name1:name2") with `parent`
+    /// occupying one whole side. Anchors at colon boundaries to avoid substring
+    /// false positives between distinct UID names (e.g. "u1" vs "u11").
+    fn keyHasParent(key: []const u8, parent: []const u8) bool {
+        if (key.len <= parent.len) return false;
+        if (std.mem.startsWith(u8, key, parent) and key[parent.len] == ':') return true;
+        // key[key.len - parent.len - 1] is the byte immediately before the suffix match
+        // (i.e. the colon separator). The bounds check above guarantees this is in range.
+        if (std.mem.endsWith(u8, key, parent) and key[key.len - parent.len - 1] == ':') return true;
+        return false;
+    }
+
+    /// Drop a single-cluster-keyed entry, freeing the duped key (and the duped value
+    /// when V == []u8). The `if (V == []u8)` branch is comptime-evaluated.
+    fn pruneSingleKey(self: *Glomerator, comptime V: type, map: *std.StringHashMapUnmanaged(V), key: []const u8) void {
+        if (map.fetchRemove(key)) |kv| {
+            self.allocator.free(kv.key);
+            if (V == []u8) self.allocator.free(kv.value);
+        }
+    }
+
+    /// Drop every pair-keyed f64 entry whose key has p1 or p2 as one whole side.
+    /// Two-pass to avoid invalidating the map iterator: collect dead keys first,
+    /// then fetchRemove + free.
+    fn pruneParentPairsF64(self: *Glomerator, map: *std.StringHashMapUnmanaged(f64), p1: []const u8, p2: []const u8) !void {
+        var dead_keys: std.ArrayListUnmanaged([]const u8) = .{};
+        defer dead_keys.deinit(self.allocator);
+        var it = map.iterator();
+        while (it.next()) |e| {
+            const k = e.key_ptr.*;
+            if (keyHasParent(k, p1) or keyHasParent(k, p2)) {
+                try dead_keys.append(self.allocator, k);
+            }
+        }
+        for (dead_keys.items) |k| {
+            if (map.fetchRemove(k)) |kv| self.allocator.free(kv.key);
+        }
+    }
+
+    /// After a merge of (p1, p2) → AB, drop pair-keyed lratios[K] for every
+    /// K = joinNames(p1, _) or joinNames(p2, _). lratios is compute-only and
+    /// never persisted to the cache file (see partis/utils.py:955), so this
+    /// prune is a free memory win without affecting cache-file parity with
+    /// cpp. The other post-merge maps (log_probs, naive_seqs, errors,
+    /// naive_hfracs) are *not* pruned here: cpp keeps them until process exit
+    /// and writes them to hmm_cached_info.csv, and pruning them on the zig
+    /// side caused the cache-file divergence reported in issue #387.
+    fn pruneMergedLratios(self: *Glomerator, p1: []const u8, p2: []const u8) !void {
+        try self.pruneParentPairsF64(&self.lratios, p1, p2);
+    }
+
+    /// C++: Glomerator::JoinNames() — glomerator.cc:404
+    fn joinNames(self: *Glomerator, name1: []const u8, name2: []const u8) ![]u8 {
+        var names = [_][]const u8{ name1, name2 };
+        std.mem.sort([]const u8, &names, {}, struct {
+            fn lessThan(_: void, a: []const u8, b: []const u8) bool {
+                return std.mem.lessThan(u8, a, b);
+            }
+        }.lessThan);
+        return std.fmt.allocPrint(self.allocator, "{s}:{s}", .{ names[0], names[1] });
+    }
+
+    fn geneListToSlice(self: *Glomerator, genes: []const []u8) ![]const []const u8 {
+        const result = try self.allocator.alloc([]const u8, genes.len);
+        for (genes, result) |g, *r| r.* = g;
+        return result;
+    }
+};
+
+// ── Module-level helpers ──────────────────────────────────────────────────────
+
+fn splitName(allocator: std.mem.Allocator, query: []const u8) !std.ArrayListUnmanaged([]u8) {
+    var result: std.ArrayListUnmanaged([]u8) = .{};
+    var it = std.mem.splitScalar(u8, query, ':');
+    while (it.next()) |part| {
+        if (part.len > 0) try result.append(allocator, try allocator.dupe(u8, part));
+    }
+    return result;
+}
+
+/// Return "len(N)" if the cluster has >= 10 members, otherwise the full string.
+/// Corresponds to C++ `Glomerator::PrintStr`.
+/// Uses alternating static buffers since this may be called twice per print.
+fn printStr(queries: []const u8) []const u8 {
+    if (countMembers(queries) < 10) return queries;
+    const S = struct {
+        var bufs: [2][32]u8 = .{ undefined, undefined };
+        var idx: u1 = 0;
+    };
+    const i = S.idx;
+    S.idx +%= 1;
+    const s = std.fmt.bufPrint(&S.bufs[i], "len({d})", .{countMembers(queries)}) catch return queries;
+    return s;
+}
+
+/// C++: Glomerator::CountMembers() — glomerator.cc:360
+fn countMembers(namestr: []const u8) i32 {
+    var n: i32 = 1;
+    for (namestr) |c| {
+        if (c == ':') n += 1;
+    }
+    return n;
+}
+
+fn countMembersWithExcludeSeeds(namestr: []const u8, seed_uid: []const u8) i32 {
+    _ = seed_uid;
+    return countMembers(namestr);
+}
+
+/// C++: Glomerator::LargestClusterSize() — glomerator.cc:374
+fn largestClusterSize(partition: *const Partition) u32 {
+    var max: u32 = 0;
+    for (partition.items) |cluster| {
+        const sz: u32 = @intCast(countMembers(cluster));
+        if (sz > max) max = sz;
+    }
+    return max;
+}
+
+/// GCC libstdc++ `std::hash<std::string>` on 64-bit Linux.
+/// Based on MurmurHashUnaligned2 variant from gcc/libstdc++-v3/libsupc++/hash_bytes.cc,
+/// `_Hash_bytes` function and `load_bytes` helper. Seed is 0xc70f6907 (from functional_hash.h).
+/// Only valid on little-endian architectures (x86-64).
+fn gccStringHash(s: []const u8) u64 {
+    comptime if (@import("builtin").cpu.arch.endian() != .little)
+        @compileError("gccStringHash assumes little-endian (x86-64)");
+    const mul: u64 = 0xc6a4a7935bd1e995;
+    const seed: u64 = 0xc70f6907;
+    const len = s.len;
+
+    var hash: u64 = seed ^ (len *% mul);
+
+    // Process 8 bytes at a time
+    var i: usize = 0;
+    while (i + 8 <= len) : (i += 8) {
+        const data = shiftMix(std.mem.readInt(u64, s[i..][0..8], .little) *% mul) *% mul;
+        hash ^= data;
+        hash *%= mul;
+    }
+
+    // Tail: remaining bytes
+    const remaining = len & 7;
+    if (remaining != 0) {
+        // Matches libstdc++ load_bytes (hash_bytes.cc): packs remaining
+        // bytes into u64 with last byte most-significant.
+        var data: u64 = 0;
+        var j: usize = remaining;
+        while (j > 0) {
+            j -= 1;
+            data = (data << 8) + @as(u64, s[i + j]);
+        }
+        hash ^= data;
+        hash *%= mul;
+    }
+
+    // Finalization
+    hash = shiftMix(hash) *% mul;
+    hash = shiftMix(hash);
+    return hash;
+}
+
+fn shiftMix(v: u64) u64 {
+    return v ^ (v >> 47);
+}
+
+/// glibc TYPE_3 PRNG — matches srand()/rand() on Linux.
+/// State: 31 words, separation 3, trinomial x^31 + x^3 + 1.
+const GlibcRand = struct {
+    state: [31]i32,
+    fptr: usize, // index into state (initially 3)
+    rptr: usize, // index into state (initially 0)
+
+    fn init(seed_val: u32) GlibcRand {
+        var self = GlibcRand{ .state = undefined, .fptr = 3, .rptr = 0 };
+        // glibc treats seed=0 as seed=1. @bitCast reinterprets u32 as i32 (may
+        // be negative for seeds > 0x7FFFFFFF), matching glibc's cast from
+        // unsigned int to int32_t in __srandom_r.
+        const seed: i32 = if (seed_val == 0) 1 else @bitCast(seed_val);
+        self.state[0] = seed;
+
+        // Fill state[1..30] with Park-Miller LCG: x = 16807*x mod 2^31-1
+        var word: i32 = seed;
+        for (1..31) |i| {
+            const lo: i64 = @as(i64, @rem(word, 127773)) * 16807;
+            const hi: i64 = @as(i64, @divTrunc(word, 127773)) * 2836;
+            var val: i64 = lo - hi;
+            if (val < 0) val += 2147483647;
+            word = @intCast(val);
+            self.state[i] = word;
+        }
+
+        // Warm up: discard 310 values (DEG_3 * 10)
+        for (0..310) |_| _ = self.next();
+
+        return self;
+    }
+
+    /// Returns a 31-bit non-negative value (0..2^31-1), matching glibc rand().
+    fn next(self: *GlibcRand) u32 {
+        // Additive feedback: state[fptr] += state[rptr]
+        const val: u32 = @as(u32, @bitCast(self.state[self.fptr])) +% @as(u32, @bitCast(self.state[self.rptr]));
+        self.state[self.fptr] = @bitCast(val);
+        const result: u32 = val >> 1; // drop LSB, return 31-bit value
+
+        // Advance pointers cyclically
+        self.fptr += 1;
+        if (self.fptr >= 31) {
+            self.fptr = 0;
+            self.rptr += 1;
+        } else {
+            self.rptr += 1;
+            if (self.rptr >= 31) self.rptr = 0;
+        }
+
+        return result;
+    }
+};
+
+fn cloneQuery(allocator: std.mem.Allocator, q: *const Query) !Query {
+    return Query.create(
+        allocator,
+        q.name,
+        q.seqs,
+        q.seed_missing,
+        q.only_genes.items,
+        q.kbounds,
+        q.mute_freq,
+        q.cdr3_length,
+        if (q.parents) |p| p[0] else null,
+        if (q.parents) |p| p[1] else null,
+    );
+}

--- a/packages/zig-core/src/ham/glomerator/query.zig
+++ b/packages/zig-core/src/ham/glomerator/query.zig
@@ -1,0 +1,105 @@
+/// ham/glomerator/query.zig — Zig port of ham::Query
+///
+/// A named cluster with associated sequences, kbounds, and gene lists.
+/// C++ source: packages/ham/include/glomerator.h
+
+const std = @import("std");
+const Sequence = @import("../sequences.zig").Sequence;
+const KBounds = @import("../bcr_utils/k_bounds.zig").KBounds;
+
+/// Corresponds to C++ `ham::Query`.
+///
+/// Sequence ownership (issue #342, items 6 and 16): `seqs` holds **borrowed**
+/// `*const Sequence` pointers into buffers owned by `Glomerator.single_seqs`.
+/// The Query must not outlive the Glomerator that owns those buffers, and
+/// `Query.deinit` must not call `Sequence.deinit` on the pointed-to values —
+/// only the pointer slice itself is owned.
+pub const Query = struct {
+    name: []u8,
+    /// Borrowed pointers into `Glomerator.single_seqs`. Allocated as a single
+    /// slice at create-time; never grown. Must not be deinit'd per-item.
+    seqs: []*const Sequence,
+    seed_missing: bool,
+    only_genes: std.ArrayListUnmanaged([]u8),
+    kbounds: KBounds,
+    mute_freq: f64,
+    cdr3_length: usize,
+    /// Names of the two parent queries (may be empty when not set).
+    parents: ?[2][]u8,
+
+    pub fn init(allocator: std.mem.Allocator) !Query {
+        _ = allocator;
+        return Query{
+            .name = &.{},
+            .seqs = &.{},
+            .seed_missing = false,
+            .only_genes = .{},
+            .kbounds = .{},
+            .mute_freq = 0.0,
+            .cdr3_length = 0,
+            .parents = null,
+        };
+    }
+
+    /// Create a fully-specified Query. `seqs` is borrowed: each pointer is
+    /// stored verbatim, and the pointed-to Sequences must outlive this Query.
+    /// See struct doc comment.
+    pub fn create(
+        allocator: std.mem.Allocator,
+        name: []const u8,
+        seqs: []const *const Sequence,
+        seed_missing: bool,
+        only_genes: []const []const u8,
+        kbounds: KBounds,
+        mute_freq: f64,
+        cdr3_length: usize,
+        parent1: ?[]const u8,
+        parent2: ?[]const u8,
+    ) !Query {
+        var q = Query{
+            .name = try allocator.dupe(u8, name),
+            .seqs = &.{},
+            .seed_missing = seed_missing,
+            .only_genes = .{},
+            .kbounds = kbounds,
+            .mute_freq = mute_freq,
+            .cdr3_length = cdr3_length,
+            .parents = null,
+        };
+        errdefer q.deinit(allocator);
+
+        if (seqs.len > 0) {
+            const seqs_buf = try allocator.alloc(*const Sequence, seqs.len);
+            @memcpy(seqs_buf, seqs);
+            q.seqs = seqs_buf;
+        }
+        for (only_genes) |g| {
+            try q.only_genes.append(allocator, try allocator.dupe(u8, g));
+        }
+        if (parent1 != null and parent2 != null) {
+            q.parents = .{
+                try allocator.dupe(u8, parent1.?),
+                try allocator.dupe(u8, parent2.?),
+            };
+        }
+        return q;
+    }
+
+    pub fn deinit(self: *Query, allocator: std.mem.Allocator) void {
+        if (self.name.len > 0) allocator.free(self.name);
+        // seqs entries are borrowed pointers (see struct doc); do not call
+        // Sequence.deinit on them. Only the pointer slice itself is owned.
+        if (self.seqs.len > 0) allocator.free(self.seqs);
+        for (self.only_genes.items) |g| allocator.free(g);
+        self.only_genes.deinit(allocator);
+        if (self.parents) |*ps| {
+            allocator.free(ps[0]);
+            allocator.free(ps[1]);
+        }
+    }
+
+    /// Return number of sequences.
+    pub fn nSeqs(self: *const Query) usize {
+        return self.seqs.len;
+    }
+};

--- a/packages/zig-core/src/ham/glomerator/root.zig
+++ b/packages/zig-core/src/ham/glomerator/root.zig
@@ -1,0 +1,11 @@
+/// ham/glomerator/root.zig — Zig port of ham::Glomerator (directory group)
+///
+/// Re-exports all sub-modules of the glomerator directory group.
+/// C++ source: packages/ham/src/glomerator.cc, packages/ham/include/glomerator.h
+/// C++ author: psathyrella/ham
+
+pub const query = @import("query.zig");
+pub const glomerator = @import("glomerator.zig");
+
+pub const Query = query.Query;
+pub const Glomerator = glomerator.Glomerator;

--- a/packages/zig-core/src/ham/hmm_yaml.zig
+++ b/packages/zig-core/src/ham/hmm_yaml.zig
@@ -1,0 +1,425 @@
+/// ham/hmm_yaml.zig — Minimal YAML reader for partis HMM parameter files.
+///
+/// Hand-rolled line-oriented parser tailored to the known HMM file structure.
+/// This avoids a full YAML dependency and handles the Python-tagged objects
+/// (`!!python/object:...`) that appear in partis HMM files.
+///
+/// Supported structure (from packages/ham/src/model.cc Parse()):
+///   top-level scalar keys: name, extras.gene_prob, extras.overall_mute_freq,
+///                          extras.ambiguous_char
+///   tracks: map of track_name → list of symbols
+///   states: sequence of state objects, each with:
+///     name, extras (germline, ambiguous_char, ambiguous_emission_prob),
+///     transitions (map of name → prob), emissions (probs map + track name)
+
+const std = @import("std");
+
+/// Parsed emission data for one state.
+pub const EmissionData = struct {
+    /// Map from symbol name to raw probability.
+    /// Keys are owned allocator strings; must deinit keys separately.
+    probs: std.StringHashMap(f64),
+    /// Track name (e.g. "nukes"). Owned string.
+    track_name: []u8,
+
+    pub fn deinit(self: *EmissionData, allocator: std.mem.Allocator) void {
+        var it = self.probs.keyIterator();
+        while (it.next()) |k| allocator.free(k.*);
+        self.probs.deinit();
+        allocator.free(self.track_name);
+    }
+};
+
+/// Parsed data for one HMM state.
+pub const StateData = struct {
+    name: []u8,
+    germline_nuc: ?[]u8,
+    ambiguous_char: ?[]u8,
+    ambiguous_emission_prob: ?f64,
+    /// Map from to_state_name to raw probability.
+    /// Keys are owned allocator strings.
+    transitions: std.StringHashMap(f64),
+    /// null for "init" state or states with null emissions.
+    emissions: ?EmissionData,
+
+    pub fn deinit(self: *StateData, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        if (self.germline_nuc) |g| allocator.free(g);
+        if (self.ambiguous_char) |a| allocator.free(a);
+        var it = self.transitions.keyIterator();
+        while (it.next()) |k| allocator.free(k.*);
+        self.transitions.deinit();
+        if (self.emissions) |*e| e.deinit(allocator);
+    }
+};
+
+/// Parsed track data.
+pub const TrackData = struct {
+    name: []u8,
+    symbols: std.ArrayListUnmanaged([]u8),
+
+    pub fn deinit(self: *TrackData, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        for (self.symbols.items) |s| allocator.free(s);
+        self.symbols.deinit(allocator);
+    }
+};
+
+/// Full parsed HMM model data.
+pub const HmmData = struct {
+    name: []u8,
+    overall_prob: f64,
+    original_overall_mute_freq: f64,
+    ambiguous_char: []u8,
+    tracks: std.ArrayListUnmanaged(TrackData),
+    states: std.ArrayListUnmanaged(StateData),
+
+    pub fn deinit(self: *HmmData, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.ambiguous_char);
+        for (self.tracks.items) |*t| t.deinit(allocator);
+        self.tracks.deinit(allocator);
+        for (self.states.items) |*s| s.deinit(allocator);
+        self.states.deinit(allocator);
+    }
+};
+
+/// Parse a partis HMM YAML file.
+/// Returns an owned HmmData that the caller must deinit.
+pub fn parseFile(allocator: std.mem.Allocator, path: []const u8) !HmmData {
+    const content = try std.fs.cwd().readFileAlloc(allocator, path, 16 * 1024 * 1024);
+    defer allocator.free(content);
+    return parseString(allocator, content);
+}
+
+/// Context sections for the parser.
+const Section = enum {
+    top,
+    top_extras,
+    tracks,
+    track_symbols,
+    state_body,
+    state_extras,
+    state_transitions,
+    state_emissions,
+    state_emissions_probs,
+};
+
+fn countLeadingSpaces(line: []const u8) usize {
+    var n: usize = 0;
+    for (line) |c| {
+        if (c == ' ') n += 1 else break;
+    }
+    return n;
+}
+
+fn trimLine(line: []const u8) []const u8 {
+    return std.mem.trim(u8, line, " \t\r");
+}
+
+/// Flush current_state into result.states (if non-null) and reset.
+fn flushState(allocator: std.mem.Allocator, result: *HmmData, current_state: *?StateData) !void {
+    if (current_state.*) |cs| {
+        try result.states.append(allocator, cs);
+        current_state.* = null;
+    }
+}
+
+/// Flush current_track into result.tracks (if non-null) and reset.
+fn flushTrack(allocator: std.mem.Allocator, result: *HmmData, current_track: *?TrackData) !void {
+    if (current_track.*) |ct| {
+        try result.tracks.append(allocator, ct);
+        current_track.* = null;
+    }
+}
+
+/// Parse the HMM YAML string.
+pub fn parseString(allocator: std.mem.Allocator, content: []const u8) !HmmData {
+    var result = HmmData{
+        .name = try allocator.dupe(u8, ""),
+        .overall_prob = 0.0,
+        .original_overall_mute_freq = 0.0,
+        .ambiguous_char = try allocator.dupe(u8, ""),
+        .tracks = .{},
+        .states = .{},
+    };
+    errdefer result.deinit(allocator);
+
+    var section: Section = .top;
+    var current_track: ?TrackData = null;
+    var current_state: ?StateData = null;
+
+    var line_iter = std.mem.splitScalar(u8, content, '\n');
+    while (line_iter.next()) |raw| {
+        const line = if (raw.len > 0 and raw[raw.len - 1] == '\r') raw[0 .. raw.len - 1] else raw;
+
+        // Detect start of a new state (list item with Python object tag)
+        if (std.mem.startsWith(u8, line, "- !!python/object:")) {
+            try flushState(allocator, &result, &current_state);
+            current_state = StateData{
+                .name = try allocator.dupe(u8, ""),
+                .germline_nuc = null,
+                .ambiguous_char = null,
+                .ambiguous_emission_prob = null,
+                .transitions = std.StringHashMap(f64).init(allocator),
+                .emissions = null,
+            };
+            section = .state_body;
+            continue;
+        }
+
+        // Skip top-level Python object tag and blank lines
+        if (std.mem.startsWith(u8, line, "!!python/object:")) continue;
+        if (line.len == 0) continue;
+
+        const indent = countLeadingSpaces(line);
+        const t = trimLine(line);
+
+        // Universal top-level section transitions (can arrive from any section).
+        // The `tracks:` key appears *after* all states in real partis YAML files.
+        if (indent == 0 and std.mem.eql(u8, t, "tracks:")) {
+            try flushState(allocator, &result, &current_state);
+            section = .tracks;
+            continue;
+        }
+        if (indent == 0 and std.mem.eql(u8, t, "states:")) {
+            try flushTrack(allocator, &result, &current_track);
+            section = .top; // states are started by "- !!python/object:" lines
+            continue;
+        }
+        if (indent == 0 and std.mem.startsWith(u8, t, "name: ")) {
+            allocator.free(result.name);
+            result.name = try allocator.dupe(u8, t["name: ".len..]);
+            continue;
+        }
+
+        reprocess: while (true) {
+        switch (section) {
+            .top => {
+                if (std.mem.startsWith(u8, t, "name: ")) {
+                    allocator.free(result.name);
+                    result.name = try allocator.dupe(u8, t["name: ".len..]);
+                } else if (std.mem.eql(u8, t, "extras:")) {
+                    section = .top_extras;
+                } else if (std.mem.eql(u8, t, "tracks:")) {
+                    section = .tracks;
+                }
+                // "states:" is handled by the - !!python/object: detection
+            },
+            .top_extras => {
+                if (indent == 0) {
+                    section = .top;
+                    // re-process
+                    if (std.mem.startsWith(u8, t, "name: ")) {
+                        allocator.free(result.name);
+                        result.name = try allocator.dupe(u8, t["name: ".len..]);
+                    } else if (std.mem.eql(u8, t, "tracks:")) {
+                        section = .tracks;
+                    }
+                } else if (std.mem.startsWith(u8, t, "gene_prob: ")) {
+                    result.overall_prob = try std.fmt.parseFloat(f64, t["gene_prob: ".len..]);
+                } else if (std.mem.startsWith(u8, t, "overall_mute_freq: ")) {
+                    result.original_overall_mute_freq = try std.fmt.parseFloat(f64, t["overall_mute_freq: ".len..]);
+                } else if (std.mem.startsWith(u8, t, "ambiguous_char: ")) {
+                    allocator.free(result.ambiguous_char);
+                    result.ambiguous_char = try allocator.dupe(u8, t["ambiguous_char: ".len..]);
+                }
+            },
+            .tracks => {
+                if (indent == 0) {
+                    try flushTrack(allocator, &result, &current_track);
+                    section = .top;
+                    if (std.mem.startsWith(u8, t, "name: ")) {
+                        allocator.free(result.name);
+                        result.name = try allocator.dupe(u8, t["name: ".len..]);
+                    }
+                } else if (indent == 2 and std.mem.endsWith(u8, t, ":") and !std.mem.startsWith(u8, t, "- ")) {
+                    // New track: "  nukes:"
+                    try flushTrack(allocator, &result, &current_track);
+                    current_track = TrackData{
+                        .name = try allocator.dupe(u8, t[0 .. t.len - 1]),
+                        .symbols = .{},
+                    };
+                } else if (indent >= 2 and std.mem.startsWith(u8, t, "- ")) {
+                    // Track symbol: "  - A"
+                    if (current_track) |*ct| {
+                        try ct.symbols.append(allocator, try allocator.dupe(u8, t[2..]));
+                    }
+                }
+            },
+            .track_symbols => unreachable,
+            .state_body => {
+                if (current_state == null) continue;
+                if (std.mem.startsWith(u8, t, "name: ")) {
+                    allocator.free(current_state.?.name);
+                    current_state.?.name = try allocator.dupe(u8, t["name: ".len..]);
+                } else if (std.mem.eql(u8, t, "extras:")) {
+                    section = .state_extras;
+                } else if (std.mem.eql(u8, t, "extras: {}")) {
+                    // empty extras — do nothing
+                } else if (std.mem.eql(u8, t, "transitions:")) {
+                    section = .state_transitions;
+                } else if (std.mem.eql(u8, t, "emissions: null")) {
+                    // init state or null emissions — stay as null
+                } else if (std.mem.eql(u8, t, "emissions:")) {
+                    section = .state_emissions;
+                    if (current_state.?.emissions == null) {
+                        current_state.?.emissions = EmissionData{
+                            .probs = std.StringHashMap(f64).init(allocator),
+                            .track_name = try allocator.dupe(u8, ""),
+                        };
+                    }
+                }
+            },
+            .state_extras => {
+                if (current_state == null) continue;
+                if (indent <= 2) {
+                    // Indent fell below extras level — re-process as state_body
+                    section = .state_body;
+                    continue :reprocess;
+                } else if (std.mem.startsWith(u8, t, "germline: ")) {
+                    if (current_state.?.germline_nuc) |g| allocator.free(g);
+                    current_state.?.germline_nuc = try allocator.dupe(u8, t["germline: ".len..]);
+                } else if (std.mem.startsWith(u8, t, "ambiguous_char: ")) {
+                    if (current_state.?.ambiguous_char) |a| allocator.free(a);
+                    current_state.?.ambiguous_char = try allocator.dupe(u8, t["ambiguous_char: ".len..]);
+                } else if (std.mem.startsWith(u8, t, "ambiguous_emission_prob: ")) {
+                    current_state.?.ambiguous_emission_prob = try std.fmt.parseFloat(f64, t["ambiguous_emission_prob: ".len..]);
+                }
+            },
+            .state_transitions => {
+                if (current_state == null) continue;
+                if (indent <= 2) {
+                    // Indent fell below transitions level — re-process as state_body
+                    section = .state_body;
+                    continue :reprocess;
+                } else {
+                    // "    state_name: 0.5"
+                    if (std.mem.indexOf(u8, t, ": ")) |colon| {
+                        const key = try allocator.dupe(u8, t[0..colon]);
+                        const prob = try std.fmt.parseFloat(f64, t[colon + 2 ..]);
+                        try current_state.?.transitions.put(key, prob);
+                    }
+                }
+            },
+            .state_emissions => {
+                if (current_state == null) continue;
+                if (indent <= 2) {
+                    // Indent fell below emissions level — re-process as state_body
+                    section = .state_body;
+                    continue :reprocess;
+                } else if (std.mem.startsWith(u8, t, "track: ")) {
+                    if (current_state.?.emissions) |*em| {
+                        allocator.free(em.track_name);
+                        em.track_name = try allocator.dupe(u8, t["track: ".len..]);
+                    }
+                } else if (std.mem.eql(u8, t, "probs:")) {
+                    section = .state_emissions_probs;
+                }
+            },
+            .state_emissions_probs => {
+                if (current_state == null) continue;
+                // Probs lines have indent >= 6. Track line has indent == 4.
+                if (indent <= 2) {
+                    // Indent fell below emissions_probs level — re-process as state_body
+                    section = .state_body;
+                    continue :reprocess;
+                } else if (indent == 4) {
+                    // Back to emissions level (e.g. "    track: nukes")
+                    section = .state_emissions;
+                    if (std.mem.startsWith(u8, t, "track: ")) {
+                        if (current_state.?.emissions) |*em| {
+                            allocator.free(em.track_name);
+                            em.track_name = try allocator.dupe(u8, t["track: ".len..]);
+                        }
+                    }
+                } else {
+                    // "      A: 0.25"
+                    if (std.mem.indexOf(u8, t, ": ")) |colon| {
+                        const key = try allocator.dupe(u8, t[0..colon]);
+                        const prob = try std.fmt.parseFloat(f64, t[colon + 2 ..]);
+                        if (current_state.?.emissions) |*em| {
+                            try em.probs.put(key, prob);
+                        } else {
+                            allocator.free(key);
+                        }
+                    }
+                }
+            },
+        }
+        break; // processed line; exit reprocess loop
+        }
+    }
+
+    // Flush final state and track
+    if (current_state) |cs| try result.states.append(allocator, cs);
+    if (current_track) |ct| try result.tracks.append(allocator, ct);
+
+    return result;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "hmm_yaml: parse simple HMM string" {
+    const allocator = std.testing.allocator;
+
+    // Use the exact same indentation as real partis YAML files.
+    const yaml = "!!python/object:python.hmmwriter.HMM\n" ++
+        "extras:\n" ++
+        "  gene_prob: 0.5\n" ++
+        "  overall_mute_freq: 0.1\n" ++
+        "name: test_gene\n" ++
+        "tracks:\n" ++
+        "  nukes:\n" ++
+        "  - A\n" ++
+        "  - C\n" ++
+        "  - G\n" ++
+        "  - T\n" ++
+        "states:\n" ++
+        "- !!python/object:python.hmmwriter.State\n" ++
+        "  emissions: null\n" ++
+        "  extras: {}\n" ++
+        "  name: init\n" ++
+        "  transitions:\n" ++
+        "    state0: 1.0\n" ++
+        "- !!python/object:python.hmmwriter.State\n" ++
+        "  emissions:\n" ++
+        "    probs:\n" ++
+        "      A: 0.25\n" ++
+        "      C: 0.25\n" ++
+        "      G: 0.25\n" ++
+        "      T: 0.25\n" ++
+        "    track: nukes\n" ++
+        "  extras:\n" ++
+        "    ambiguous_char: N\n" ++
+        "    ambiguous_emission_prob: 0.25\n" ++
+        "    germline: A\n" ++
+        "  name: state0\n" ++
+        "  transitions:\n" ++
+        "    end: 1.0\n";
+
+    var data = try parseString(allocator, yaml);
+    defer data.deinit(allocator);
+
+    try std.testing.expectEqualStrings("test_gene", data.name);
+    try std.testing.expectApproxEqAbs(0.5, data.overall_prob, 1e-9);
+    try std.testing.expectApproxEqAbs(0.1, data.original_overall_mute_freq, 1e-9);
+    try std.testing.expectEqual(@as(usize, 1), data.tracks.items.len);
+    try std.testing.expectEqualStrings("nukes", data.tracks.items[0].name);
+    try std.testing.expectEqual(@as(usize, 4), data.tracks.items[0].symbols.items.len);
+    try std.testing.expectEqual(@as(usize, 2), data.states.items.len);
+
+    // Check init state
+    const init_state = &data.states.items[0];
+    try std.testing.expectEqualStrings("init", init_state.name);
+    try std.testing.expect(init_state.emissions == null);
+    try std.testing.expectEqual(@as(usize, 1), init_state.transitions.count());
+
+    // Check state0
+    const s0 = &data.states.items[1];
+    try std.testing.expectEqualStrings("state0", s0.name);
+    try std.testing.expectEqualStrings("A", s0.germline_nuc.?);
+    try std.testing.expect(s0.emissions != null);
+    try std.testing.expectEqual(@as(usize, 4), s0.emissions.?.probs.count());
+    try std.testing.expectApproxEqAbs(0.25, s0.emissions.?.probs.get("A").?, 1e-9);
+}

--- a/packages/zig-core/src/ham/lexical_table.zig
+++ b/packages/zig-core/src/ham/lexical_table.zig
@@ -1,0 +1,183 @@
+/// ham/lexical_table.zig — Zig port of ham/src/lexicaltable.cc + ham/include/lexicaltable.h
+///
+/// Emission probability lookup table: maps a digitized symbol index → log-probability.
+/// Used by the Emission model and ultimately by Trellis (Forward/Viterbi).
+///
+/// C++ source: packages/ham/src/lexicaltable.cc, packages/ham/include/lexicaltable.h
+/// C++ author: psathyrella/ham
+
+const std = @import("std");
+const Track = @import("track.zig").Track;
+const Sequence = @import("sequences.zig").Sequence;
+
+/// EPS for normalization check (matches C++ build define -DEPS=1e-6).
+const EPS: f64 = 1e-6;
+
+/// Emission probability lookup table indexed by digitized symbol.
+/// Corresponds to C++ `ham::LexicalTable`.
+pub const LexicalTable = struct {
+    /// Pointer to the track (not owned; must outlive this LexicalTable).
+    track: ?*const Track,
+    /// Log-probabilities for each symbol in the track's alphabet.
+    /// Owned by this struct, allocated by setLogProbs and reused thereafter.
+    log_probs: []f64,
+    /// Saved copy of log_probs from the last replaceLogProbs call. Sized
+    /// the same as log_probs and allocated together by setLogProbs (item 15
+    /// of #342). Treated as a scratch buffer: replace/unReplace @memcpy
+    /// rather than realloc, so per-query rescale/un-rescale cycles do not
+    /// hit the allocator (~50k calls per 5k-seq run).
+    original_log_probs: []f64,
+
+    /// Create an empty LexicalTable with no track.
+    /// Corresponds to C++ `LexicalTable()`.
+    pub fn init() LexicalTable {
+        return LexicalTable{
+            .track = null,
+            .log_probs = &[_]f64{},
+            .original_log_probs = &[_]f64{},
+        };
+    }
+
+    /// Set the track pointer.
+    /// Corresponds to C++ `LexicalTable::Init(Track*)`.
+    pub fn setTrack(self: *LexicalTable, trk: *const Track) void {
+        self.track = trk;
+    }
+
+    pub fn deinit(self: *LexicalTable, allocator: std.mem.Allocator) void {
+        if (self.log_probs.len > 0) allocator.free(self.log_probs);
+        if (self.original_log_probs.len > 0) allocator.free(self.original_log_probs);
+    }
+
+    /// Set (replace) log_probs from a slice, taking a copy. Also (re)allocates
+    /// the `original_log_probs` scratch buffer to the same size, so subsequent
+    /// replace/unReplace calls can @memcpy without hitting the allocator.
+    /// Atomic: if either allocation fails the struct is left unchanged.
+    /// Corresponds to C++ `LexicalTable::SetLogProbs(vector<double>)`.
+    pub fn setLogProbs(self: *LexicalTable, allocator: std.mem.Allocator, logprobs: []const f64) !void {
+        const new_log_probs = try allocator.dupe(f64, logprobs);
+        errdefer allocator.free(new_log_probs);
+        const new_original = try allocator.alloc(f64, logprobs.len);
+        if (self.log_probs.len > 0) allocator.free(self.log_probs);
+        if (self.original_log_probs.len > 0) allocator.free(self.original_log_probs);
+        self.log_probs = new_log_probs;
+        self.original_log_probs = new_original;
+    }
+
+    /// Replace log_probs with new values, saving the originals for unReplaceLogProbs.
+    /// Asserts that sizes match. Checks that exp(new probs) sum to ~1.0 within EPS.
+    /// Atomic: validates the new distribution before mutating either buffer,
+    /// so a `BadNormalization` return leaves `log_probs` and `original_log_probs`
+    /// untouched.
+    /// Corresponds to C++ `LexicalTable::ReplaceLogProbs(vector<double>)`.
+    pub fn replaceLogProbs(self: *LexicalTable, new_log_probs: []const f64) !void {
+        std.debug.assert(self.log_probs.len == new_log_probs.len);
+        std.debug.assert(self.original_log_probs.len == new_log_probs.len);
+        var total: f64 = 0.0;
+        for (new_log_probs) |lp| total += @exp(lp);
+        if (@abs(total - 1.0) >= EPS) {
+            return error.BadNormalization;
+        }
+        @memcpy(self.original_log_probs, self.log_probs);
+        @memcpy(self.log_probs, new_log_probs);
+    }
+
+    /// Revert log_probs to the values saved by replaceLogProbs.
+    /// Corresponds to C++ `LexicalTable::UnReplaceLogProbs()`.
+    pub fn unReplaceLogProbs(self: *LexicalTable) void {
+        std.debug.assert(self.original_log_probs.len == self.log_probs.len);
+        @memcpy(self.log_probs, self.original_log_probs);
+    }
+
+    /// Return the log-probability for a digitized symbol index.
+    /// Corresponds to C++ `inline double LogProb(uint8_t index)`.
+    pub fn logProb(self: *const LexicalTable, index: u8) f64 {
+        return self.log_probs[index];
+    }
+
+    /// Return the log-probability for the symbol at `pos` in `seq`.
+    /// Corresponds to C++ `double LogProb(Sequence *seq, size_t pos)`.
+    pub fn logProbSeq(self: *const LexicalTable, seq: *const Sequence, pos: usize) f64 {
+        std.debug.assert(pos < seq.size());
+        const idx = seq.seqq[pos];
+        std.debug.assert(idx < self.log_probs.len);
+        return self.log_probs[idx];
+    }
+
+    /// Return a copy of the log_probs slice.
+    /// Corresponds to C++ `vector<double> log_probs()` (which returns a copy).
+    pub fn logProbs(self: *const LexicalTable, allocator: std.mem.Allocator) ![]f64 {
+        return allocator.dupe(f64, self.log_probs);
+    }
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "LexicalTable: init and setLogProbs" {
+    const allocator = std.testing.allocator;
+    var lt = LexicalTable.init();
+    defer lt.deinit(allocator);
+
+    const lps = [_]f64{ @log(0.25), @log(0.25), @log(0.25), @log(0.25) };
+    try lt.setLogProbs(allocator, &lps);
+
+    try std.testing.expectEqual(@as(usize, 4), lt.log_probs.len);
+    try std.testing.expectApproxEqAbs(@log(0.25), lt.logProb(0), 1e-9);
+    try std.testing.expectApproxEqAbs(@log(0.25), lt.logProb(3), 1e-9);
+}
+
+test "LexicalTable: replaceLogProbs and unReplaceLogProbs" {
+    const allocator = std.testing.allocator;
+    var lt = LexicalTable.init();
+    defer lt.deinit(allocator);
+
+    const orig = [_]f64{ @log(0.25), @log(0.25), @log(0.25), @log(0.25) };
+    try lt.setLogProbs(allocator, &orig);
+
+    // Replace with new valid distribution
+    const new_lps = [_]f64{ @log(0.5), @log(0.3), @log(0.1), @log(0.1) };
+    try lt.replaceLogProbs(&new_lps);
+    try std.testing.expectApproxEqAbs(@log(0.5), lt.logProb(0), 1e-9);
+
+    // Revert
+    lt.unReplaceLogProbs();
+    try std.testing.expectApproxEqAbs(@log(0.25), lt.logProb(0), 1e-9);
+}
+
+test "LexicalTable: replaceLogProbs rejects bad normalization" {
+    const allocator = std.testing.allocator;
+    var lt = LexicalTable.init();
+    defer lt.deinit(allocator);
+
+    const orig = [_]f64{ @log(0.25), @log(0.25), @log(0.25), @log(0.25) };
+    try lt.setLogProbs(allocator, &orig);
+
+    // Distribution that sums to 0.9, not 1.0
+    const bad = [_]f64{ @log(0.3), @log(0.3), @log(0.2), @log(0.1) };
+    const result = lt.replaceLogProbs(&bad);
+    try std.testing.expectError(error.BadNormalization, result);
+    // Atomicity: log_probs must be unchanged on BadNormalization
+    try std.testing.expectApproxEqAbs(@log(0.25), lt.logProb(0), 1e-9);
+}
+
+test "LexicalTable: logProbSeq" {
+    const allocator = std.testing.allocator;
+    const sym_list = [_][]const u8{ "A", "C", "G", "T" };
+    var track = try @import("track.zig").Track.initWithSymbols(allocator, "nucs", &sym_list, "N");
+    defer track.deinit(allocator);
+
+    var lt = LexicalTable.init();
+    defer lt.deinit(allocator);
+    lt.setTrack(&track);
+
+    const lps = [_]f64{ @log(0.1), @log(0.2), @log(0.3), @log(0.4) };
+    try lt.setLogProbs(allocator, &lps);
+
+    var seq = try @import("sequences.zig").Sequence.initFromString(allocator, &track, "s1", "ACGT");
+    defer seq.deinit(allocator);
+
+    // A → index 0 → log(0.1)
+    try std.testing.expectApproxEqAbs(@log(0.1), lt.logProbSeq(&seq, 0), 1e-9);
+    // T → index 3 → log(0.4)
+    try std.testing.expectApproxEqAbs(@log(0.4), lt.logProbSeq(&seq, 3), 1e-9);
+}

--- a/packages/zig-core/src/ham/mathutils.zig
+++ b/packages/zig-core/src/ham/mathutils.zig
@@ -1,0 +1,219 @@
+/// ham/mathutils.zig — Zig port of ham/include/mathutils.h + ham/src/mathutils.cc
+///
+/// Math utility functions used throughout ham.
+/// All functions in namespace ham (free functions, no class).
+///
+/// C++ source: packages/ham/src/mathutils.cc, packages/ham/include/mathutils.h
+/// C++ author: psathyrella/ham
+///
+/// Checkpoint strategy: per-call checkpoints are impractical for HMM inner-loop
+/// functions (e.g. AddWithMinusInfinities is called ~117k times per sequence).
+/// Checkpoint coverage is provided by higher-level callers (DpHandler, Trellis)
+/// once those are ported.
+
+const std = @import("std");
+const math = std.math;
+const perf_counters = @import("perf_counters.zig");
+
+// Use glibc log/exp via C wrapper (glibc_math.c) to match C++ bcrham bit-for-bit.
+// Zig's `extern fn log/exp` resolves to compiler-rt (bundled as local 't' symbols),
+// NOT glibc. On some CPUs compiler-rt differs from glibc by ~1 ULP, which accumulates
+// to ~0.001 over thousands of trellis DP steps. The C wrapper forces actual glibc calls.
+extern fn glibc_log(x: f64) f64;
+extern fn glibc_exp(x: f64) f64;
+pub const log = glibc_log;
+pub const exp = glibc_exp;
+
+// fast_softplus(d) = log(1 + exp(d)), via 64K-entry linear-interp LUT.
+// Implemented in fast_math.c; mirrored on the C++ side at
+// packages/ham/src/fast_math.c. Replaces 1 log + 1 exp glibc call inside
+// addInLogSpace with a single load + 1 mul + 1 fma — ~22-40% speedup
+// per addInLogSpace call across Zen 3-5 and Intel Broadwell. Accuracy
+// 6.5e-9 max abs over [-30, 0] (5 orders under partis-test 1e-5 gate).
+// See fast_math.c for the design notes (issue #366 item 3.2).
+extern fn fast_softplus(d: f64) f64;
+
+/// Negative infinity constant for log-probability computations.
+/// Replaces the verbose `-std.math.inf(f64)` throughout the codebase.
+pub const NEG_INF: f64 = -math.inf(f64);
+
+// ── POWER table ───────────────────────────────────────────────────────────────
+//
+// Corresponds to C++ `POWER[b][a-1] = a**b` in mathutils.h.
+// Used by LexicalTable for alphabet size lookups.
+// In C++ this is a compile-time static const uint64_t[32][128].
+// We represent it the same way: comptime-evaluated lookup table.
+//
+// Rather than replicate the 32×128 literal (which is large), we compute it
+// at comptime. C++ defines POWER[b][a-1] = a**b (note: a-1 indexing).
+// We expose a function power(b, a) = a**b matching the C++ semantics.
+pub fn power(b: usize, a: usize) u64 {
+    if (b == 0) return 1;
+    var result: u64 = 1;
+    var i: usize = 0;
+    while (i < b) : (i += 1) {
+        result *= @as(u64, a);
+    }
+    return result;
+}
+
+// ── AddWithMinusInfinities ────────────────────────────────────────────────────
+
+/// Add two log-space values, treating -inf as the absorbing zero element.
+/// Computes log(a * b) = log(a) + log(b) where -inf represents probability 0.
+/// Corresponds to C++ `ham::AddWithMinusInfinities(double first, double second)`.
+pub fn addWithMinusInfinities(first: f64, second: f64) f64 {
+    if (first == NEG_INF or second == NEG_INF)
+        return NEG_INF;
+    return first + second;
+}
+
+// ── AddInLogSpace ─────────────────────────────────────────────────────────────
+
+/// Log-sum-exp: computes log(a + b) from (log a, log b).
+/// Implements the log-space *or* operation (a OR b = a + b in probability space).
+/// Corresponds to C++ `ham::AddInLogSpace<T>(T first, T second)`.
+pub fn addInLogSpace(first: f64, second: f64) f64 {
+    perf_counters.bumpAddInLogSpace();
+    if (first == NEG_INF) return second;
+    if (second == NEG_INF) return first;
+    // Past both early-outs: one call to fast_softplus (LUT lookup, no glibc
+    // log/exp). The counter name kept its original log+exp suffix because
+    // the call site is still the place where item-3.2's transcendental work
+    // used to live — re-naming would invalidate prior #368 measurements.
+    perf_counters.bumpAddInLogSpaceLogExp();
+    // fast_softplus's C implementation has a `if (d > 0.0) return d + fast_softplus(-d)`
+    // symmetry recursion. ReleaseFast can elide that guard on subnormal positive d
+    // after negation, so we assert non-positive here at the only Zig call site
+    // (both branches feed (smaller − larger) ≤ 0).
+    if (first > second) {
+        const d = second - first;
+        std.debug.assert(d <= 0.0);
+        return first + fast_softplus(d);
+    } else {
+        const d = first - second;
+        std.debug.assert(d <= 0.0);
+        return second + fast_softplus(d);
+    }
+}
+
+// ── Vector utilities ──────────────────────────────────────────────────────────
+//
+// These correspond to the C++ template functions in mathutils.h.
+// All operate on slices (the Zig equivalent of vector<T>).
+
+/// Sum all elements of a slice.
+/// Corresponds to C++ `ham::sumVector(vector<T>& data)`.
+pub fn sumVector(comptime T: type, data: []const T) T {
+    var s: T = 0;
+    for (data) |v| s += v;
+    return s;
+}
+
+/// Product of all elements in a slice.
+/// Corresponds to C++ `ham::productVector(vector<T>& data)`.
+pub fn productVector(comptime T: type, data: []const T) T {
+    if (data.len == 0) return 1;
+    var p: T = data[0];
+    for (data[1..]) |v| p *= v;
+    return p;
+}
+
+/// Minimum element.
+/// Corresponds to C++ `ham::minVector(vector<T>& data)`.
+pub fn minVector(comptime T: type, data: []const T) T {
+    return std.mem.min(T, data);
+}
+
+/// Maximum element.
+/// Corresponds to C++ `ham::maxVector(vector<T>& data)`.
+pub fn maxVector(comptime T: type, data: []const T) T {
+    return std.mem.max(T, data);
+}
+
+/// Average of all elements.
+/// Corresponds to C++ `ham::avgVector(vector<T>& data)`.
+pub fn avgVector(comptime T: type, data: []const T) T {
+    return sumVector(T, data) / @as(T, @floatFromInt(data.len));
+}
+
+/// Take log of each element in-place.
+/// Corresponds to C++ `ham::logVector(vector<T>& data)`.
+pub fn logVector(data: []f64) void {
+    for (data) |*v| v.* = @log(v.*);
+}
+
+/// Return a new slice of exp(x) for each element in data.
+/// Caller owns the returned slice.
+/// Corresponds to C++ `ham::get_exp_vector(vector<T> data)`.
+pub fn getExpVector(allocator: std.mem.Allocator, data: []const f64) ![]f64 {
+    const result = try allocator.alloc(f64, data.len);
+    for (data, 0..) |v, i| result[i] = @exp(v);
+    return result;
+}
+
+/// Normalize data in-place to sum to 1 (convert to probabilities).
+/// Corresponds to C++ `ham::probVector(vector<T>& data)`.
+pub fn probVector(data: []f64) void {
+    const s = sumVector(f64, data);
+    if (s == 0.0) {
+        for (data) |*v| v.* = 0.0;
+    } else {
+        for (data) |*v| v.* /= s;
+    }
+}
+
+/// Add rhs element-wise into lhs in-place.
+/// Corresponds to C++ `ham::addVector(vector<T>& lhs, vector<T>& rhs)`.
+pub fn addVector(comptime T: type, lhs: []T, rhs: []const T) void {
+    std.debug.assert(lhs.len == rhs.len);
+    for (lhs, rhs) |*l, r| l.* += r;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "addWithMinusInfinities: both finite" {
+    const result = addWithMinusInfinities(-1.5, -2.3);
+    try std.testing.expectApproxEqAbs(-3.8, result, 1e-10);
+}
+
+test "addWithMinusInfinities: first -inf" {
+    const result = addWithMinusInfinities(NEG_INF, -2.3);
+    try std.testing.expect(result == NEG_INF);
+}
+
+test "addWithMinusInfinities: second -inf" {
+    const result = addWithMinusInfinities(-1.5, NEG_INF);
+    try std.testing.expect(result == NEG_INF);
+}
+
+test "addInLogSpace: log(e^0 + e^0) = log(2)" {
+    const result = addInLogSpace(0.0, 0.0);
+    try std.testing.expectApproxEqAbs(@log(2.0), result, 1e-10);
+}
+
+test "addInLogSpace: first -inf" {
+    const result = addInLogSpace(NEG_INF, -1.5);
+    try std.testing.expectApproxEqAbs(-1.5, result, 1e-10);
+}
+
+test "addInLogSpace: second -inf" {
+    const result = addInLogSpace(-1.5, NEG_INF);
+    try std.testing.expectApproxEqAbs(-1.5, result, 1e-10);
+}
+
+test "sumVector" {
+    const data = [_]f64{ 1.0, 2.0, 3.0 };
+    try std.testing.expectApproxEqAbs(6.0, sumVector(f64, &data), 1e-10);
+}
+
+test "productVector" {
+    const data = [_]f64{ 2.0, 3.0, 4.0 };
+    try std.testing.expectApproxEqAbs(24.0, productVector(f64, &data), 1e-10);
+}
+
+test "power" {
+    try std.testing.expectEqual(@as(u64, 8), power(3, 2)); // 2^3 = 8
+    try std.testing.expectEqual(@as(u64, 1), power(0, 5)); // 5^0 = 1
+    try std.testing.expectEqual(@as(u64, 4), power(2, 2)); // 2^2 = 4
+}

--- a/packages/zig-core/src/ham/model.zig
+++ b/packages/zig-core/src/ham/model.zig
@@ -1,0 +1,441 @@
+/// ham/model.zig — Zig port of ham/src/model.cc + ham/include/model.h
+///
+/// HMM model: loads from a YAML file, holds all states, finalizes connectivity.
+///
+/// C++ source: packages/ham/src/model.cc, packages/ham/include/model.h
+/// C++ author: psathyrella/ham
+
+const std = @import("std");
+const Track = @import("track.zig").Track;
+const track_mod = @import("track.zig");
+const State = @import("state.zig").State;
+const Transition = @import("transitions.zig").Transition;
+const hmm_yaml = @import("hmm_yaml.zig");
+const mathutils = @import("mathutils.zig");
+
+/// EPS for normalization checks (-DEPS=1e-6).
+const EPS: f64 = 1e-6;
+
+/// HMM model: all states, a track, and finalized connectivity.
+/// Corresponds to C++ `ham::Model`.
+pub const Model = struct {
+    name: []u8,
+    /// Overall probability of this gene/HMM (from YAML extras.gene_prob).
+    overall_prob: f64,
+    /// Original mean mutation frequency (from YAML extras.overall_mute_freq).
+    original_overall_mute_freq: f64,
+    /// Ratio by which we've rescaled emissions (-inf if not rescaled).
+    rescale_ratio: f64,
+    /// Ambiguous character (e.g. "N"). Empty if not set.
+    ambiguous_char: []u8,
+
+    /// Track (alphabet). Owned by this Model.
+    track: ?*Track,
+
+    /// All non-init states in model order. Stored as values in a flat slice so the
+    /// hot path (Trellis.middleViterbi/Forward, which call `stateByIndex` once per
+    /// (current, prev) pair per position) does a single index instead of an extra
+    /// pointer dereference. Capacity is reserved once in `parse` from the YAML
+    /// state count and never grown afterward, so `*State` pointers obtained via
+    /// `&states.items[i]` remain stable for the lifetime of the Model — that
+    /// invariant is what lets `states_by_name` and Transition.to_state_ptr keep
+    /// holding `*State` directly.
+    states: std.ArrayListUnmanaged(State),
+    /// Map from state name to State pointer. Non-init pointers reference into
+    /// `states.items`; the init pointer references the separately heap-allocated
+    /// `initial`. The Model never grows `states` after parse, so these pointers
+    /// stay valid for the Model's lifetime.
+    states_by_name: std.StringHashMap(*State),
+    /// The "init" state. Owned.
+    initial: ?*State,
+    /// The synthetic "end" state (no emissions, only from-states). Owned.
+    ending: *State,
+
+    finalized: bool,
+
+    /// Create an empty Model (not yet parsed).
+    /// Corresponds to C++ `Model()`.
+    pub fn init(allocator: std.mem.Allocator) !Model {
+        const ending = try allocator.create(State);
+        ending.* = State.init();
+        return Model{
+            .name = try allocator.dupe(u8, ""),
+            .overall_prob = 0.0,
+            .original_overall_mute_freq = 0.0,
+            .rescale_ratio = mathutils.NEG_INF,
+            .ambiguous_char = try allocator.dupe(u8, ""),
+            .track = null,
+            .states = .{},
+            .states_by_name = std.StringHashMap(*State).init(allocator),
+            .initial = null,
+            .ending = ending,
+            .finalized = false,
+        };
+    }
+
+    pub fn deinit(self: *Model, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.ambiguous_char);
+        // Non-init states live as values in the flat slice — deinit each in place,
+        // then free the slice's backing storage. No allocator.destroy: the State
+        // values were never individually heap-allocated.
+        for (self.states.items) |*st| st.deinit(allocator);
+        self.states.deinit(allocator);
+        // states_by_name pointers reference into states.items / initial / ending.
+        // Just free the map's own storage.
+        self.states_by_name.deinit();
+        // init and ending are separately heap-allocated (init is not in
+        // states.items by construction; ending is synthetic and never indexed).
+        if (self.initial) |init_st| {
+            init_st.deinit(allocator);
+            allocator.destroy(init_st);
+        }
+        self.ending.deinit(allocator);
+        allocator.destroy(self.ending);
+        if (self.track) |t| {
+            t.deinit(allocator);
+            allocator.destroy(t);
+        }
+    }
+
+    /// Parse a model from a YAML file.
+    /// Corresponds to C++ `Model::Parse(string infname)`.
+    pub fn parse(self: *Model, allocator: std.mem.Allocator, infname: []const u8) !void {
+        var data = try hmm_yaml.parseFile(allocator, infname);
+        defer data.deinit(allocator);
+
+        // Model-wide info
+        allocator.free(self.name);
+        self.name = try allocator.dupe(u8, data.name);
+        self.overall_prob = data.overall_prob;
+        self.original_overall_mute_freq = data.original_overall_mute_freq;
+        if (data.ambiguous_char.len > 0) {
+            allocator.free(self.ambiguous_char);
+            self.ambiguous_char = try allocator.dupe(u8, data.ambiguous_char);
+        }
+
+        // Build track
+        if (data.tracks.items.len != 1) return error.ExpectedExactlyOneTrack;
+        const td = &data.tracks.items[0];
+        const trk = try allocator.create(Track);
+        // NOTE: assign to self.track immediately so model.deinit handles cleanup on error.
+        // Do NOT use an errdefer for trk — model.deinit owns it via self.track.
+        trk.* = try Track.init(allocator, td.name);
+        if (self.track) |old_t| {
+            old_t.deinit(allocator);
+            allocator.destroy(old_t);
+        }
+        self.track = trk;
+        if (self.ambiguous_char.len > 0) {
+            try trk.setAmbiguous(allocator, self.ambiguous_char);
+        }
+        for (td.symbols.items) |sym| try trk.addSymbol(allocator, sym);
+
+        // Collect state names for transition validation, and count non-init
+        // states so we can reserve flat-slice capacity in one shot. The capacity
+        // reservation is what makes `&states.items[i]` pointers stable — without
+        // it, addOneAssumeCapacity below would assert.
+        var state_names: std.ArrayListUnmanaged([]const u8) = .{};
+        defer state_names.deinit(allocator);
+        var n_non_init: usize = 0;
+        for (data.states.items) |*sd| {
+            try state_names.append(allocator, sd.name);
+            if (!std.mem.eql(u8, sd.name, "init")) n_non_init += 1;
+        }
+        // Match the C++/old behavior of allowing exactly STATE_MAX non-init
+        // states. The old code checked `items.len >= STATE_MAX` immediately
+        // before each append, so the (N+1)-th append (when items.len was
+        // already N==STATE_MAX) was the one that errored.
+        if (n_non_init > @import("state.zig").STATE_MAX) return error.TooManyStates;
+        try self.states.ensureTotalCapacityPrecise(allocator, n_non_init);
+
+        // Parse each state
+        for (data.states.items) |*sd| {
+            if (std.mem.eql(u8, sd.name, "init")) {
+                // init stays in its own heap allocation (one per Model, not indexed).
+                const st = try allocator.create(State);
+                errdefer {
+                    st.deinit(allocator);
+                    allocator.destroy(st);
+                }
+                st.* = State.init();
+                try st.parse(
+                    allocator,
+                    sd.name,
+                    sd.germline_nuc,
+                    sd.ambiguous_emission_prob,
+                    sd.ambiguous_char,
+                    sd.transitions,
+                    if (sd.emissions) |*em| em.probs else null,
+                    state_names.items,
+                    trk,
+                );
+                self.initial = st;
+                try self.states_by_name.put(st.name, st);
+            } else {
+                // Grow the flat slice by one slot; capacity reserved above so this
+                // never reallocates and the &slot pointer is stable.
+                const slot = self.states.addOneAssumeCapacity();
+                slot.* = State.init();
+                // Roll back the addOne if parse or states_by_name.put fails.
+                // Order matters: `slot.deinit` must precede `pop`, because after
+                // pop the slot index is past states.items.len and a later
+                // model.deinit would not see it. Conversely, without pop, the
+                // slot would still live in states.items and model.deinit would
+                // re-deinit it (double free). If states_by_name.put is the
+                // failing call, no key was stored (put is failure-atomic), so
+                // freeing slot.name in deinit doesn't dangle a map entry.
+                errdefer {
+                    slot.deinit(allocator);
+                    _ = self.states.pop();
+                }
+                try slot.parse(
+                    allocator,
+                    sd.name,
+                    sd.germline_nuc,
+                    sd.ambiguous_emission_prob,
+                    sd.ambiguous_char,
+                    sd.transitions,
+                    if (sd.emissions) |*em| em.probs else null,
+                    state_names.items,
+                    trk,
+                );
+                try self.states_by_name.put(slot.name, slot);
+            }
+        }
+
+        // Make the stable-pointer invariant machine-checkable: any future code
+        // that accidentally appends to self.states would reallocate the slice
+        // and silently invalidate every *State held by states_by_name and by
+        // Transition.to_state_ptr. The capacity reservation above sized the
+        // slice to exactly n_non_init; if items.len ever drifts from capacity,
+        // the invariant has been broken.
+        std.debug.assert(self.states.items.len == self.states.capacity);
+
+        try self.finalize(allocator);
+    }
+
+    /// Post-process: set indices, compute to/from bitsets, reorder transitions.
+    /// Corresponds to C++ `Model::Finalize()`.
+    fn finalize(self: *Model, allocator: std.mem.Allocator) !void {
+        std.debug.assert(!self.finalized);
+
+        // Assign indices to all non-init states
+        for (self.states.items, 0..) |*st, i| st.setIndex(i);
+
+        // Set to/from connectivity for each non-init state
+        for (self.states.items) |*st| try self.finalizeState(st);
+        if (self.initial) |init_st| try self.finalizeState(init_st);
+
+        // Reorder transitions in index order
+        for (self.states.items) |*st| try st.reorderTransitions(allocator, &self.states_by_name);
+        if (self.initial) |init_st| try init_st.reorderTransitions(allocator, &self.states_by_name);
+
+        // Check topology
+        try self.checkTopology(allocator);
+
+        // Build from_state_indices
+        try self.addMaybeFasterFromStateStuff(allocator);
+
+        // Materialize flat log_probs and free *Transition allocations. Must run
+        // after every reader of to_state_name/to_state_ptr (finalizeState,
+        // reorderTransitions, checkTopology, addMaybeFasterFromStateStuff).
+        for (self.states.items) |*st| try st.materializeTransitionLogProbs(allocator);
+        if (self.initial) |init_st| try init_st.materializeTransitionLogProbs(allocator);
+
+        self.finalized = true;
+    }
+
+    /// Set to/from bitsets for a state and update destination states' from-bitsets.
+    /// Corresponds to C++ `Model::FinalizeState(State*)`.
+    fn finalizeState(self: *Model, st: *State) !void {
+        // Iterate over parse-order transitions (before reorder)
+        for (st.transitions.items) |maybe_t| {
+            const t = maybe_t orelse continue;
+            const to_state = self.states_by_name.get(t.to_state_name) orelse return error.UnknownTransitionTarget;
+            st.addToState(to_state);
+            t.setToState(to_state);
+            if (st != self.initial) to_state.addFromState(st);
+        }
+        if (st.trans_to_end) |_| {
+            self.ending.addFromState(st);
+        }
+    }
+
+    /// Build from_state_indices and to_state_indices for all states.
+    /// Corresponds to C++ `Model::AddMaybeFasterFromStateStuff()`.
+    fn addMaybeFasterFromStateStuff(self: *Model, allocator: std.mem.Allocator) !void {
+        if (self.initial) |init_st| {
+            try init_st.setFromStateIndices(allocator);
+            try init_st.setToStateIndices(allocator);
+        }
+        for (self.states.items) |*st| {
+            try st.setFromStateIndices(allocator);
+            try st.setToStateIndices(allocator);
+        }
+        try self.ending.setFromStateIndices(allocator);
+        try self.ending.setToStateIndices(allocator);
+    }
+
+    /// Topology check: all states reachable from init, each has a non-self path.
+    /// Corresponds to C++ `Model::CheckTopology()`.
+    fn checkTopology(self: *Model, allocator: std.mem.Allocator) !void {
+        const init_st = self.initial orelse return error.NoInitState;
+        const n = self.states.items.len;
+
+        var states_to_check: std.ArrayListUnmanaged(u16) = .{};
+        defer states_to_check.deinit(allocator);
+        try self.addToStateIndicesHelper(allocator, init_st, &states_to_check);
+
+        var checked = try allocator.alloc(bool, n);
+        defer allocator.free(checked);
+        for (checked) |*c| c.* = false;
+
+        while (states_to_check.items.len > 0) {
+            const icheck = states_to_check.pop() orelse break;
+            if (checked[icheck]) continue;
+
+            var tmp: std.ArrayListUnmanaged(u16) = .{};
+            defer tmp.deinit(allocator);
+            try self.addToStateIndicesHelper(allocator, &self.states.items[icheck], &tmp);
+            const num_visited = tmp.items.len;
+
+            if (num_visited == 0) {
+                if (self.states.items[icheck].trans_to_end == null)
+                    return error.StateHasNoTransitions;
+            } else if (num_visited == 1 and tmp.items[0] == icheck) {
+                if (self.states.items[icheck].trans_to_end == null)
+                    return error.StateOnlySelfTransition;
+            }
+            checked[icheck] = true;
+            for (tmp.items) |idx| {
+                if (!checked[idx]) try states_to_check.append(allocator, idx);
+            }
+        }
+
+        // At least one transition to end
+        var found_end = false;
+        for (self.states.items) |*st| {
+            if (st.trans_to_end != null) {
+                found_end = true;
+                break;
+            }
+        }
+        if (!found_end) return error.NoTransitionToEnd;
+
+        // All states reachable
+        for (checked, 0..) |c, i| {
+            if (!c) {
+                std.debug.print("ERROR: state '{s}' not reachable from init\n", .{self.states.items[i].name});
+                return error.StateNotReachable;
+            }
+        }
+    }
+
+    fn addToStateIndicesHelper(_: *const Model, allocator: std.mem.Allocator, st: *const State, visited: *std.ArrayListUnmanaged(u16)) !void {
+        for (st.transitions.items) |maybe_t| {
+            if (maybe_t) |t| {
+                const to_st = t.to_state_ptr orelse continue;
+                try visited.append(allocator, @intCast(to_st.index));
+            }
+        }
+    }
+
+    /// Rescale all state emissions by a factor derived from `overall_mute_freq`.
+    /// Corresponds to C++ `Model::RescaleOverallMuteFreq(double)`.
+    pub fn rescaleOverallMuteFreq(self: *Model, allocator: std.mem.Allocator, overall_mute_freq: f64) !void {
+        std.debug.assert(!std.math.isNegativeInf(overall_mute_freq));
+        if (self.original_overall_mute_freq == 0.0) return error.ZeroOriginalMuteFreq;
+        const factor = @max(0.01, overall_mute_freq) / self.original_overall_mute_freq;
+        for (self.states.items) |*st| try st.rescaleOverallMuteFreq(allocator, factor);
+    }
+
+    /// Undo rescaling.
+    /// Corresponds to C++ `Model::UnRescaleOverallMuteFreq()`.
+    pub fn unRescaleOverallMuteFreq(self: *Model) void {
+        for (self.states.items) |*st| st.unRescaleOverallMuteFreq();
+    }
+
+    pub fn nStates(self: *const Model) usize {
+        return self.states.items.len;
+    }
+
+    pub fn stateByName(self: *const Model, name: []const u8) ?*State {
+        return self.states_by_name.get(name);
+    }
+
+    pub inline fn stateByIndex(self: *const Model, idx: usize) *State {
+        return &self.states.items[idx];
+    }
+
+    pub fn initState(self: *const Model) ?*State {
+        return self.initial;
+    }
+
+    pub fn initialToStates(self: *const Model) ?*@import("state.zig").StateBitset {
+        if (self.initial) |init_st| return &init_st.to_states;
+        return null;
+    }
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "Model: parse simple 2-state HMM from string" {
+    const allocator = std.testing.allocator;
+
+    // Write a minimal YAML to a temp file
+    const yaml = "!!python/object:python.hmmwriter.HMM\n" ++
+        "extras:\n" ++
+        "  gene_prob: 0.5\n" ++
+        "  overall_mute_freq: 0.1\n" ++
+        "name: test_gene\n" ++
+        "tracks:\n" ++
+        "  nukes:\n" ++
+        "  - A\n" ++
+        "  - C\n" ++
+        "  - G\n" ++
+        "  - T\n" ++
+        "states:\n" ++
+        "- !!python/object:python.hmmwriter.State\n" ++
+        "  emissions: null\n" ++
+        "  extras: {}\n" ++
+        "  name: init\n" ++
+        "  transitions:\n" ++
+        "    state0: 1.0\n" ++
+        "- !!python/object:python.hmmwriter.State\n" ++
+        "  emissions:\n" ++
+        "    probs:\n" ++
+        "      A: 0.25\n" ++
+        "      C: 0.25\n" ++
+        "      G: 0.25\n" ++
+        "      T: 0.25\n" ++
+        "    track: nukes\n" ++
+        "  extras:\n" ++
+        "    ambiguous_char: N\n" ++
+        "    ambiguous_emission_prob: 0.25\n" ++
+        "    germline: A\n" ++
+        "  name: state0\n" ++
+        "  transitions:\n" ++
+        "    end: 1.0\n";
+
+    // Write to a temporary file
+    const tmp_path = "/tmp/test_model.yaml";
+    {
+        const f = try std.fs.createFileAbsolute(tmp_path, .{});
+        defer f.close();
+        try f.writeAll(yaml);
+    }
+    defer std.fs.deleteFileAbsolute(tmp_path) catch {};
+
+    var model = try Model.init(allocator);
+    defer model.deinit(allocator);
+
+    try model.parse(allocator, tmp_path);
+
+    try std.testing.expectEqualStrings("test_gene", model.name);
+    try std.testing.expectApproxEqAbs(0.5, model.overall_prob, 1e-9);
+    try std.testing.expectEqual(@as(usize, 1), model.nStates());
+    try std.testing.expect(model.initial != null);
+    try std.testing.expect(model.stateByName("state0") != null);
+    try std.testing.expect(model.stateByName("init") != null);
+}

--- a/packages/zig-core/src/ham/perf_counters.zig
+++ b/packages/zig-core/src/ham/perf_counters.zig
@@ -1,0 +1,336 @@
+/// ham/perf_counters.zig — Phase-0 diagnostics counters for issue #366.
+///
+/// The whole module is gated on the `-Dperf-counters` build option (see
+/// `build.zig`). When the option is `false` (default), `enabled` is a
+/// comptime `false` and every `if (enabled) { ... }` block in the hot
+/// path compiles to nothing — bit-equality with the un-instrumented build
+/// is preserved.
+///
+/// Counters cover the metrics requested in #366 phase 0.1 / 0.2:
+///
+///   - addInLogSpace_calls          — `mathutils.zig:addInLogSpace` entry
+///   - addInLogSpace_log_exp_calls  — calls past both NEG_INF early-outs
+///                                    (each = 1 log + 1 exp of work)
+///   - fillTrellis_calls            — `dp_handler.zig:fillTrellis` entry
+///   - n_ksets                      — `dp_handler.zig:run` kset loop
+///   - chunk_cache_lookups/hits     — `dp_handler.zig:fillTrellis` cache
+///                                    branch entry / prefix-match success
+///   - active_state_hist[count]     — `trellis.zig` middleViterbiVals/
+///                                    middleForwardVals
+///
+/// Phase-B sub-phase nanosecond accumulators (added 2026-05 after the
+/// lever-5 close — see `/tmp/perf-1.1-results/next-steps-plan.md`). The
+/// Phase-0 counts told us the chunk-cache HIT RATE; they did not tell us
+/// how time is split between the cache-hit path (the `partial_match`
+/// branch in `runKSet`) and the various sub-phases inside `fillTrellis`
+/// on the cache-miss path. The lever-5 close was the proximate motivator:
+/// a 24.63% perf-record symbol bucket turned out to over-attribute work
+/// inside an amortized hot loop, and eliminating ~70% of those calls only
+/// shifted bcrham wall by ~2%. The next-steps plan calls for cycle-
+/// precise per-sub-phase timing before any further lever pull. These
+/// `*_ns` accumulators provide that data:
+///
+///   - fillTrellis_total_ns         — whole `fillTrellis` body
+///   - fillTrellis_chunkScan_ns     — chunk-cache prefix-match for-loop
+///   - fillTrellis_init_ns          — cache-miss path: create+clone+initWithSeqs+append
+///   - fillTrellis_tmpInit_ns       — cache-hit (trellis) path: tmptrell init
+///   - fillTrellis_viterbi_ns       — `trell_ptr.viterbi()` call
+///   - fillTrellis_forward_ns       — `trell_ptr.forward()` call
+///   - fillTrellis_traceback_ns     — `trell_ptr.traceback(...)` call
+///   - fillTrellis_put_ns           — `gc.paths.put` + `gc.scores.put`
+///   - cachedPath_ns                — `runKSet`'s `partial_match` cache-hit
+///                                    branch (does NOT enter `fillTrellis`)
+///
+/// All timers use `std.time.Instant` (CLOCK_MONOTONIC). They compile to
+/// nothing when `-Dperf-counters=false` (the `Tick` type is `void`, and
+/// `tick`/`addElapsed` early-return). The corresponding output line is
+/// `PERFCOUNTER_TIMING` (separate from `PERFCOUNTER` so the existing
+/// aggregator keeps parsing the original line unchanged).
+///
+/// The `_calls` vs `_log_exp_calls` split for `addInLogSpace` matters for
+/// item-3.2 costing: at function entry the call may still hit a cheap
+/// `NEG_INF` short-circuit and do zero transcendental work. The first
+/// counter is the call rate; the second is the rate of work that an
+/// item-3.2 log/exp approximation would actually replace.
+///
+/// State is process-global and reset at start of each `DPHandler.run()`.
+/// `formatPerfCounters` returns one heap-allocated PERFCOUNTER line per
+/// query; caller writes it to the destination it picks (current dump site
+/// is the file at `PARTIS_ZIG_PERF_LOG`, opened O_APPEND to keep parallel
+/// bcrham processes non-clobbering — see `dp_handler.zig:dumpPerfCounters`).
+///
+/// SAFETY: the counters below are plain `pub var` globals, NOT atomics.
+/// Every caller must run single-threaded within a process. bcrham is
+/// single-threaded by design (#342 item 1 investigated and rejected
+/// `smp_allocator`); cross-process parallelism via `partis --n-procs N`
+/// runs each bcrham in its own address space, so the globals stay
+/// per-process. If a future caller introduces threading inside a single
+/// bcrham process, this module must grow atomic counters or per-thread
+/// shadow state.
+const std = @import("std");
+const build_options = @import("build_options");
+
+pub const enabled: bool = build_options.perf_counters;
+
+/// Length of the active-state histogram. State indices in this codebase
+/// are bounded by `state.zig:STATE_MAX = 500`; one extra slot for 500 itself.
+const HIST_LEN: usize = 501;
+
+pub var addInLogSpace_calls: u64 = 0;
+pub var addInLogSpace_log_exp_calls: u64 = 0;
+pub var fillTrellis_calls: u64 = 0;
+pub var n_ksets: u64 = 0;
+pub var chunk_cache_lookups: u64 = 0;
+pub var chunk_cache_hits: u64 = 0;
+pub var active_state_hist: [HIST_LEN]u64 = [_]u64{0} ** HIST_LEN;
+
+// Phase-B sub-phase ns accumulators. Wrap-around (`+%=`) is fine: a u64
+// of nanoseconds is ~584 years.
+pub var fillTrellis_total_ns: u64 = 0;
+pub var fillTrellis_chunkScan_ns: u64 = 0;
+pub var fillTrellis_init_ns: u64 = 0;
+pub var fillTrellis_tmpInit_ns: u64 = 0;
+pub var fillTrellis_viterbi_ns: u64 = 0;
+pub var fillTrellis_forward_ns: u64 = 0;
+pub var fillTrellis_traceback_ns: u64 = 0;
+pub var fillTrellis_put_ns: u64 = 0;
+pub var cachedPath_ns: u64 = 0;
+
+// Phase-B outer-perimeter accumulators. These pair with the inner ones
+// above to bound the un-timed gap inside one `DPHandler.run()`:
+//   runKSet_overhead       = runKSet_total       − (fillTrellis_total + cachedPath)
+//   dpHandler_run_overhead = dpHandler_run_total − Σ runKSet_total
+// The latter covers the run()-body pre/post work: Sequences build, the
+// only_genes map, `hmms.rescaleOverallMuteFreqs`, `fillRecoEvent` for
+// viterbi, `Result.finalize`, debug logging, etc. Phase B saw the
+// inner perimeter (fillTrellis+cachedPath) is ~95% DP; these outer
+// accumulators let us check whether the remaining bcrham wall really
+// is Glomerator+driver, or whether there's an addressable bucket
+// hiding in run() pre/post or runKSet plumbing.
+pub var runKSet_total_ns: u64 = 0;
+pub var dpHandler_run_total_ns: u64 = 0;
+
+// Phase-B'' deeper-DP timers: split `viterbi()` and `forward()` (in
+// `trellis.zig`) into init / position-loop / ending sub-phases. The
+// position-loop body is derived in the aggregator as the residual:
+//   viterbi_positionLoop_ns ≈ fillTrellis_viterbi_ns − init − ending
+//   forward_positionLoop_ns ≈ fillTrellis_forward_ns − init − ending
+// Expected outcome: init + ending sum to <5%, so the position loop
+// — i.e. `middleViterbiVals`/`middleForwardVals` + `swapColumnsActive`
+// — accounts for ~95%+ of the DP time. That confirms the only
+// remaining lever surface is the inner DP body, which is not localized
+// (it's the algorithm itself).
+pub var viterbi_init_ns: u64 = 0;
+pub var viterbi_ending_ns: u64 = 0;
+pub var forward_init_ns: u64 = 0;
+pub var forward_ending_ns: u64 = 0;
+
+// Process-lifetime accumulator: total wall in `Glomerator.cluster()` OR
+// `Glomerator.cacheNaiveSeqs()`. The dumped `PERFCOUNTER_GLOMERATOR`
+// line tags which mode via its `kind=` field. Distinct from the
+// per-DPHandler.run() counters above — this one survives the per-query
+// `reset()` so it accumulates across all the nested DPHandler.run()
+// invocations inside one Glomerator entry-point call. Bcrham emits one
+// `PERFCOUNTER_GLOMERATOR` line at the end of each call reporting
+// this value plus the cumulative DPHandler.run time across all calls
+// inside it (the latter via a paired `cumul_dpHandler_run_ns`
+// accumulator that ALSO survives reset()).
+//
+// Together with the `bcrham time:` line printed by partis, the gap
+//   bcrham_CPU − cumul_dpHandler_run_ns × n_procs
+// tells us whether the remaining bcrham CPU is in Glomerator driver
+// code (merge decisions, partition writes) or in bcrham startup /
+// model loading. Phase B' shows ~28% of bcrham CPU lives outside
+// DPHandler.run(); this counter lets us split it.
+pub var glomerator_ns: u64 = 0;
+pub var cumul_dpHandler_run_ns: u64 = 0;
+
+pub fn reset() void {
+    if (!enabled) return;
+    addInLogSpace_calls = 0;
+    addInLogSpace_log_exp_calls = 0;
+    fillTrellis_calls = 0;
+    n_ksets = 0;
+    chunk_cache_lookups = 0;
+    chunk_cache_hits = 0;
+    fillTrellis_total_ns = 0;
+    fillTrellis_chunkScan_ns = 0;
+    fillTrellis_init_ns = 0;
+    fillTrellis_tmpInit_ns = 0;
+    fillTrellis_viterbi_ns = 0;
+    fillTrellis_forward_ns = 0;
+    fillTrellis_traceback_ns = 0;
+    fillTrellis_put_ns = 0;
+    cachedPath_ns = 0;
+    runKSet_total_ns = 0;
+    dpHandler_run_total_ns = 0;
+    viterbi_init_ns = 0;
+    viterbi_ending_ns = 0;
+    forward_init_ns = 0;
+    forward_ending_ns = 0;
+    // NB: explicit loop instead of `@memset(&active_state_hist, 0)` —
+    // Zig 0.15.2 hits an x86_64 codegen bug ("no encoding found for:
+    // none mov m64 m64 none none") on a Debug @memset over a fixed-size
+    // global u64 array. The loop sidesteps the bug and any optimizer
+    // will turn it back into a memset under ReleaseFast/ReleaseSafe.
+    var i: usize = 0;
+    while (i < HIST_LEN) : (i += 1) active_state_hist[i] = 0;
+}
+
+/// Cycle-precise sub-phase timer pair, gated on the `-Dperf-counters`
+/// build option. When disabled, `Tick` is `void`, both helpers early-
+/// return, and the call site reduces to nothing under the optimizer —
+/// preserving the default-build bit-equality contract.
+///
+/// Usage:
+///   const t = perf_counters.tick();
+///   // ... work to time ...
+///   perf_counters.addElapsed(&perf_counters.fillTrellis_chunkScan_ns, t);
+pub const Tick = if (enabled) std.time.Instant else void;
+
+pub inline fn tick() Tick {
+    if (!enabled) return {};
+    // `Instant.now()` only returns `error.Unsupported` on platforms
+    // without a monotonic clock. Linux/macOS/Windows all provide one.
+    return std.time.Instant.now() catch unreachable;
+}
+
+pub inline fn addElapsed(accum: *u64, start: Tick) void {
+    if (!enabled) return;
+    const now_inst = std.time.Instant.now() catch unreachable;
+    accum.* +%= now_inst.since(start);
+}
+
+pub inline fn bumpAddInLogSpace() void {
+    if (enabled) addInLogSpace_calls += 1;
+}
+
+pub inline fn bumpAddInLogSpaceLogExp() void {
+    if (enabled) addInLogSpace_log_exp_calls += 1;
+}
+
+pub inline fn bumpFillTrellis() void {
+    if (enabled) fillTrellis_calls += 1;
+}
+
+pub inline fn bumpKSet() void {
+    if (enabled) n_ksets += 1;
+}
+
+pub inline fn bumpChunkCacheLookup() void {
+    if (enabled) chunk_cache_lookups += 1;
+}
+
+pub inline fn bumpChunkCacheHit() void {
+    if (enabled) chunk_cache_hits += 1;
+}
+
+pub inline fn recordActiveStates(n: usize) void {
+    if (!enabled) return;
+    const idx = if (n >= HIST_LEN) HIST_LEN - 1 else n;
+    active_state_hist[idx] += 1;
+}
+
+/// Compute (median, p95, max, total_positions) over the active-state histogram.
+fn activeStateStats() struct { median: usize, p95: usize, max: usize, total: u64 } {
+    var total: u64 = 0;
+    for (active_state_hist) |c| total += c;
+    if (total == 0) return .{ .median = 0, .p95 = 0, .max = 0, .total = 0 };
+    const median_target = (total + 1) / 2;
+    const p95_target = (total * 95 + 99) / 100;
+    var cum: u64 = 0;
+    var median: usize = 0;
+    var p95: usize = 0;
+    var max_idx: usize = 0;
+    var i: usize = 0;
+    while (i < HIST_LEN) : (i += 1) {
+        if (active_state_hist[i] == 0) continue;
+        max_idx = i;
+        const next_cum = cum + active_state_hist[i];
+        if (cum < median_target and median_target <= next_cum) median = i;
+        if (cum < p95_target and p95_target <= next_cum) p95 = i;
+        cum = next_cum;
+    }
+    return .{ .median = median, .p95 = p95, .max = max_idx, .total = total };
+}
+
+/// Format the per-query counter summary as a heap-allocated `[]u8` (caller frees).
+/// Returns null when counters are disabled (caller skips the write).
+/// Format is intentionally trivial-to-grep:
+///   PERFCOUNTER alg=... q=... n_seqs=... ksets=... fillTrellis=... \
+///       chunk_hits=H/L addInLogSpace=... addInLogSpace_log_exp=... \
+///       active_states_med=... active_states_p95=... active_states_max=... \
+///       active_states_positions=...
+///
+/// `chunk_hits=H/L`: H = prefix-match successes, L = lookup attempts (the
+/// `if (!no_chunk_cache)` branch entries in fillTrellis). Hit rate is H/L.
+pub fn formatPerfCounters(
+    allocator: std.mem.Allocator,
+    algorithm: []const u8,
+    query_name: []const u8,
+    n_seqs: usize,
+) !?[]u8 {
+    if (!enabled) return null;
+    const stats = activeStateStats();
+    return try std.fmt.allocPrint(
+        allocator,
+        "PERFCOUNTER alg={s} q={s} n_seqs={d} ksets={d} fillTrellis={d} chunk_hits={d}/{d} addInLogSpace={d} addInLogSpace_log_exp={d} active_states_med={d} active_states_p95={d} active_states_max={d} active_states_positions={d}\n",
+        .{
+            algorithm,
+            query_name,
+            n_seqs,
+            n_ksets,
+            fillTrellis_calls,
+            chunk_cache_hits,
+            chunk_cache_lookups,
+            addInLogSpace_calls,
+            addInLogSpace_log_exp_calls,
+            stats.median,
+            stats.p95,
+            stats.max,
+            stats.total,
+        },
+    );
+}
+
+/// Format the per-query sub-phase ns accumulators as a separate
+/// `PERFCOUNTER_TIMING` line. Kept distinct from `PERFCOUNTER` so the
+/// existing aggregator parses unchanged; the timing aggregator reads only
+/// these lines.
+///
+///   PERFCOUNTER_TIMING alg=... q=... n_seqs=... \
+///       fillTrellis_total_ns=T chunkScan_ns=... init_ns=... \
+///       tmpInit_ns=... viterbi_ns=... forward_ns=... traceback_ns=... \
+///       put_ns=... cachedPath_ns=...
+pub fn formatPerfCountersTiming(
+    allocator: std.mem.Allocator,
+    algorithm: []const u8,
+    query_name: []const u8,
+    n_seqs: usize,
+) !?[]u8 {
+    if (!enabled) return null;
+    return try std.fmt.allocPrint(
+        allocator,
+        "PERFCOUNTER_TIMING alg={s} q={s} n_seqs={d} dpHandler_run_total_ns={d} runKSet_total_ns={d} fillTrellis_total_ns={d} chunkScan_ns={d} init_ns={d} tmpInit_ns={d} viterbi_ns={d} forward_ns={d} traceback_ns={d} put_ns={d} cachedPath_ns={d} viterbi_init_ns={d} viterbi_ending_ns={d} forward_init_ns={d} forward_ending_ns={d}\n",
+        .{
+            algorithm,
+            query_name,
+            n_seqs,
+            dpHandler_run_total_ns,
+            runKSet_total_ns,
+            fillTrellis_total_ns,
+            fillTrellis_chunkScan_ns,
+            fillTrellis_init_ns,
+            fillTrellis_tmpInit_ns,
+            fillTrellis_viterbi_ns,
+            fillTrellis_forward_ns,
+            fillTrellis_traceback_ns,
+            fillTrellis_put_ns,
+            cachedPath_ns,
+            viterbi_init_ns,
+            viterbi_ending_ns,
+            forward_init_ns,
+            forward_ending_ns,
+        },
+    );
+}

--- a/packages/zig-core/src/ham/sequences.zig
+++ b/packages/zig-core/src/ham/sequences.zig
@@ -1,0 +1,273 @@
+/// ham/sequences.zig — Zig port of ham/src/sequences.cc + ham/include/sequences.h
+///
+/// Sequence container: stores a nucleotide string with its digitized (u8 index) form.
+///
+/// C++ source: packages/ham/src/sequences.cc, packages/ham/include/sequences.h
+/// C++ author: psathyrella/ham
+
+const std = @import("std");
+const ham_text = @import("text.zig");
+const Track = @import("track.zig").Track;
+
+/// A single sequence with its name, undigitized string, and digitized u8 slice.
+/// Corresponds to C++ `ham::Sequence`.
+pub const Sequence = struct {
+    name: []u8,
+    /// Optional header line (e.g. FASTA header).
+    header: []u8,
+    /// The original nucleotide string (with any whitespace stripped).
+    undigitized: []u8,
+    /// Digitized form: each character → u8 index via the track's alphabet.
+    /// Owned by this struct.
+    seqq: []u8,
+    /// Pointer to the track (not owned; must outlive this Sequence).
+    track: ?*const Track,
+
+    /// Initialize an empty Sequence (not generally useful; exists for container compatibility).
+    /// Corresponds to C++ `Sequence()`.
+    pub fn init() Sequence {
+        return Sequence{
+            .name = &[_]u8{},
+            .header = &[_]u8{},
+            .undigitized = &[_]u8{},
+            .seqq = &[_]u8{},
+            .track = null,
+        };
+    }
+
+    /// Create a Sequence from a track, name, and undigitized string.
+    /// Strips `\n` from the string (matching C++ ClearWhitespace call).
+    /// Digitizes the sequence via the track's symbol_index.
+    /// Corresponds to C++ `Sequence(Track*, string name, string& undigitized)`.
+    pub fn initFromString(
+        allocator: std.mem.Allocator,
+        trk: *const Track,
+        name: []const u8,
+        undigitized_in: []const u8,
+    ) !Sequence {
+        var seq = Sequence{
+            .name = try allocator.dupe(u8, name),
+            .header = try allocator.dupe(u8, ""),
+            .undigitized = try allocator.dupe(u8, undigitized_in),
+            .seqq = try allocator.dupe(u8, ""),
+            .track = trk,
+        };
+        // ClearWhitespace("\n", &undigitized_)
+        var ud_list = std.ArrayList(u8).fromOwnedSlice(seq.undigitized);
+        ham_text.clearWhitespace(allocator, "\n", &ud_list);
+        seq.undigitized = try ud_list.toOwnedSlice(allocator);
+        // Digitize (free the placeholder empty allocation)
+        allocator.free(seq.seqq);
+        seq.seqq = try digitize(allocator, trk, seq.undigitized);
+        return seq;
+    }
+
+    /// Create a subsequence from position `pos` of length `len`.
+    /// Corresponds to C++ `Sequence(Track*, string name, string& undigitized, size_t pos, size_t len)`.
+    pub fn initSubstring(
+        allocator: std.mem.Allocator,
+        trk: *const Track,
+        name: []const u8,
+        undigitized_in: []const u8,
+        pos: usize,
+        len: usize,
+    ) !Sequence {
+        try checkPosLen(name, undigitized_in, pos, len);
+        const sub = undigitized_in[pos .. pos + len];
+        return initFromString(allocator, trk, name, sub);
+    }
+
+    /// Create a subsequence of an existing Sequence (slice without re-digitizing from string).
+    /// Corresponds to C++ `Sequence(Sequence& rhs, size_t pos, size_t len)`.
+    pub fn initSlice(
+        allocator: std.mem.Allocator,
+        rhs: *const Sequence,
+        pos: usize,
+        len: usize,
+    ) !Sequence {
+        try checkPosLen(rhs.name, rhs.undigitized, pos, len);
+        return Sequence{
+            .name = try allocator.dupe(u8, rhs.name),
+            .header = try allocator.dupe(u8, rhs.header),
+            .undigitized = try allocator.dupe(u8, rhs.undigitized[pos .. pos + len]),
+            .seqq = try allocator.dupe(u8, rhs.seqq[pos .. pos + len]),
+            .track = rhs.track,
+        };
+    }
+
+    /// Clone a Sequence (deep copy).
+    /// Corresponds to C++ `Sequence(const Sequence& rhs)`.
+    pub fn clone(self: *const Sequence, allocator: std.mem.Allocator) !Sequence {
+        return Sequence{
+            .name = try allocator.dupe(u8, self.name),
+            .header = try allocator.dupe(u8, self.header),
+            .undigitized = try allocator.dupe(u8, self.undigitized),
+            .seqq = try allocator.dupe(u8, self.seqq),
+            .track = self.track,
+        };
+    }
+
+    pub fn deinit(self: *Sequence, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.header);
+        allocator.free(self.undigitized);
+        allocator.free(self.seqq);
+    }
+
+    pub fn size(self: *const Sequence) usize {
+        return self.seqq.len;
+    }
+
+    pub fn setName(self: *Sequence, allocator: std.mem.Allocator, nm: []const u8) !void {
+        allocator.free(self.name);
+        self.name = try allocator.dupe(u8, nm);
+    }
+};
+
+/// Validate that `[pos, pos+len)` is in bounds for `undigitized`.
+fn checkPosLen(name: []const u8, undigitized: []const u8, pos: usize, len: usize) !void {
+    if (pos >= undigitized.len or pos + len > undigitized.len) {
+        std.debug.print("ERROR: len {d} too large for '{s}' in '{s}'\n", .{ len, undigitized, name });
+        return error.InvalidPosLen;
+    }
+}
+
+/// Digitize `undigitized` using the track's symbol_index.
+fn digitize(allocator: std.mem.Allocator, trk: *const Track, undigitized: []const u8) ![]u8 {
+    const result = try allocator.alloc(u8, undigitized.len);
+    for (undigitized, 0..) |_, i| {
+        const sym = undigitized[i .. i + 1];
+        result[i] = trk.symbolIndex(sym) catch |err| {
+            allocator.free(result);
+            return err;
+        };
+    }
+    return result;
+}
+
+/// A collection of equal-length Sequences.
+/// Corresponds to C++ `ham::Sequences`.
+pub const Sequences = struct {
+    seqs: std.ArrayListUnmanaged(Sequence),
+    /// Length of each sequence (all must be equal).
+    sequence_length: usize,
+
+    pub fn init() Sequences {
+        return Sequences{
+            .seqs = .{},
+            .sequence_length = 0,
+        };
+    }
+
+    pub fn deinit(self: *Sequences, allocator: std.mem.Allocator) void {
+        for (self.seqs.items) |*s| s.deinit(allocator);
+        self.seqs.deinit(allocator);
+    }
+
+    pub fn nSeqs(self: *const Sequences) usize {
+        return self.seqs.items.len;
+    }
+
+    pub fn get(self: *const Sequences, index: usize) *const Sequence {
+        return &self.seqs.items[index];
+    }
+
+    pub fn getPtr(self: *Sequences, index: usize) *Sequence {
+        return &self.seqs.items[index];
+    }
+
+    /// Deep-copy this Sequences (matches C++ copy constructor semantics).
+    pub fn clone(self: *const Sequences, allocator: std.mem.Allocator) !Sequences {
+        var result = Sequences.init();
+        errdefer result.deinit(allocator);
+        for (self.seqs.items) |*sq| {
+            try result.addSeq(allocator, try sq.clone(allocator));
+        }
+        return result;
+    }
+
+    /// Add a sequence, taking ownership.
+    /// All sequences must have the same length.
+    /// Corresponds to C++ `Sequences::AddSeq(Sequence sq)`.
+    pub fn addSeq(self: *Sequences, allocator: std.mem.Allocator, sq: Sequence) !void {
+        if (self.seqs.items.len == 0) {
+            self.sequence_length = sq.size();
+        } else if (sq.size() != self.sequence_length) {
+            return error.SequenceLengthMismatch;
+        }
+        try self.seqs.append(allocator, sq);
+    }
+
+    /// Return a new Sequences with the union of self and otherseqs.
+    /// Detects duplicate names.
+    pub fn unionWith(
+        self: *const Sequences,
+        allocator: std.mem.Allocator,
+        other: *const Sequences,
+    ) !Sequences {
+        var result = Sequences.init();
+        var seen = std.StringHashMap(void).init(allocator);
+        defer seen.deinit();
+
+        for (self.seqs.items) |*s| {
+            if (seen.contains(s.name)) return error.DuplicateSequenceName;
+            try seen.put(s.name, {});
+            try result.addSeq(allocator, try s.clone(allocator));
+        }
+        for (other.seqs.items) |*s| {
+            if (seen.contains(s.name)) return error.DuplicateSequenceName;
+            try seen.put(s.name, {});
+            try result.addSeq(allocator, try s.clone(allocator));
+        }
+        return result;
+    }
+
+    /// Return a comma-separated string of sequence names.
+    /// Corresponds to C++ `Sequences::name_str(string delimiter)`.
+    pub fn nameStr(self: *const Sequences, allocator: std.mem.Allocator, delimiter: []const u8) ![]u8 {
+        var names: std.ArrayListUnmanaged([]const u8) = .{};
+        defer names.deinit(allocator);
+        for (self.seqs.items) |*s| try names.append(allocator, s.name);
+        return ham_text.joinStrings(allocator, names.items, delimiter);
+    }
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "Sequence: initFromString digitizes correctly" {
+    const allocator = std.testing.allocator;
+    const sym_list = [_][]const u8{ "A", "C", "G", "T" };
+    var track = try Track.initWithSymbols(allocator, "nucs", &sym_list, "N");
+    defer track.deinit(allocator);
+
+    var seq = try Sequence.initFromString(allocator, &track, "test_seq", "ACGT");
+    defer seq.deinit(allocator);
+
+    try std.testing.expectEqualStrings("test_seq", seq.name);
+    try std.testing.expectEqual(@as(usize, 4), seq.size());
+    try std.testing.expectEqual(@as(u8, 0), seq.seqq[0]); // A
+    try std.testing.expectEqual(@as(u8, 1), seq.seqq[1]); // C
+    try std.testing.expectEqual(@as(u8, 2), seq.seqq[2]); // G
+    try std.testing.expectEqual(@as(u8, 3), seq.seqq[3]); // T
+}
+
+test "Sequences: addSeq and length check" {
+    const allocator = std.testing.allocator;
+    const sym_list = [_][]const u8{ "A", "C", "G", "T" };
+    var track = try Track.initWithSymbols(allocator, "nucs", &sym_list, "N");
+    defer track.deinit(allocator);
+
+    var seqs = Sequences.init();
+    defer seqs.deinit(allocator);
+
+    const s1 = try Sequence.initFromString(allocator, &track, "s1", "ACGT");
+    try seqs.addSeq(allocator, s1);
+    try std.testing.expectEqual(@as(usize, 4), seqs.sequence_length);
+
+    // Adding a sequence of different length should error
+    const s2 = try Sequence.initFromString(allocator, &track, "s2", "AC");
+    var bad_seq = s2;
+    const result = seqs.addSeq(allocator, bad_seq);
+    _ = result catch {};
+    bad_seq.deinit(allocator);
+}

--- a/packages/zig-core/src/ham/state.zig
+++ b/packages/zig-core/src/ham/state.zig
@@ -1,0 +1,480 @@
+/// ham/state.zig — Zig port of ham/src/state.cc + ham/include/state.h
+///
+/// HMM state: name, transitions, emission probabilities, and graph connectivity.
+///
+/// C++ source: packages/ham/src/state.cc, packages/ham/include/state.h
+/// C++ author: psathyrella/ham
+
+const std = @import("std");
+const Track = @import("track.zig").Track;
+const track_mod = @import("track.zig");
+const Emission = @import("emission.zig").Emission;
+const Transition = @import("transitions.zig").Transition;
+const Sequences = @import("sequences.zig").Sequences;
+const mathutils = @import("mathutils.zig");
+
+const log = mathutils.log;
+const exp = mathutils.exp;
+
+/// Matches C++ build define -DSTATE_MAX=500.
+pub const STATE_MAX: usize = 500;
+
+/// EPS for normalization check (matches C++ -DEPS=1e-6).
+const EPS: f64 = 1e-6;
+
+/// Bitset over STATE_MAX bits. Uses std.StaticBitSet for compact representation.
+/// Corresponds to C++ `std::bitset<STATE_MAX>`.
+pub const StateBitset = std.StaticBitSet(STATE_MAX);
+
+/// A single HMM state.
+/// Corresponds to C++ `ham::State`.
+pub const State = struct {
+    name: []u8,
+    /// The germline nucleotide for this position (empty if none).
+    germline_nuc: []u8,
+    /// Log-probability for the ambiguous character emission (-inf if not set).
+    ambiguous_emission_logprob: f64,
+    /// The ambiguous character string (empty if not set).
+    ambiguous_char: []u8,
+
+    /// Transitions to other states (not the "end" state), in parse order.
+    /// After reorderTransitions(), reindexed to model order (with null sentinels for absent).
+    /// Each pointer is owned by this State. Kept alive after finalize so print() can
+    /// resolve destination names; the hot path reads `log_probs` and ignores this.
+    transitions: std.ArrayListUnmanaged(?*Transition),
+    /// Transition to the "end" state (null if none). Owned by this State.
+    /// Kept alive after finalize for print(); the hot path reads `end_log_prob`.
+    trans_to_end: ?*Transition,
+    /// Flat log-probabilities indexed by destination state, populated by
+    /// materializeTransitionLogProbs() at the end of Model.finalize. Replaces the
+    /// pointer-of-pointers chase in transitionLogprob() — that's the hottest data
+    /// access in the trellis DP. NEG_INF for absent transitions.
+    log_probs: []f64,
+    /// Log-probability for the transition to "end". Set during parse(); read by
+    /// endTransitionLogprob() in the hot path. NEG_INF if no end transition.
+    end_log_prob: f64,
+
+    /// Emission model for this state.
+    emission: Emission,
+
+    /// Index of this state in the model's state vector (set by model finalize).
+    index: usize,
+
+    /// Bitset of states this state can transition *to* (set by model finalize).
+    to_states: StateBitset,
+    /// Bitset of states that can transition *to* this state (set by model finalize).
+    from_states: StateBitset,
+    /// Indices of states in `from_states` (faster iteration than bitset scan).
+    from_state_indices: std.ArrayListUnmanaged(usize),
+    /// Indices of states in `to_states` (faster iteration than bitset scan).
+    to_state_indices: std.ArrayListUnmanaged(usize),
+
+    /// Create an empty State.
+    /// Corresponds to C++ `State()`.
+    pub fn init() State {
+        return State{
+            .name = &[_]u8{},
+            .germline_nuc = &[_]u8{},
+            .ambiguous_emission_logprob = mathutils.NEG_INF,
+            .ambiguous_char = &[_]u8{},
+            .transitions = .{},
+            .trans_to_end = null,
+            .log_probs = &[_]f64{},
+            .end_log_prob = mathutils.NEG_INF,
+            .emission = Emission.init(),
+            .index = std.math.maxInt(usize),
+            .to_states = StateBitset.initEmpty(),
+            .from_states = StateBitset.initEmpty(),
+            .from_state_indices = .{},
+            .to_state_indices = .{},
+        };
+    }
+
+    pub fn deinit(self: *State, allocator: std.mem.Allocator) void {
+        if (self.name.len > 0) allocator.free(self.name);
+        if (self.germline_nuc.len > 0) allocator.free(self.germline_nuc);
+        if (self.ambiguous_char.len > 0) allocator.free(self.ambiguous_char);
+        for (self.transitions.items) |maybe_t| {
+            if (maybe_t) |t| {
+                t.deinit(allocator);
+                allocator.destroy(t);
+            }
+        }
+        self.transitions.deinit(allocator);
+        if (self.trans_to_end) |t| {
+            t.deinit(allocator);
+            allocator.destroy(t);
+        }
+        if (self.log_probs.len > 0) allocator.free(self.log_probs);
+        self.emission.deinit(allocator);
+        self.from_state_indices.deinit(allocator);
+        self.to_state_indices.deinit(allocator);
+    }
+
+    /// Parse state data from already-extracted fields.
+    ///
+    /// `transitions_map` maps to_state_name → raw probability.
+    /// `emission_probs` maps symbol_name → raw emission probability
+    ///   (pass null for the "init" state which has no emissions).
+    /// `state_names` is the list of valid non-"end" state names (for validation).
+    ///
+    /// Corresponds to C++ `State::Parse(YAML::Node, vector<string>, Track*)`.
+    pub fn parse(
+        self: *State,
+        allocator: std.mem.Allocator,
+        name: []const u8,
+        germline_nuc: ?[]const u8,
+        ambiguous_emission_prob: ?f64,
+        ambiguous_char: ?[]const u8,
+        transitions_map: std.StringHashMap(f64),
+        emission_probs: ?std.StringHashMap(f64),
+        state_names: []const []const u8,
+        track: *const Track,
+    ) !void {
+        std.debug.assert(name.len > 0);
+        if (self.name.len > 0) allocator.free(self.name);
+        self.name = try allocator.dupe(u8, name);
+
+        if (germline_nuc) |gn| {
+            if (self.germline_nuc.len > 0) allocator.free(self.germline_nuc);
+            self.germline_nuc = try allocator.dupe(u8, gn);
+        }
+        if (ambiguous_emission_prob) |aep| {
+            self.ambiguous_emission_logprob = log(aep);
+        }
+        if (ambiguous_char) |ac| {
+            if (self.ambiguous_char.len > 0) allocator.free(self.ambiguous_char);
+            self.ambiguous_char = try allocator.dupe(u8, ac);
+        }
+
+        // Parse transitions
+        var total: f64 = 0.0;
+        var it = transitions_map.iterator();
+        while (it.next()) |entry| {
+            const to_state = entry.key_ptr.*;
+            const prob = entry.value_ptr.*;
+            // Validate: must be "end" or a known state name
+            if (!std.mem.eql(u8, to_state, "end")) {
+                var found = false;
+                for (state_names) |sn| {
+                    if (std.mem.eql(u8, sn, to_state)) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) return error.UnknownTransitionTarget;
+            }
+            total += prob;
+            const trans = try allocator.create(Transition);
+            trans.* = try Transition.init(allocator, to_state, prob);
+            if (std.mem.eql(u8, to_state, "end")) {
+                self.trans_to_end = trans;
+                self.end_log_prob = trans.log_prob;
+            } else {
+                try self.transitions.append(allocator, trans);
+            }
+        }
+        if (@abs(total - 1.0) >= EPS) {
+            return error.BadNormalization;
+        }
+
+        // Parse emissions (skip for "init" state)
+        if (std.mem.eql(u8, name, "init")) return;
+
+        const ep = emission_probs orelse return error.MissingEmissions;
+        try self.emission.parse(allocator, ep, track);
+    }
+
+    /// Return the state's name.
+    pub fn getName(self: *const State) []const u8 {
+        return self.name;
+    }
+
+    /// First character of name (C++ `abbreviation()`).
+    pub fn abbreviation(self: *const State) u8 {
+        return if (self.name.len > 0) self.name[0] else '?';
+    }
+
+    /// Emission log-probability for a single digitized character.
+    /// Handles ambiguous character specially.
+    /// Corresponds to C++ `State::EmissionLogprob(uint8_t ch)`.
+    pub fn emissionLogprob(self: *const State, ch: u8) f64 {
+        if (self.ambiguous_char.len > 0 and ch == track_mod.AMBIGUOUS_INDEX) {
+            return self.ambiguous_emission_logprob;
+        }
+        return self.emission.scoreIndex(ch);
+    }
+
+    /// Emission log-probability for a position in a Sequences object.
+    /// Accumulates log-probs for each sequence at that position.
+    /// Corresponds to C++ `State::EmissionLogprob(Sequences*, size_t pos)`.
+    pub inline fn emissionLogprobSeqs(self: *const State, seqs: *const Sequences, pos: usize) f64 {
+        // Single-sequence fast path. The general loop's first (and only)
+        // iteration computes addWithMinusInfinities(0.0, emissionLogprob(...)),
+        // which equals emissionLogprob(...) for every value emissionLogprob can
+        // return: finite logprobs (0.0 + x == x) and NEG_INF (the function
+        // propagates -inf). emissionLogprob never returns NaN — its outputs come
+        // from the precomputed log-probability slice and the stored
+        // ambiguous_emission_logprob, both of which are seeded from log() of
+        // probabilities — so the fast path is value-identical to running the
+        // loop once.
+        if (seqs.nSeqs() == 1) {
+            return self.emissionLogprob(seqs.get(0).seqq[pos]);
+        }
+        var logprob: f64 = 0.0;
+        for (0..seqs.nSeqs()) |iseq| {
+            const seq = seqs.get(iseq);
+            logprob = mathutils.addWithMinusInfinities(logprob, self.emissionLogprob(seq.seqq[pos]));
+        }
+        return logprob;
+    }
+
+    /// Transition log-probability to state at index `to_state` (post-finalize).
+    /// Returns -inf if no transition exists to that state. Reads from the flat
+    /// `log_probs` array materialized at the end of Model.finalize — eliminates
+    /// the pointer-chain dereference that was the hottest data access in the
+    /// trellis DP.
+    pub inline fn transitionLogprob(self: *const State, to_state: usize) f64 {
+        if (to_state >= self.log_probs.len) return mathutils.NEG_INF;
+        return self.log_probs[to_state];
+    }
+
+    /// Log-probability for the transition to "end" (-inf if no such transition).
+    /// Corresponds to C++ `State::end_transition_logprob()`.
+    pub fn endTransitionLogprob(self: *const State) f64 {
+        return self.end_log_prob;
+    }
+
+    /// Mark that this state transitions to `st`.
+    /// Corresponds to C++ `State::AddToState(State*)`.
+    pub fn addToState(self: *State, st: *const State) void {
+        self.to_states.set(st.index);
+    }
+
+    /// Mark that `st` transitions to this state.
+    /// Corresponds to C++ `State::AddFromState(State*)`.
+    pub fn addFromState(self: *State, st: *const State) void {
+        self.from_states.set(st.index);
+    }
+
+    /// Set this state's index.
+    pub fn setIndex(self: *State, val: usize) void {
+        self.index = val;
+    }
+
+    /// Materialize a flat `log_probs: []f64` from `transitions` (post-reorder).
+    /// Called at the end of Model.finalize, after every reader of `to_state_name`
+    /// /`to_state_ptr` has run.
+    ///
+    /// Eliminates the pointer-chain dereference in transitionLogprob (the hottest
+    /// data access in the trellis DP). The original `*Transition` allocations
+    /// remain alive — print() walks them post-finalize to resolve destination
+    /// names. Memory cost is one f64 per state per slot (~2 MB total across all
+    /// loaded models); the wall-time win comes from the read pattern, not from
+    /// freeing.
+    pub fn materializeTransitionLogProbs(self: *State, allocator: std.mem.Allocator) !void {
+        std.debug.assert(self.log_probs.len == 0);
+        const n = self.transitions.items.len;
+        self.log_probs = try allocator.alloc(f64, n);
+        for (self.transitions.items, 0..) |maybe_t, i| {
+            self.log_probs[i] = if (maybe_t) |t| t.log_prob else mathutils.NEG_INF;
+        }
+    }
+
+    /// Reorder `transitions` to indexed order matching `state_indices` map.
+    /// Resizes transitions to `n_states - 1` with null sentinels for absent transitions.
+    /// Corresponds to C++ `State::ReorderTransitions(map<string,State*>&)`.
+    pub fn reorderTransitions(
+        self: *State,
+        allocator: std.mem.Allocator,
+        state_indices: *const std.StringHashMap(*State),
+    ) !void {
+        const n_states = state_indices.count();
+        // Collect existing transitions before clearing
+        var old_list = self.transitions;
+        self.transitions = .{};
+        defer old_list.deinit(allocator);
+
+        // Build null-filled fixed array of size n_states-1
+        const fixed_len = n_states - 1;
+        var fixed = try allocator.alloc(?*Transition, fixed_len);
+        defer allocator.free(fixed);
+        for (fixed) |*p| p.* = null;
+
+        for (old_list.items) |maybe_t| {
+            const t = maybe_t orelse continue;
+            const to_state = state_indices.get(t.to_state_name) orelse return error.UnknownTransitionTarget;
+            fixed[to_state.index] = t;
+        }
+
+        // Populate new transitions list
+        for (fixed) |maybe_t| {
+            try self.transitions.append(allocator, maybe_t);
+        }
+    }
+
+    /// Build `from_state_indices` from `from_states` bitset.
+    /// Corresponds to C++ `State::SetFromStateIndices()`.
+    pub fn setFromStateIndices(self: *State, allocator: std.mem.Allocator) !void {
+        self.from_state_indices.clearRetainingCapacity();
+        for (0..STATE_MAX) |i| {
+            if (self.from_states.isSet(i)) {
+                try self.from_state_indices.append(allocator, i);
+            }
+        }
+    }
+
+    /// Build `to_state_indices` from `to_states` bitset.
+    pub fn setToStateIndices(self: *State, allocator: std.mem.Allocator) !void {
+        self.to_state_indices.clearRetainingCapacity();
+        for (0..STATE_MAX) |i| {
+            if (self.to_states.isSet(i)) {
+                try self.to_state_indices.append(allocator, i);
+            }
+        }
+    }
+
+    /// Rescale emission probabilities for overall mutation frequency.
+    /// Corresponds to C++ `State::RescaleOverallMuteFreq(double factor)`.
+    pub fn rescaleOverallMuteFreq(self: *State, allocator: std.mem.Allocator, factor: f64) !void {
+        // Skip if germline is ambiguous or unset
+        if (self.germline_nuc.len == 0 or
+            (self.ambiguous_char.len > 0 and std.mem.eql(u8, self.germline_nuc, self.ambiguous_char)))
+            return;
+
+        const trk = self.emission.getTrack() orelse return;
+        const alpha_size = trk.alphabetSize();
+        var new_log_probs = try self.emission.logProbs(allocator);
+        defer allocator.free(new_log_probs);
+        std.debug.assert(new_log_probs.len == alpha_size);
+
+        // Find old mutation frequency
+        var old_mute_freq: f64 = -1.0;
+        for (0..alpha_size) |ip| {
+            const is_germ = std.mem.eql(u8, trk.symbol(ip), self.germline_nuc);
+            if (is_germ) {
+                old_mute_freq = 1.0 - exp(new_log_probs[ip]);
+            }
+        }
+        std.debug.assert(old_mute_freq >= 0.0);
+        var new_mute_freq = @min(0.95, factor * old_mute_freq);
+        new_mute_freq = @max(EPS, new_mute_freq);
+        if (new_mute_freq <= 0.0 or new_mute_freq >= 1.0) return error.BadMuteFreq;
+
+        for (0..alpha_size) |ip| {
+            const is_germ = std.mem.eql(u8, trk.symbol(ip), self.germline_nuc);
+            if (is_germ) {
+                new_log_probs[ip] = log(1.0 - new_mute_freq);
+            } else {
+                new_log_probs[ip] = log(exp(new_log_probs[ip]) * new_mute_freq / old_mute_freq);
+            }
+        }
+        try self.emission.replaceLogProbs(new_log_probs);
+    }
+
+    /// Revert emission rescaling.
+    /// Corresponds to C++ `State::UnRescaleOverallMuteFreq()`.
+    pub fn unRescaleOverallMuteFreq(self: *State) void {
+        if (self.germline_nuc.len == 0 or
+            (self.ambiguous_char.len > 0 and std.mem.eql(u8, self.germline_nuc, self.ambiguous_char)))
+            return;
+        self.emission.unReplaceLogProbs();
+    }
+
+    /// Print this state to stderr.
+    /// Corresponds to C++ `State::Print()`.
+    pub fn print(self: *const State) void {
+        std.debug.print("state: {s}", .{self.name});
+        if (self.germline_nuc.len > 0) std.debug.print(" ({s})", .{self.germline_nuc});
+        std.debug.print("\n", .{});
+        std.debug.print("  transitions:\n", .{});
+        for (self.transitions.items) |maybe_t| {
+            if (maybe_t) |t| t.print();
+        }
+        if (self.trans_to_end) |t| t.print();
+        if (std.mem.eql(u8, self.name, "init")) return;
+        std.debug.print("  emissions:\n", .{});
+        self.emission.print();
+    }
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "State: init state parse (no emissions)" {
+    const allocator = std.testing.allocator;
+    const sym_list = [_][]const u8{ "A", "C", "G", "T" };
+    var track = try Track.initWithSymbols(allocator, "nucs", &sym_list, "N");
+    defer track.deinit(allocator);
+
+    var state = State.init();
+    defer state.deinit(allocator);
+
+    var trans = std.StringHashMap(f64).init(allocator);
+    defer trans.deinit();
+    try trans.put("state1", 0.7);
+    try trans.put("end", 0.3);
+
+    const snames = [_][]const u8{"state1"};
+    try state.parse(allocator, "init", null, null, null, trans, null, &snames, &track);
+
+    try std.testing.expectEqualStrings("init", state.name);
+    try std.testing.expectEqual(@as(usize, 1), state.transitions.items.len);
+    try std.testing.expect(state.trans_to_end != null);
+}
+
+test "State: normal state parse with emissions" {
+    const allocator = std.testing.allocator;
+    const sym_list = [_][]const u8{ "A", "C", "G", "T" };
+    var track = try Track.initWithSymbols(allocator, "nucs", &sym_list, "N");
+    defer track.deinit(allocator);
+
+    var state = State.init();
+    defer state.deinit(allocator);
+
+    var trans = std.StringHashMap(f64).init(allocator);
+    defer trans.deinit();
+    try trans.put("end", 1.0);
+
+    var em_probs = std.StringHashMap(f64).init(allocator);
+    defer em_probs.deinit();
+    try em_probs.put("A", 0.25);
+    try em_probs.put("C", 0.25);
+    try em_probs.put("G", 0.25);
+    try em_probs.put("T", 0.25);
+
+    const snames = [_][]const u8{};
+    try state.parse(allocator, "state0", "A", null, "N", trans, em_probs, &snames, &track);
+
+    try std.testing.expectEqualStrings("state0", state.name);
+    try std.testing.expectEqualStrings("A", state.germline_nuc);
+    try std.testing.expectApproxEqAbs(@log(0.25), state.emissionLogprob(0), 1e-9);
+    // end_log_prob is set during parse() at the same site that creates trans_to_end
+    try std.testing.expectApproxEqAbs(@log(1.0), state.endTransitionLogprob(), 1e-9);
+}
+
+test "State: endTransitionLogprob absent returns -inf" {
+    const allocator = std.testing.allocator;
+    const sym_list = [_][]const u8{ "A", "C", "G", "T" };
+    var track = try Track.initWithSymbols(allocator, "nucs", &sym_list, "N");
+    defer track.deinit(allocator);
+
+    var state = State.init();
+    defer state.deinit(allocator);
+
+    var trans = std.StringHashMap(f64).init(allocator);
+    defer trans.deinit();
+    try trans.put("state_x", 0.5);
+    try trans.put("state_y", 0.5);
+
+    var em_probs = std.StringHashMap(f64).init(allocator);
+    defer em_probs.deinit();
+    try em_probs.put("A", 0.25);
+    try em_probs.put("C", 0.25);
+    try em_probs.put("G", 0.25);
+    try em_probs.put("T", 0.25);
+
+    const snames = [_][]const u8{ "state_x", "state_y" };
+    try state.parse(allocator, "mystate", null, null, null, trans, em_probs, &snames, &track);
+
+    try std.testing.expect(std.math.isNegativeInf(state.endTransitionLogprob()));
+}

--- a/packages/zig-core/src/ham/text.zig
+++ b/packages/zig-core/src/ham/text.zig
@@ -1,0 +1,178 @@
+/// ham/text.zig — Zig port of ham/src/text.cc
+///
+/// String utility functions used pervasively throughout ham.
+/// All functions in namespace ham::Text.
+///
+/// C++ source: packages/ham/src/text.cc, packages/ham/include/text.h
+/// C++ author: psathyrella/ham
+///
+/// Zig 0.15 note: std.ArrayList is the unmanaged variant — initialize with
+/// `.empty`, pass allocator to each mutating call, deinit with `deinit(allocator)`.
+
+const std = @import("std");
+
+/// Removes all instances of characters in `chars` from `input` in place.
+/// Corresponds to C++ `ham::ClearWhitespace(string white, string *input)`.
+pub fn clearWhitespace(allocator: std.mem.Allocator, chars: []const u8, input: *std.ArrayList(u8)) void {
+    _ = allocator; // not needed for in-place removal
+    var i: usize = 0;
+    while (i < input.items.len) {
+        if (std.mem.indexOfScalar(u8, chars, input.items[i]) != null) {
+            _ = input.orderedRemove(i);
+            // do not advance i — recheck same position
+        } else {
+            i += 1;
+        }
+    }
+}
+
+/// Splits `argstr` by whitespace (any run), returning a list of owned slices.
+/// Caller owns the returned ArrayList and its items (free each item, then call deinit).
+/// Corresponds to C++ `ham::PythonSplit(string argstr)`.
+pub fn pythonSplit(allocator: std.mem.Allocator, argstr: []const u8) !std.ArrayList([]u8) {
+    var tokens: std.ArrayList([]u8) = .empty;
+    var it = std.mem.tokenizeAny(u8, argstr, " \t\n\r");
+    while (it.next()) |tok| {
+        const owned = try allocator.dupe(u8, tok);
+        try tokens.append(allocator, owned);
+    }
+    return tokens;
+}
+
+/// Splits `argstr` by `delimiter`, returning owned slices.
+/// Default delimiter in C++ is `":"`.
+/// Corresponds to C++ `ham::SplitString(string argstr, string delimiter)`.
+pub fn splitString(allocator: std.mem.Allocator, argstr: []const u8, delimiter: []const u8) !std.ArrayList([]u8) {
+    var parts: std.ArrayList([]u8) = .empty;
+    var remaining = argstr;
+    while (true) {
+        if (std.mem.indexOf(u8, remaining, delimiter)) |pos| {
+            const part = try allocator.dupe(u8, remaining[0..pos]);
+            try parts.append(allocator, part);
+            remaining = remaining[pos + delimiter.len ..];
+        } else {
+            // last (or only) segment
+            const part = try allocator.dupe(u8, remaining);
+            try parts.append(allocator, part);
+            break;
+        }
+    }
+    return parts;
+}
+
+/// Returns true if `query` is found as a delimited token in `liststr`.
+/// Default delimiter in C++ is `":"`.
+/// Corresponds to C++ `ham::InString(string query, string liststr, string delimiter)`.
+pub fn inString(query: []const u8, liststr: []const u8, delimiter: []const u8) bool {
+    var remaining = liststr;
+    while (true) {
+        if (std.mem.indexOf(u8, remaining, delimiter)) |pos| {
+            if (std.mem.eql(u8, remaining[0..pos], query)) {
+                return true;
+            }
+            remaining = remaining[pos + delimiter.len ..];
+        } else {
+            if (std.mem.eql(u8, remaining, query)) {
+                return true;
+            }
+            break;
+        }
+    }
+    return false;
+}
+
+/// Joins a slice of strings with `delimiter` between each pair.
+/// Returns owned string. Caller owns the result.
+/// Corresponds to C++ `ham::JoinStrings(vector<string> &strlist, string delimiter)`.
+pub fn joinStrings(allocator: std.mem.Allocator, strlist: []const []const u8, delimiter: []const u8) ![]u8 {
+    if (strlist.len == 0) {
+        return try allocator.dupe(u8, "");
+    }
+    var total_len: usize = 0;
+    for (strlist, 0..) |s, i| {
+        total_len += s.len;
+        if (i + 1 < strlist.len) total_len += delimiter.len;
+    }
+    const buf = try allocator.alloc(u8, total_len);
+    var pos: usize = 0;
+    for (strlist, 0..) |s, i| {
+        @memcpy(buf[pos .. pos + s.len], s);
+        pos += s.len;
+        if (i + 1 < strlist.len) {
+            @memcpy(buf[pos .. pos + delimiter.len], delimiter);
+            pos += delimiter.len;
+        }
+    }
+    return buf;
+}
+
+/// Converts a slice of strings to a slice of i32.
+/// Corresponds to C++ `ham::Intify(vector<string> strlist)` (uses stoi → int).
+pub fn intify(allocator: std.mem.Allocator, strlist: []const []const u8) ![]i32 {
+    const result = try allocator.alloc(i32, strlist.len);
+    for (strlist, 0..) |s, i| {
+        result[i] = try std.fmt.parseInt(i32, s, 10);
+    }
+    return result;
+}
+
+/// Converts a slice of strings to a slice of f64.
+/// C++ uses stod (full f64 precision) since ham f41e055 "fix precision: stof→stod for cache reads".
+/// Corresponds to C++ `ham::Floatify(vector<string> strlist)`.
+pub fn floatify(allocator: std.mem.Allocator, strlist: []const []const u8) ![]f64 {
+    const result = try allocator.alloc(f64, strlist.len);
+    for (strlist, 0..) |s, i| {
+        result[i] = try std.fmt.parseFloat(f64, s);
+    }
+    return result;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "splitString default delimiter" {
+    const allocator = std.testing.allocator;
+    var parts = try splitString(allocator, "a:b:c", ":");
+    defer {
+        for (parts.items) |p| allocator.free(p);
+        parts.deinit(allocator);
+    }
+    try std.testing.expectEqual(@as(usize, 3), parts.items.len);
+    try std.testing.expectEqualStrings("a", parts.items[0]);
+    try std.testing.expectEqualStrings("b", parts.items[1]);
+    try std.testing.expectEqualStrings("c", parts.items[2]);
+}
+
+test "inString found" {
+    try std.testing.expect(inString("b", "a:b:c", ":"));
+}
+
+test "inString not found" {
+    try std.testing.expect(!inString("d", "a:b:c", ":"));
+}
+
+test "joinStrings" {
+    const allocator = std.testing.allocator;
+    const strs = [_][]const u8{ "a", "b", "c" };
+    const result = try joinStrings(allocator, &strs, ":");
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("a:b:c", result);
+}
+
+test "intify" {
+    const allocator = std.testing.allocator;
+    const strs = [_][]const u8{ "1", "2", "3" };
+    const result = try intify(allocator, &strs);
+    defer allocator.free(result);
+    try std.testing.expectEqualSlices(i32, &[_]i32{ 1, 2, 3 }, result);
+}
+
+test "pythonSplit" {
+    const allocator = std.testing.allocator;
+    var tokens = try pythonSplit(allocator, "  foo  bar  baz  ");
+    defer {
+        for (tokens.items) |t| allocator.free(t);
+        tokens.deinit(allocator);
+    }
+    try std.testing.expectEqual(@as(usize, 3), tokens.items.len);
+    try std.testing.expectEqualStrings("foo", tokens.items[0]);
+}

--- a/packages/zig-core/src/ham/traceback_path.zig
+++ b/packages/zig-core/src/ham/traceback_path.zig
@@ -1,0 +1,180 @@
+/// ham/traceback_path.zig — Zig port of ham/src/tracebackpath.cc + ham/include/tracebackpath.h
+///
+/// Viterbi traceback path: a sequence of state indices with an associated log-score.
+///
+/// C++ source: packages/ham/src/tracebackpath.cc, packages/ham/include/tracebackpath.h
+/// C++ author: psathyrella/ham
+
+const std = @import("std");
+const Model = @import("model.zig").Model;
+
+/// Viterbi traceback path: ordered sequence of state indices (in reverse order of traversal).
+/// Corresponds to C++ `ham::TracebackPath`.
+pub const TracebackPath = struct {
+    /// Pointer to the HMM model (not owned; must outlive this path).
+    hmm: ?*const Model,
+    /// The path as a sequence of state indices.
+    /// Stored in Viterbi fill order (index 0 = last state, end = first after init).
+    /// Corresponds to C++ `vector<int> path_`.
+    path: std.ArrayListUnmanaged(i32),
+    /// Log-score of this path.
+    score: f64,
+    /// If true, use 1-char abbreviations for printing.
+    abbreviate_flag: bool,
+
+    /// Create a TracebackPath for a given model.
+    /// Corresponds to C++ `TracebackPath(Model*)`.
+    pub fn initWithModel(model: *const Model) TracebackPath {
+        return TracebackPath{
+            .hmm = model,
+            .path = .{},
+            .score = 0.0,
+            .abbreviate_flag = false,
+        };
+    }
+
+    /// Create an empty TracebackPath (no model).
+    /// Corresponds to C++ `TracebackPath()`.
+    pub fn init() TracebackPath {
+        return TracebackPath{
+            .hmm = null,
+            .path = .{},
+            .score = 0.0,
+            .abbreviate_flag = false,
+        };
+    }
+
+    pub fn deinit(self: *TracebackPath, allocator: std.mem.Allocator) void {
+        self.path.deinit(allocator);
+    }
+
+    /// Append a state index to the path.
+    /// Corresponds to C++ `void push_back(int state)`.
+    pub fn pushBack(self: *TracebackPath, allocator: std.mem.Allocator, state: i32) !void {
+        try self.path.append(allocator, state);
+    }
+
+    /// Clear all state indices.
+    pub fn clear(self: *TracebackPath) void {
+        self.path.clearRetainingCapacity();
+    }
+
+    pub fn size(self: *const TracebackPath) usize {
+        return self.path.items.len;
+    }
+
+    pub fn setAbbreviate(self: *TracebackPath, abb: bool) void {
+        self.abbreviate_flag = abb;
+    }
+
+    pub fn setModel(self: *TracebackPath, model: *const Model) void {
+        self.hmm = model;
+    }
+
+    pub fn setScore(self: *TracebackPath, s: f64) void {
+        self.score = s;
+    }
+
+    /// Access state index at position `val`.
+    /// Corresponds to C++ `operator[](size_t val)`.
+    pub fn at(self: *const TracebackPath, val: usize) i32 {
+        return self.path.items[val];
+    }
+
+    /// Return the sequence of state names, in path order (reversed from storage order).
+    /// Caller owns the returned ArrayList of owned strings.
+    /// Corresponds to C++ `TracebackPath::name_vector()`.
+    pub fn nameVector(self: *const TracebackPath, allocator: std.mem.Allocator) !std.ArrayListUnmanaged([]u8) {
+        var result: std.ArrayListUnmanaged([]u8) = .{};
+        const model = self.hmm orelse return result;
+        const n = self.path.items.len;
+        var k: usize = n;
+        while (k > 0) {
+            k -= 1;
+            const idx: usize = @intCast(self.path.items[k]);
+            const st = model.stateByIndex(idx);
+            try result.append(allocator, try allocator.dupe(u8, st.name));
+        }
+        return result;
+    }
+
+    /// Print this path to stderr (in path order, reversed from storage order).
+    /// Corresponds to C++ `operator<<(ostream&, const TracebackPath&)`.
+    pub fn print(self: *const TracebackPath) void {
+        const model = self.hmm orelse return;
+        const n = self.path.items.len;
+        var k: usize = n;
+        while (k > 0) {
+            k -= 1;
+            const idx: usize = @intCast(self.path.items[k]);
+            const st = model.stateByIndex(idx);
+            if (self.abbreviate_flag) {
+                std.debug.print("{c} ", .{st.abbreviation()});
+            } else {
+                std.debug.print("{s} ", .{st.name});
+            }
+        }
+        std.debug.print("\n", .{});
+    }
+
+    /// Equality comparison (compares path arrays).
+    pub fn eql(self: *const TracebackPath, other: *const TracebackPath) bool {
+        if (self.path.items.len != other.path.items.len) return false;
+        for (self.path.items, other.path.items) |a, b| {
+            if (a != b) return false;
+        }
+        return true;
+    }
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "TracebackPath: init, pushBack, at, size" {
+    const allocator = std.testing.allocator;
+
+    var path = TracebackPath.init();
+    defer path.deinit(allocator);
+
+    try path.pushBack(allocator, 5);
+    try path.pushBack(allocator, 3);
+    try path.pushBack(allocator, 7);
+
+    try std.testing.expectEqual(@as(usize, 3), path.size());
+    try std.testing.expectEqual(@as(i32, 5), path.at(0));
+    try std.testing.expectEqual(@as(i32, 3), path.at(1));
+    try std.testing.expectEqual(@as(i32, 7), path.at(2));
+}
+
+test "TracebackPath: score and clear" {
+    const allocator = std.testing.allocator;
+
+    var path = TracebackPath.init();
+    defer path.deinit(allocator);
+
+    path.setScore(-42.5);
+    try std.testing.expectApproxEqAbs(-42.5, path.score, 1e-9);
+
+    try path.pushBack(allocator, 1);
+    try path.pushBack(allocator, 2);
+    path.clear();
+    try std.testing.expectEqual(@as(usize, 0), path.size());
+}
+
+test "TracebackPath: eql" {
+    const allocator = std.testing.allocator;
+
+    var p1 = TracebackPath.init();
+    defer p1.deinit(allocator);
+    var p2 = TracebackPath.init();
+    defer p2.deinit(allocator);
+
+    try p1.pushBack(allocator, 1);
+    try p1.pushBack(allocator, 2);
+    try p2.pushBack(allocator, 1);
+    try p2.pushBack(allocator, 2);
+
+    try std.testing.expect(p1.eql(&p2));
+
+    try p2.pushBack(allocator, 3);
+    try std.testing.expect(!p1.eql(&p2));
+}

--- a/packages/zig-core/src/ham/track.zig
+++ b/packages/zig-core/src/ham/track.zig
@@ -1,0 +1,170 @@
+/// ham/track.zig — Zig port of ham/src/track.cc + ham/include/track.h
+///
+/// Alphabet/symbol-index mapping for HMM tracks (nucleotide sequences).
+///
+/// C++ source: packages/ham/src/track.cc, packages/ham/include/track.h
+/// C++ author: psathyrella/ham
+
+const std = @import("std");
+
+/// Maximum number of symbols in an alphabet (matches C++ `max_alphabet_size_`).
+pub const MAX_ALPHABET_SIZE: usize = 255;
+
+/// The reserved index for the ambiguous character (matches C++ `ambiguous_index_`).
+pub const AMBIGUOUS_INDEX: u8 = MAX_ALPHABET_SIZE - 1;
+
+/// Symbol alphabet and index map for HMM tracks.
+/// Corresponds to C++ `ham::Track`.
+pub const Track = struct {
+    name: []u8,
+    /// Ordered list of symbols in the alphabet (owned slices).
+    alphabet: std.ArrayListUnmanaged([]u8),
+    /// Map from symbol string to u8 index (keys are slices owned by `alphabet`).
+    symbol_indices: std.StringHashMapUnmanaged(u8),
+    /// The string representing an ambiguous/wildcard character (e.g. "N").
+    /// Empty string means no ambiguous character set.
+    ambiguous_char: []u8,
+
+    pub fn init(allocator: std.mem.Allocator, name: []const u8) !Track {
+        return Track{
+            .name = try allocator.dupe(u8, name),
+            .alphabet = .{},
+            .symbol_indices = .{},
+            .ambiguous_char = try allocator.dupe(u8, ""),
+        };
+    }
+
+    /// Create a Track with a name, initial symbol list, and optional ambiguous char.
+    /// Corresponds to C++ `Track(string name, vector<string> symbols, string ambiguous_char)`.
+    pub fn initWithSymbols(
+        allocator: std.mem.Allocator,
+        name: []const u8,
+        symbols: []const []const u8,
+        ambiguous_char: []const u8,
+    ) !Track {
+        var t = try Track.init(allocator, name);
+        allocator.free(t.ambiguous_char);
+        t.ambiguous_char = try allocator.dupe(u8, ambiguous_char);
+        try t.addSymbols(allocator, symbols);
+        return t;
+    }
+
+    pub fn deinit(self: *Track, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.ambiguous_char);
+        // alphabet owns all the symbol strings
+        for (self.alphabet.items) |sym| allocator.free(sym);
+        self.alphabet.deinit(allocator);
+        self.symbol_indices.deinit(allocator);
+    }
+
+    pub fn setName(self: *Track, allocator: std.mem.Allocator, nm: []const u8) !void {
+        allocator.free(self.name);
+        self.name = try allocator.dupe(u8, nm);
+    }
+
+    /// Add a single symbol to the alphabet.
+    /// Corresponds to C++ `Track::AddSymbol(string symbol)`.
+    pub fn addSymbol(self: *Track, allocator: std.mem.Allocator, sym: []const u8) !void {
+        std.debug.assert(self.alphabet.items.len < MAX_ALPHABET_SIZE);
+        const owned = try allocator.dupe(u8, sym);
+        try self.alphabet.append(allocator, owned);
+        const index: u8 = @intCast(self.alphabet.items.len - 1);
+        try self.symbol_indices.put(allocator, owned, index);
+    }
+
+    /// Add multiple symbols.
+    /// Corresponds to C++ `Track::AddSymbols(vector<string>& symbols)`.
+    pub fn addSymbols(self: *Track, allocator: std.mem.Allocator, symbols: []const []const u8) !void {
+        for (symbols) |s| try self.addSymbol(allocator, s);
+    }
+
+    pub fn setAmbiguous(self: *Track, allocator: std.mem.Allocator, amb: []const u8) !void {
+        allocator.free(self.ambiguous_char);
+        self.ambiguous_char = try allocator.dupe(u8, amb);
+    }
+
+    pub fn alphabetSize(self: *const Track) usize {
+        return self.alphabet.items.len;
+    }
+
+    /// Get the symbol string at position `iter`.
+    /// Corresponds to C++ `Track::symbol(size_t iter)`.
+    pub fn symbol(self: *const Track, iter: usize) []const u8 {
+        return self.alphabet.items[iter];
+    }
+
+    /// Return the u8 index for a symbol string.
+    /// Returns AMBIGUOUS_INDEX for the ambiguous character.
+    /// Corresponds to C++ `Track::symbol_index(const string &symbol)`.
+    pub fn symbolIndex(self: *const Track, s: []const u8) !u8 {
+        if (self.ambiguous_char.len > 0 and std.mem.eql(u8, s, self.ambiguous_char)) {
+            return AMBIGUOUS_INDEX;
+        }
+        return self.symbol_indices.get(s) orelse
+            return error.SymbolNotFound;
+    }
+
+    /// Return a human-readable string listing all symbols.
+    /// Caller owns the returned string.
+    /// Corresponds to C++ `Track::Stringify()`.
+    pub fn stringify(self: *const Track, allocator: std.mem.Allocator) ![]u8 {
+        var buf: std.ArrayListUnmanaged(u8) = .{};
+        errdefer buf.deinit(allocator);
+        for (self.alphabet.items) |sym| {
+            try buf.append(allocator, ' ');
+            try buf.appendSlice(allocator, sym);
+        }
+        if (self.ambiguous_char.len > 0) {
+            try buf.appendSlice(allocator, "   ambiguous: ");
+            try buf.appendSlice(allocator, self.ambiguous_char);
+        }
+        return buf.toOwnedSlice(allocator);
+    }
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "Track: init and addSymbol" {
+    const allocator = std.testing.allocator;
+    var track = try Track.init(allocator, "nucs");
+    defer track.deinit(allocator);
+
+    try track.addSymbol(allocator, "A");
+    try track.addSymbol(allocator, "C");
+    try track.addSymbol(allocator, "G");
+    try track.addSymbol(allocator, "T");
+
+    try std.testing.expectEqual(@as(usize, 4), track.alphabetSize());
+    try std.testing.expectEqualStrings("G", track.symbol(2));
+    try std.testing.expectEqual(@as(u8, 0), try track.symbolIndex("A"));
+    try std.testing.expectEqual(@as(u8, 3), try track.symbolIndex("T"));
+}
+
+test "Track: ambiguous character" {
+    const allocator = std.testing.allocator;
+    const syms = [_][]const u8{ "A", "C", "G", "T" };
+    var track = try Track.initWithSymbols(allocator, "nucs", &syms, "N");
+    defer track.deinit(allocator);
+
+    try std.testing.expectEqual(AMBIGUOUS_INDEX, try track.symbolIndex("N"));
+}
+
+test "Track: symbolIndex error on unknown" {
+    const allocator = std.testing.allocator;
+    var track = try Track.init(allocator, "nucs");
+    defer track.deinit(allocator);
+    try track.addSymbol(allocator, "A");
+
+    try std.testing.expectError(error.SymbolNotFound, track.symbolIndex("Z"));
+}
+
+test "Track: stringify" {
+    const allocator = std.testing.allocator;
+    const syms = [_][]const u8{ "A", "C" };
+    var track = try Track.initWithSymbols(allocator, "nucs", &syms, "");
+    defer track.deinit(allocator);
+    const s = try track.stringify(allocator);
+    defer allocator.free(s);
+    try std.testing.expectEqualStrings(" A C", s);
+}

--- a/packages/zig-core/src/ham/transitions.zig
+++ b/packages/zig-core/src/ham/transitions.zig
@@ -1,0 +1,67 @@
+/// ham/transitions.zig — Zig port of ham/src/transitions.cc + ham/include/transitions.h
+///
+/// Transition probability data structure used by State.
+///
+/// C++ source: packages/ham/src/transitions.cc, packages/ham/include/transitions.h
+/// C++ author: psathyrella/ham
+
+const std = @import("std");
+const State = @import("state.zig").State;
+
+const log = @import("mathutils.zig").log;
+
+/// Transition from one HMM state to another with an associated log-probability.
+/// Corresponds to C++ `ham::Transition`.
+pub const Transition = struct {
+    /// Name of the destination state (owned string).
+    to_state_name: []u8,
+    /// Log transition probability (log of the raw probability passed to constructor).
+    log_prob: f64,
+    /// Pointer to the destination State (set by Model::FinalizeState; not owned).
+    to_state_ptr: ?*State,
+
+    /// Create a Transition from a destination state name and a raw probability.
+    /// Stores log(prob) to match C++ constructor behavior.
+    /// Caller owns the returned Transition; call deinit when done.
+    /// Corresponds to C++ `Transition(string to_state, double prob)`.
+    pub fn init(allocator: std.mem.Allocator, to_state: []const u8, prob: f64) !Transition {
+        return Transition{
+            .to_state_name = try allocator.dupe(u8, to_state),
+            .log_prob = log(prob),
+            .to_state_ptr = null,
+        };
+    }
+
+    pub fn deinit(self: *Transition, allocator: std.mem.Allocator) void {
+        allocator.free(self.to_state_name);
+    }
+
+    /// Set the destination state pointer (called by Model during finalization).
+    /// Corresponds to C++ `void set_to_state(State*)`.
+    pub fn setToState(self: *Transition, st: *State) void {
+        self.to_state_ptr = st;
+    }
+
+    /// Print the transition in C++ format: `%30s%14.3e\n`.
+    /// Corresponds to C++ `Transition::Print()`.
+    pub fn print(self: *const Transition) void {
+        std.debug.print("{s:>30}{e:14.3}\n", .{ self.to_state_name, @exp(self.log_prob) });
+    }
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test "Transition init and log_prob" {
+    const allocator = std.testing.allocator;
+    var t = try Transition.init(allocator, "state_A", 0.5);
+    defer t.deinit(allocator);
+    try std.testing.expectEqualStrings("state_A", t.to_state_name);
+    try std.testing.expectApproxEqAbs(@log(0.5), t.log_prob, 1e-10);
+}
+
+test "Transition: prob 1.0 gives log_prob 0.0" {
+    const allocator = std.testing.allocator;
+    var t = try Transition.init(allocator, "end", 1.0);
+    defer t.deinit(allocator);
+    try std.testing.expectApproxEqAbs(0.0, t.log_prob, 1e-10);
+}

--- a/packages/zig-core/src/ham/trellis.zig
+++ b/packages/zig-core/src/ham/trellis.zig
@@ -1,0 +1,740 @@
+/// ham/trellis.zig — Zig port of ham/src/trellis.cc + ham/include/trellis.h
+///
+/// Forward/Viterbi DP trellis for a single HMM run over a Sequences object.
+///
+/// C++ source: packages/ham/src/trellis.cc, packages/ham/include/trellis.h
+/// C++ author: psathyrella/ham
+
+const std = @import("std");
+const Model = @import("model.zig").Model;
+const State = @import("state.zig").State;
+const state_mod = @import("state.zig");
+const Sequences = @import("sequences.zig").Sequences;
+const Sequence = @import("sequences.zig").Sequence;
+const TracebackPath = @import("traceback_path.zig").TracebackPath;
+const mathutils = @import("mathutils.zig");
+const perf_counters = @import("perf_counters.zig");
+
+/// DP trellis for Forward/Viterbi algorithms.
+/// Corresponds to C++ `ham::Trellis`.
+pub const Trellis = struct {
+    /// HMM model (not owned).
+    hmm: *const Model,
+    /// Sequences to run DP over (BORROWED; not owned).
+    /// The pointee must outlive this Trellis. For trellises stored in
+    /// `DPHandler.scratch_cachefo`, the owning Sequences lives in the
+    /// enclosing TrellisEntry and is freed alongside the trellis.
+    /// For temporary chunk-borrowing trellises, the pointee is the caller's
+    /// stack-local `query_seqs` and lives only for the duration of fillTrellis.
+    seqs: *const Sequences,
+    /// Cached at init from `seqs.sequence_length`. Read by `traceback`,
+    /// `viterbi`, and `forward`; valid even if the borrowed seqs is no longer
+    /// being read post-DP.
+    seq_len: usize,
+
+    /// Flat traceback table indexed as [position * traceback_n_states + state].
+    /// Each entry is the previous state index (-1 if no valid predecessor).
+    /// Corresponds to C++ `typedef vector<vector<int16_t>> int_2D`, but stored
+    /// as a single contiguous allocation for locality and one alloc/free per
+    /// Trellis instead of seq_len + 1.
+    /// Empty (`&.{}`) until `viterbi()` allocates it; `forward()` never touches
+    /// this field. Read via `pickTracebackView` (returns a `TracebackView` with
+    /// the slice and stride); written via `tracebackSet`.
+    traceback_table: []i16,
+    /// State width of `traceback_table`. Captured at allocation time and equal
+    /// to `hmm.nStates()` for the trellis's lifetime. Stored explicitly so a
+    /// chunk-borrowing temp trellis can verify its `cached_trellis` was built
+    /// against the same model (see `initWithSeqs` assert).
+    traceback_n_states: usize,
+
+    /// Pointer to another trellis with pre-filled DP tables (not owned).
+    cached_trellis: ?*const Trellis,
+
+    ending_viterbi_pointer: i16,
+    ending_viterbi_log_prob: f64,
+    ending_forward_log_prob: f64,
+
+    /// Per-position Viterbi log-probs (including ending transition).
+    viterbi_log_probs: std.ArrayListUnmanaged(f64),
+    /// Per-position Forward log-probs.
+    forward_log_probs: std.ArrayListUnmanaged(f64),
+    /// Per-position best-state index (for Viterbi).
+    viterbi_indices: std.ArrayListUnmanaged(i32),
+
+    /// Current and previous scoring columns (size = n_states each).
+    scoring_current: []f64,
+    scoring_previous: []f64,
+
+    /// Scratch bitset for deduplicating next_states additions.
+    next_seen: state_mod.StateBitset,
+
+    /// Captured at `initWithSeqs` time. For trellises stored in
+    /// `DPHandler.scratch_cachefo`, this is `dph.scratchAllocator()`,
+    /// whose `Allocator.ptr` aliases `&dph.query_arena`. The DPHandler
+    /// must therefore not be moved after a Trellis is constructed against
+    /// it, or every stored `allocator.ptr` would dangle. All current
+    /// callers bind `dph` to a stack-local `var` and never reassign,
+    /// which preserves the invariant. (Item 4, #342.)
+    allocator: std.mem.Allocator,
+
+    /// Create a Trellis borrowing the given Sequences.
+    /// The caller retains ownership; `seqs` must outlive this Trellis.
+    /// Corresponds to C++ `Trellis(Model*, Sequences, Trellis*)`, but without
+    /// the C++ copy-by-value clone — the borrow is sufficient for DP read
+    /// access, and for cached/stored trellises only the result arrays are
+    /// re-read.
+    pub fn initWithSeqs(allocator: std.mem.Allocator, hmm: *const Model, seqs: *const Sequences, cached: ?*const Trellis) !Trellis {
+        const n = hmm.nStates();
+        // Stale-cache guard: a chunk-borrowing trellis must be built against
+        // the same model as its cached source, otherwise its scalar reads from
+        // `cached.traceback_table` (via `pickTracebackView`) would index with
+        // the wrong stride. The cached trellis can have an empty traceback
+        // table (forward-only), so guard only when it has one.
+        if (cached) |ct| {
+            if (ct.traceback_table.len > 0) {
+                std.debug.assert(ct.traceback_n_states == n);
+            }
+        }
+
+        const scoring_current = try allocator.alloc(f64, n);
+        errdefer allocator.free(scoring_current);
+        const scoring_previous = try allocator.alloc(f64, n);
+        errdefer allocator.free(scoring_previous);
+        @memset(scoring_current, mathutils.NEG_INF);
+        @memset(scoring_previous, mathutils.NEG_INF);
+
+        return Trellis{
+            .hmm = hmm,
+            .seqs = seqs,
+            .seq_len = seqs.sequence_length,
+            .traceback_table = &.{},
+            .traceback_n_states = 0,
+            .cached_trellis = cached,
+            .ending_viterbi_pointer = -1,
+            .ending_viterbi_log_prob = mathutils.NEG_INF,
+            .ending_forward_log_prob = mathutils.NEG_INF,
+            .viterbi_log_probs = .{},
+            .forward_log_probs = .{},
+            .viterbi_indices = .{},
+            .scoring_current = scoring_current,
+            .scoring_previous = scoring_previous,
+            .next_seen = state_mod.StateBitset.initEmpty(),
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *Trellis) void {
+        const allocator = self.allocator;
+        // seqs is borrowed; not freed here.
+        if (self.traceback_table.len > 0) allocator.free(self.traceback_table);
+        self.viterbi_log_probs.deinit(allocator);
+        self.forward_log_probs.deinit(allocator);
+        self.viterbi_indices.deinit(allocator);
+        allocator.free(self.scoring_current);
+        allocator.free(self.scoring_previous);
+    }
+
+    /// Run the Viterbi algorithm.
+    /// After calling this, `ending_viterbi_log_prob` and `traceback_table` are set.
+    /// Corresponds to C++ `Trellis::Viterbi()`.
+    pub fn viterbi(self: *Trellis) !void {
+        const allocator = self.allocator;
+        const seq_len = self.seq_len;
+        const n_states = self.hmm.nStates();
+        // Cache the borrowed seqs pointer in a local so the inner DP loop reads
+        // it from a register rather than re-loading `self.seqs` (a heap-pointer
+        // member after #357) on every emission lookup.
+        const seqs = self.seqs;
+
+        if (self.cached_trellis) |ct| {
+            // Poach scalar values from cached trellis; array data accessed via accessors.
+            self.ending_viterbi_pointer = @intCast(ct.viterbiIndicesAt(seq_len));
+            self.ending_viterbi_log_prob = ct.endingViterbiLogProbAt(seq_len);
+            return;
+        }
+
+        // Phase-B'' timer: capture all pre-position-loop work — log_probs/indices
+        // resize, traceback_table allocate, 4× @memset on log_probs/indices/
+        // traceback_table/scoring_current/scoring_previous, plus the position-0
+        // init transitions below. The main position-loop body is derivable as
+        // fillTrellis_viterbi_ns − init − ending. Skeptic flag (#383 review,
+        // 2026-05-12): t_init was originally placed AFTER the resize/memset
+        // block, so the O(seq_len × n_states) memsets leaked into the
+        // positionLoop residual. Moving the tick up makes init_ns honest.
+        const t_init = perf_counters.tick();
+
+        // Initialize storage
+        try self.viterbi_log_probs.resize(allocator, seq_len);
+        try self.viterbi_indices.resize(allocator, seq_len);
+        @memset(self.viterbi_log_probs.items, mathutils.NEG_INF);
+        @memset(self.viterbi_indices.items, -1);
+
+        // Initialize flat traceback table [seq_len * n_states] = -1.
+        // Single allocation replaces seq_len per-row allocations (item 3 of #342).
+        // Note the explicit `traceback_table = &.{}` between free and alloc:
+        // if the alloc fails, deinit reads `traceback_table` and would otherwise
+        // see the just-freed slice with len > 0 and double-free it.
+        std.debug.assert(seq_len <= std.math.maxInt(usize) / @max(n_states, 1));
+        const total = seq_len * n_states;
+        if (self.traceback_table.len != total) {
+            if (self.traceback_table.len > 0) allocator.free(self.traceback_table);
+            self.traceback_table = &.{};
+            self.traceback_table = try allocator.alloc(i16, total);
+        }
+        @memset(self.traceback_table, -1);
+        self.traceback_n_states = n_states;
+
+        // Reset scoring columns
+        @memset(self.scoring_current, mathutils.NEG_INF);
+        @memset(self.scoring_previous, mathutils.NEG_INF);
+
+        var current_states = std.ArrayListUnmanaged(usize){};
+        defer current_states.deinit(allocator);
+        var next_states = std.ArrayListUnmanaged(usize){};
+        defer next_states.deinit(allocator);
+        // Third list for the sparse-memset three-way rotation in
+        // swapColumnsActive (#366 item 1.1). Holds the candidate-set used
+        // as input to the previous middleViterbiVals call; rotates into
+        // the role of "dirty-list for two swaps from now" so the sparse
+        // clear has the right indices in hand at every iteration without
+        // any per-active-state bookkeeping in the hot inner loop.
+        var prev_current_states = std.ArrayListUnmanaged(usize){};
+        defer prev_current_states.deinit(allocator);
+
+        // Position 0: transitions from init state
+        const init_st = self.hmm.initial orelse return error.NoInitState;
+        // Reset next_seen before populating position 0
+        self.next_seen = state_mod.StateBitset.initEmpty();
+        for (init_st.to_state_indices.items) |i_st| {
+            const emission_val = self.hmm.stateByIndex(i_st).emissionLogprobSeqs(seqs, 0);
+            const dpval = emission_val + init_st.transitionLogprob(i_st);
+            if (std.math.isNegativeInf(dpval)) continue;
+            self.scoring_current[i_st] = dpval;
+            // Track which slots the init code wrote, so the three-way list
+            // rotation in swapColumnsActive can derive iter-2's dirty-list
+            // (= these init writes) without a separate `init_written_states`
+            // list. Treats init as a virtual "iteration 0": its
+            // current_states output is the indices it wrote, and rotates
+            // into prev_current_states at swap #1 → ready for sparse-clear
+            // at swap #2 when the buffer swap exposes these slots in
+            // scoring_current. This is the small refinement of the plan's
+            // "option (b)" (init memset alone leaves swap #2's clear empty).
+            try current_states.append(allocator, i_st);
+            self.cacheViterbiVals(0, dpval, i_st);
+            // Mark outbound transitions for next position (deduplicated)
+            for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
+                if (!self.next_seen.isSet(j)) {
+                    self.next_seen.set(j);
+                    try next_states.append(allocator, j);
+                }
+            }
+        }
+        perf_counters.addElapsed(&perf_counters.viterbi_init_ns, t_init);
+
+        // Positions 1..seq_len-1
+        var position: usize = 1;
+        while (position < seq_len) : (position += 1) {
+            self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
+            try self.middleViterbiVals(allocator, current_states, &next_states, position);
+        }
+        // After this final swap `scoring_current` is left dirty by design:
+        // the ending loop below reads only `scoring_previous`, and the next
+        // entry into viterbi()/forward() does its own full @memset before
+        // reuse. Don't add a clear here without revisiting the next-entry
+        // contract — it's load-bearing for the sparse-clear win.
+        self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
+
+        // Compute ending probability
+        const t_ending = perf_counters.tick();
+        self.ending_viterbi_pointer = -1;
+        self.ending_viterbi_log_prob = mathutils.NEG_INF;
+        for (0..n_states) |st_prev| {
+            if (std.math.isNegativeInf(self.scoring_previous[st_prev])) continue;
+            const dpval = self.scoring_previous[st_prev] + self.hmm.stateByIndex(st_prev).endTransitionLogprob();
+            if (dpval > self.ending_viterbi_log_prob) {
+                self.ending_viterbi_log_prob = dpval;
+                self.ending_viterbi_pointer = @intCast(st_prev);
+            }
+        }
+        perf_counters.addElapsed(&perf_counters.viterbi_ending_ns, t_ending);
+    }
+
+    /// Run the Forward algorithm.
+    /// After calling this, `ending_forward_log_prob` is set.
+    /// Corresponds to C++ `Trellis::Forward()`.
+    pub fn forward(self: *Trellis) !void {
+        const allocator = self.allocator;
+        const seq_len = self.seq_len;
+        const n_states = self.hmm.nStates();
+        // See viterbi(): cache borrowed seqs pointer in a local for the inner DP loop.
+        const seqs = self.seqs;
+
+        if (self.cached_trellis) |ct| {
+            self.ending_forward_log_prob = ct.endingForwardLogProbAt(seq_len);
+            return;
+        }
+
+        // Phase-B'' timer: capture all pre-position-loop work — log_probs
+        // resize, 3× @memset on log_probs/scoring_current/scoring_previous, plus
+        // the position-0 init transitions below. See viterbi() above for the
+        // skeptic-flagged correction (#383 review, 2026-05-12).
+        const t_init = perf_counters.tick();
+
+        // Initialize storage
+        try self.forward_log_probs.resize(allocator, seq_len);
+        @memset(self.forward_log_probs.items, mathutils.NEG_INF);
+
+        // Reset scoring columns
+        @memset(self.scoring_current, mathutils.NEG_INF);
+        @memset(self.scoring_previous, mathutils.NEG_INF);
+
+        var current_states = std.ArrayListUnmanaged(usize){};
+        defer current_states.deinit(allocator);
+        var next_states = std.ArrayListUnmanaged(usize){};
+        defer next_states.deinit(allocator);
+        // Third list for the sparse-memset three-way rotation in
+        // swapColumnsActive (#366 item 1.1); see viterbi() for the rationale.
+        var prev_current_states = std.ArrayListUnmanaged(usize){};
+        defer prev_current_states.deinit(allocator);
+
+        // Position 0: transitions from init state
+        const init_st = self.hmm.initial orelse return error.NoInitState;
+        // Reset next_seen before populating position 0
+        self.next_seen = state_mod.StateBitset.initEmpty();
+        for (init_st.to_state_indices.items) |i_st| {
+            const emission_val = self.hmm.stateByIndex(i_st).emissionLogprobSeqs(seqs, 0);
+            const dpval = emission_val + init_st.transitionLogprob(i_st);
+            if (std.math.isNegativeInf(dpval)) continue;
+            self.scoring_current[i_st] = dpval;
+            // Track which slots the init code wrote so the three-way list
+            // rotation can derive iter-2's dirty-list. See viterbi() for
+            // the longer rationale; same logic applies here verbatim.
+            try current_states.append(allocator, i_st);
+            // Mark outbound transitions for next position (deduplicated)
+            for (self.hmm.stateByIndex(i_st).to_state_indices.items) |j| {
+                if (!self.next_seen.isSet(j)) {
+                    self.next_seen.set(j);
+                    try next_states.append(allocator, j);
+                }
+            }
+            self.cacheForwardVals(0, dpval, i_st);
+        }
+        perf_counters.addElapsed(&perf_counters.forward_init_ns, t_init);
+
+        // Positions 1..seq_len-1
+        var position: usize = 1;
+        while (position < seq_len) : (position += 1) {
+            self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
+            try self.middleForwardVals(allocator, current_states, &next_states, position);
+        }
+        // See viterbi(): `scoring_current` is intentionally left dirty here.
+        self.swapColumnsActive(&current_states, &next_states, &prev_current_states);
+
+        // Compute ending probability
+        const t_ending = perf_counters.tick();
+        self.ending_forward_log_prob = mathutils.NEG_INF;
+        for (0..n_states) |st_prev| {
+            if (std.math.isNegativeInf(self.scoring_previous[st_prev])) continue;
+            const dpval = self.scoring_previous[st_prev] + self.hmm.stateByIndex(st_prev).endTransitionLogprob();
+            if (std.math.isNegativeInf(dpval)) continue;
+            self.ending_forward_log_prob = mathutils.addInLogSpace(self.ending_forward_log_prob, dpval);
+        }
+        perf_counters.addElapsed(&perf_counters.forward_ending_ns, t_ending);
+    }
+
+    /// Traceback to produce a path.
+    /// Corresponds to C++ `Trellis::Traceback(TracebackPath&)`.
+    ///
+    /// `path_alloc` backs the path's growing item list, which may have a
+    /// different lifetime than the trellis itself: in the chunk-cache-hit
+    /// path of `DPHandler.fillTrellis`, the temp trellis lives on the
+    /// per-kset arena but the path is stored in `DPHandler.paths` (per
+    /// query). Passing the allocator explicitly avoids the use-after-free
+    /// that would otherwise come from `self.allocator` capturing a
+    /// shorter-lived arena. (Item 4, #342.)
+    pub fn traceback(self: *const Trellis, path_alloc: std.mem.Allocator, path: *TracebackPath) !void {
+        std.debug.assert(self.seq_len != 0);
+        path.setModel(self.hmm);
+        if (std.math.isNegativeInf(self.ending_viterbi_log_prob)) return;
+        path.setScore(self.ending_viterbi_log_prob);
+        try path.pushBack(path_alloc, self.ending_viterbi_pointer);
+
+        // Resolve the traceback source once: cached trellis if it has a
+        // populated table, else self. If neither does, there's nothing to
+        // walk back through.
+        const view = self.pickTracebackView() orelse return;
+        var pointer: i16 = self.ending_viterbi_pointer;
+        var position: usize = self.seq_len - 1;
+        while (position > 0) : (position -= 1) {
+            pointer = view.tbl[position * view.stride + @as(usize, @intCast(pointer))];
+            if (pointer == -1) {
+                std.debug.print("No valid path at position {d}\n", .{position});
+                return;
+            }
+            try path.pushBack(path_alloc, pointer);
+        }
+        std.debug.assert(path.size() > 0);
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    fn swapColumnsActive(
+        self: *Trellis,
+        current_states: *std.ArrayListUnmanaged(usize),
+        next_states: *std.ArrayListUnmanaged(usize),
+        prev_current_states: *std.ArrayListUnmanaged(usize),
+    ) void {
+        // Swap scoring_current ↔ scoring_previous.
+        const tmp = self.scoring_previous;
+        self.scoring_previous = self.scoring_current;
+        self.scoring_current = tmp;
+
+        // Sparse-clear scoring_current at the indices written two iterations
+        // ago (= the contents of prev_current_states at entry). After the
+        // buffer swap, scoring_current is the buffer that held those writes,
+        // so only those slots could hold non-NEG_INF; clearing them restores
+        // the same post-condition the previous full @memset gave (entire
+        // buffer NEG_INF before middle{Viterbi,Forward}Vals at iteration N
+        // writes through its current_states subset).
+        //
+        // This is the #366 item 1.1 sparse-memset path. Hot-path discipline
+        // (the rule that #369 violated): no `try`, no allocation, no fallible
+        // op in this loop — it must compile to a tight indexed store. The
+        // dirty-list arrives in `prev_current_states` as a zero-cost side
+        // effect of the three-way list rotation below; no per-active-state
+        // bookkeeping inside middle{Viterbi,Forward}Vals.
+        for (prev_current_states.items) |j| self.scoring_current[j] = mathutils.NEG_INF;
+
+        // Clear next_seen for all indices that were in next_states
+        // (they will become current_states; next_seen tracks what's queued for the NEW next)
+        for (next_states.items) |j| self.next_seen.unset(j);
+
+        // Three-way list rotation: prev_current ← current, current ← next,
+        // next ← (old prev_current, then cleared). After this rotation:
+        //   - current_states.items = the candidate-set for the NEXT
+        //     middle{Viterbi,Forward}Vals call (i.e., what was in
+        //     next_states at entry, populated by the previous iteration);
+        //   - prev_current_states.items = the candidate-set that was just
+        //     used as input to the previous middle{...}Vals call. Those
+        //     indices name the slots in scoring_previous (post-rotation),
+        //     and will become the dirty-list for the sparse-clear two
+        //     swaps from now (when those slots have rotated back into
+        //     scoring_current via the next two buffer swaps).
+        //   - next_states is empty (clearRetainingCapacity), ready for
+        //     the next middle{...}Vals to populate the iteration-after-next
+        //     candidate set.
+        //
+        // ArrayListUnmanaged is two POD fields (items: []usize, capacity:
+        // usize); this is allocation-free struct-field assignment, no `try`.
+        const tmp_items = prev_current_states.items;
+        const tmp_capacity = prev_current_states.capacity;
+        prev_current_states.items = current_states.items;
+        prev_current_states.capacity = current_states.capacity;
+        current_states.items = next_states.items;
+        current_states.capacity = next_states.capacity;
+        next_states.items = tmp_items;
+        next_states.capacity = tmp_capacity;
+        next_states.clearRetainingCapacity();
+        // Sort current_states in ascending order to match C++ bitset iteration
+        // (0..n_states). This is critical: cacheForwardVals accumulates
+        // forward_log_probs[position] across all (state, prev_state) pairs,
+        // and addInLogSpace is not associative, so different accumulation orders
+        // produce different results. The cached forward_log_probs values are
+        // then read by chunk-cached trellises via endingForwardLogProbAt().
+        std.mem.sort(usize, current_states.items, {}, std.sort.asc(usize));
+    }
+
+    fn middleViterbiVals(
+        self: *Trellis,
+        allocator: std.mem.Allocator,
+        current_states: std.ArrayListUnmanaged(usize),
+        next_states: *std.ArrayListUnmanaged(usize),
+        position: usize,
+    ) !void {
+        perf_counters.recordActiveStates(current_states.items.len);
+        // See viterbi(): cache borrowed seqs pointer in a local for the inner loop.
+        const seqs = self.seqs;
+        for (current_states.items) |i_st_cur| {
+            const st_cur = self.hmm.stateByIndex(i_st_cur);
+            const emission_val = st_cur.emissionLogprobSeqs(seqs, position);
+            if (std.math.isNegativeInf(emission_val)) continue;
+            for (st_cur.from_state_indices.items) |i_st_prev| {
+                const prev_val = self.scoring_previous[i_st_prev];
+                if (std.math.isNegativeInf(prev_val)) continue;
+                const dpval = prev_val + emission_val + self.hmm.stateByIndex(i_st_prev).transitionLogprob(i_st_cur);
+                if (dpval > self.scoring_current[i_st_cur]) {
+                    self.scoring_current[i_st_cur] = dpval;
+                    self.tracebackSet(position, i_st_cur, @intCast(i_st_prev));
+                }
+                self.cacheViterbiVals(position, dpval, i_st_cur);
+                // Mark outbound transitions inside the i_st_prev loop (as in C++) so we only
+                // include states that are really needed, i.e. that have at least one valid predecessor
+                for (st_cur.to_state_indices.items) |j| {
+                    if (!self.next_seen.isSet(j)) {
+                        self.next_seen.set(j);
+                        try next_states.append(allocator, j);
+                    }
+                }
+            }
+        }
+    }
+
+    fn middleForwardVals(
+        self: *Trellis,
+        allocator: std.mem.Allocator,
+        current_states: std.ArrayListUnmanaged(usize),
+        next_states: *std.ArrayListUnmanaged(usize),
+        position: usize,
+    ) !void {
+        perf_counters.recordActiveStates(current_states.items.len);
+        // See viterbi(): cache borrowed seqs pointer in a local for the inner loop.
+        const seqs = self.seqs;
+        for (current_states.items) |i_st_cur| {
+            const st_cur = self.hmm.stateByIndex(i_st_cur);
+            const emission_val = st_cur.emissionLogprobSeqs(seqs, position);
+            if (std.math.isNegativeInf(emission_val)) continue;
+            for (st_cur.from_state_indices.items) |i_st_prev| {
+                const prev_val = self.scoring_previous[i_st_prev];
+                if (std.math.isNegativeInf(prev_val)) continue;
+                const dpval = prev_val + emission_val + self.hmm.stateByIndex(i_st_prev).transitionLogprob(i_st_cur);
+                self.scoring_current[i_st_cur] = mathutils.addInLogSpace(dpval, self.scoring_current[i_st_cur]);
+                self.cacheForwardVals(position, dpval, i_st_cur);
+                // Mark outbound transitions inside the i_st_prev loop (as in C++) so we only
+                // include states that are really needed, i.e. that have at least one valid predecessor
+                for (st_cur.to_state_indices.items) |j| {
+                    if (!self.next_seen.isSet(j)) {
+                        self.next_seen.set(j);
+                        try next_states.append(allocator, j);
+                    }
+                }
+            }
+        }
+    }
+
+    inline fn cacheViterbiVals(self: *Trellis, position: usize, dpval: f64, i_st_cur: usize) void {
+        const end_trans = self.hmm.stateByIndex(i_st_cur).endTransitionLogprob();
+        const logprob = dpval + end_trans;
+        if (logprob > self.viterbi_log_probs.items[position]) {
+            self.viterbi_log_probs.items[position] = logprob;
+            self.viterbi_indices.items[position] = @intCast(i_st_cur);
+        }
+    }
+
+    inline fn cacheForwardVals(self: *Trellis, position: usize, dpval: f64, i_st_cur: usize) void {
+        const end_trans = self.hmm.stateByIndex(i_st_cur).endTransitionLogprob();
+        const logprob = dpval + end_trans;
+        self.forward_log_probs.items[position] = mathutils.addInLogSpace(logprob, self.forward_log_probs.items[position]);
+    }
+
+    // ── Accessors: dispatch to cached trellis data or own data ──────────────
+
+    /// Resolved view of the traceback source: the cached trellis's table if it
+    /// has one populated, else self's, else null. The stride is captured at
+    /// the same time as the slice so callers don't have to re-do the dispatch.
+    const TracebackView = struct { tbl: []const i16, stride: usize };
+
+    inline fn pickTracebackView(self: *const Trellis) ?TracebackView {
+        if (self.cached_trellis) |ct| {
+            if (ct.traceback_table.len > 0) {
+                return .{ .tbl = ct.traceback_table, .stride = ct.traceback_n_states };
+            }
+        }
+        if (self.traceback_table.len > 0) {
+            return .{ .tbl = self.traceback_table, .stride = self.traceback_n_states };
+        }
+        return null;
+    }
+
+    /// Scalar write of *self*'s traceback table at (position, state). Used by
+    /// `middleViterbiVals` while filling the table fresh.
+    inline fn tracebackSet(self: *Trellis, position: usize, state: usize, v: i16) void {
+        self.traceback_table[position * self.traceback_n_states + state] = v;
+    }
+
+    /// Ending Viterbi log-prob for a specific sequence length (used by cached trellis).
+    pub fn endingViterbiLogProbAt(self: *const Trellis, length: usize) f64 {
+        if (length == 0) return mathutils.NEG_INF;
+        const items = if (self.cached_trellis) |ct| ct.viterbi_log_probs.items else self.viterbi_log_probs.items;
+        if (length - 1 < items.len) return items[length - 1];
+        return mathutils.NEG_INF;
+    }
+
+    /// Ending Forward log-prob for a specific sequence length.
+    pub fn endingForwardLogProbAt(self: *const Trellis, length: usize) f64 {
+        if (length == 0) return mathutils.NEG_INF;
+        const items = if (self.cached_trellis) |ct| ct.forward_log_probs.items else self.forward_log_probs.items;
+        if (length - 1 < items.len) return items[length - 1];
+        return mathutils.NEG_INF;
+    }
+
+    /// Best state index at a specific sequence length (Viterbi).
+    pub fn viterbiIndicesAt(self: *const Trellis, length: usize) i32 {
+        if (length == 0) return -1;
+        const items = if (self.cached_trellis) |ct| ct.viterbi_indices.items else self.viterbi_indices.items;
+        if (length - 1 < items.len) return items[length - 1];
+        return -1;
+    }
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+// Integration test: parse a real model and run Forward on a short sequence.
+test "Trellis: forward on real IGHV3-15 model" {
+    const allocator = std.testing.allocator;
+
+    const yaml_path = "/fh/fast/matsen_e/shared/partis-zig/partis/test/ref-results-slow/test/parameters/simu/sw/hmms/IGHV3-15_star_07.yaml";
+    var model = try @import("model.zig").Model.init(allocator);
+    defer model.deinit(allocator);
+    model.parse(allocator, yaml_path) catch |err| {
+        // Skip test if YAML file not available (e.g. CI without data)
+        std.debug.print("skipping trellis test: {}\n", .{err});
+        return;
+    };
+
+    // Build a 4-symbol sequence using the model's track
+    const trk = model.track orelse return;
+    var seq = try Sequence.initFromString(allocator, trk, "test_seq", "ACGT");
+    defer seq.deinit(allocator);
+
+    // Trellis borrows the Sequences; the caller retains ownership.
+    var seqs = Sequences.init();
+    defer seqs.deinit(allocator);
+    try seqs.addSeq(allocator, try seq.clone(allocator));
+
+    var trellis = try Trellis.initWithSeqs(allocator, &model, &seqs, null);
+    defer trellis.deinit();
+
+    try trellis.forward();
+
+    // A 4-symbol query against a ~300nt V-gene HMM may legitimately return
+    // -inf (no valid path); a finite log-prob is the success signal but not
+    // a hard requirement. The structural success is that forward() ran without
+    // crashing through the trellis allocation/teardown path.
+    std.debug.print("forward log-prob: {d}\n", .{trellis.ending_forward_log_prob});
+}
+
+// Layout test: writing through `tracebackSet` and reading back via
+// `pickTracebackView` must round-trip the value at the same (position, state).
+// Catches row/col transposition in the indexing helpers without needing a full
+// Model — the byte-equality gate at 5k/30k can't catch a transposition when
+// seq_len ≈ n_states (square trellis), so this covers the gap.
+test "Trellis: flat traceback layout round-trips position/state" {
+    const allocator = std.testing.allocator;
+
+    const seq_len: usize = 4;
+    const n_states: usize = 5;
+
+    // Hand-build just the indexing fields. The non-indexing fields aren't
+    // touched by tracebackSet / pickTracebackView.
+    var trellis: Trellis = undefined;
+    trellis.allocator = allocator;
+    trellis.cached_trellis = null;
+    trellis.traceback_n_states = n_states;
+    trellis.traceback_table = try allocator.alloc(i16, seq_len * n_states);
+    defer allocator.free(trellis.traceback_table);
+    @memset(trellis.traceback_table, -1);
+
+    // Write a unique value at every (position, state).
+    for (0..seq_len) |pos| {
+        for (0..n_states) |st| {
+            trellis.tracebackSet(pos, st, @intCast(pos * 10 + st));
+        }
+    }
+    // Read back via the resolved view. A row/col swap in the indexing math
+    // would surface as the wrong value (or out-of-range index) at every cell.
+    const view = trellis.pickTracebackView() orelse return error.TestUnexpectedNull;
+    for (0..seq_len) |pos| {
+        for (0..n_states) |st| {
+            const expected: i16 = @intCast(pos * 10 + st);
+            try std.testing.expectEqual(expected, view.tbl[pos * view.stride + st]);
+        }
+    }
+
+    // Empty-table fallback: pickTracebackView returns null when neither self
+    // nor cached has a table, mirroring the original `?[][]i16` accessor's
+    // null path. `traceback()` short-circuits on this.
+    var empty_trellis: Trellis = undefined;
+    empty_trellis.allocator = allocator;
+    empty_trellis.cached_trellis = null;
+    empty_trellis.traceback_n_states = 0;
+    empty_trellis.traceback_table = &.{};
+    try std.testing.expectEqual(@as(?Trellis.TracebackView, null), empty_trellis.pickTracebackView());
+
+    // Cached-fallthrough: when self has no table but cached does, the view
+    // should come from cached, with cached's stride (not self's, which is 0).
+    var borrow_trellis: Trellis = undefined;
+    borrow_trellis.allocator = allocator;
+    borrow_trellis.cached_trellis = &trellis;
+    borrow_trellis.traceback_n_states = 0;
+    borrow_trellis.traceback_table = &.{};
+    const borrow_view = borrow_trellis.pickTracebackView() orelse return error.TestUnexpectedNull;
+    try std.testing.expectEqual(@as(usize, n_states), borrow_view.stride);
+    for (0..seq_len) |pos| {
+        for (0..n_states) |st| {
+            const expected: i16 = @intCast(pos * 10 + st);
+            try std.testing.expectEqual(expected, borrow_view.tbl[pos * borrow_view.stride + st]);
+        }
+    }
+}
+
+// Viterbi → traceback parity: run viterbi on a real model, walk the traceback
+// path through the flat table, and assert the path is consistent with the
+// per-position best-state record. This is end-to-end coverage of the indexing
+// helpers under the actual DP loop, complementing the layout test above.
+test "Trellis: viterbi traceback walks through flat table consistently" {
+    const allocator = std.testing.allocator;
+
+    const yaml_path = "/fh/fast/matsen_e/shared/partis-zig/partis/test/ref-results-slow/test/parameters/simu/sw/hmms/IGHV3-15_star_07.yaml";
+    var model = try @import("model.zig").Model.init(allocator);
+    defer model.deinit(allocator);
+    model.parse(allocator, yaml_path) catch |err| {
+        std.debug.print("skipping viterbi traceback test: {}\n", .{err});
+        return;
+    };
+
+    const trk = model.track orelse return;
+    var seq = try Sequence.initFromString(allocator, trk, "test_seq", "ACGTACGT");
+    defer seq.deinit(allocator);
+
+    var seqs = Sequences.init();
+    defer seqs.deinit(allocator);
+    try seqs.addSeq(allocator, try seq.clone(allocator));
+
+    var trellis = try Trellis.initWithSeqs(allocator, &model, &seqs, null);
+    defer trellis.deinit();
+
+    try trellis.viterbi();
+
+    // Traceback table should be populated under the new flat layout.
+    try std.testing.expectEqual(seqs.sequence_length * model.nStates(), trellis.traceback_table.len);
+    try std.testing.expectEqual(model.nStates(), trellis.traceback_n_states);
+
+    // Skip the path comparison if viterbi found no valid path through the
+    // model (depends on YAML data); the structural checks above are enough
+    // to fail on a misshapen allocation.
+    if (std.math.isNegativeInf(trellis.ending_viterbi_log_prob)) {
+        std.debug.print("viterbi found no valid path; skipping traceback walk\n", .{});
+        return;
+    }
+
+    var path = TracebackPath.initWithModel(&model);
+    defer path.deinit(allocator);
+    try trellis.traceback(allocator, &path);
+
+    // Path length should equal seq_len: traceback pushes ending pointer, then
+    // one entry per position from seq_len-1 down to 1.
+    try std.testing.expectEqual(seqs.sequence_length, path.size());
+
+    // Every traceback step must read a valid (>=0) state from the flat table.
+    // This is what would fail catastrophically under a row/col transpose: the
+    // wrong-strided read would land on -1 entries (or out of bounds — the
+    // overflow assert above guards bounds).
+    const view = trellis.pickTracebackView() orelse return error.TestUnexpectedNull;
+    var pointer: i16 = trellis.ending_viterbi_pointer;
+    var position: usize = trellis.seq_len - 1;
+    while (position > 0) : (position -= 1) {
+        const next = view.tbl[position * view.stride + @as(usize, @intCast(pointer))];
+        try std.testing.expect(next >= 0);
+        pointer = next;
+    }
+}

--- a/packages/zig-core/src/igsw/c/ig_align.c
+++ b/packages/zig-core/src/igsw/c/ig_align.c
@@ -1,0 +1,581 @@
+#include "ig_align.h"
+
+#include <assert.h>
+#include <math.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "kseq.h"
+#include "ksort.h"
+#include "kstring.h"
+#include "ksw.h"
+#include "kvec.h"
+#include <zlib.h>
+
+#define xstr(a) str(a)
+#define str(a) #a
+
+/* Cigar operations */
+/**
+ * Describing how CIGAR operation/length is packed in a 32-bit integer.
+ */
+#define BAM_CIGAR_SHIFT 4
+#define BAM_CIGAR_MASK ((1 << BAM_CIGAR_SHIFT) - 1)
+
+#define BAM_CIGAR_STR "MIDNSHP=XB"
+#define BAM_CIGAR_TYPE 0x3C1A7
+
+#define bam_cigar_op(c) ((c)&BAM_CIGAR_MASK)
+#define bam_cigar_oplen(c) ((c) >> BAM_CIGAR_SHIFT)
+#define bam_cigar_opchr(c) (BAM_CIGAR_STR[bam_cigar_op(c)])
+#define bam_cigar_gen(l, o) ((l) << BAM_CIGAR_SHIFT | (o))
+#define bam_cigar_type(o)                                                      \
+  (BAM_CIGAR_TYPE >> ((o) << 1) &                                              \
+   3) // bit 1: consume query; bit 2: consume reference
+/* end */
+
+#ifdef __GNUC__
+#define LIKELY(x) __builtin_expect((x), 1)
+#define UNLIKELY(x) __builtin_expect((x), 0)
+#else
+#define LIKELY(x) (x)
+#define UNLIKELY(x) (x)
+#endif
+
+/*! @function
+  @abstract  Round an integer to the next closest power-2 integer.
+  @param  x  integer to be rounded (in place) @discussion x will be modified.
+  */
+#ifndef kroundup32
+#define kroundup32(x)                                                          \
+  (--(x), (x) |= (x) >> 1, (x) |= (x) >> 2, (x) |= (x) >> 4, (x) |= (x) >> 8,  \
+   (x) |= (x) >> 16, ++(x))
+#endif
+
+KSEQ_INIT(gzFile, gzread)
+
+typedef kvec_t(kseq_t) kseq_v;
+
+/* Destroy a vector of pointers, calling f on each item */
+#define kvp_destroy(f, v)                                                      \
+  for (size_t __kpd = 0; __kpd < kv_size(v); ++__kpd)                          \
+    f(kv_A(v, __kpd));                                                         \
+  kv_destroy(v)
+
+#define kvi_destroy(f, v)                                                      \
+  for (size_t __kpd = 0; __kpd < kv_size(v); ++__kpd)                          \
+    f(&kv_A(v, __kpd));                                                        \
+  kv_destroy(v)
+
+static void kstring_copy(kstring_t *dest, const kstring_t *other) {
+  dest->l = other->l;
+  dest->m = dest->l + 1;
+  if (dest->l > 0) {
+    assert(other->s != NULL);
+    dest->s = malloc(dest->l + 1);
+    memcpy(dest->s, other->s, dest->l);
+    dest->s[dest->l] = 0; // null-terminate
+  } else {
+    dest->s = NULL;
+  }
+}
+
+static void kseq_stack_destroy(kseq_t *seq) {
+  free(seq->name.s);
+  free(seq->comment.s);
+  free(seq->seq.s);
+  free(seq->qual.s);
+}
+
+static void kseq_copy(kseq_t *dest, const kseq_t *seq) {
+  dest->f = NULL;
+  kstring_copy(&dest->name, &seq->name);
+  kstring_copy(&dest->comment, &seq->comment);
+  kstring_copy(&dest->seq, &seq->seq);
+  kstring_copy(&dest->qual, &seq->qual);
+}
+
+static kseq_v read_seqs(kseq_t *seq, size_t n_wanted) {
+  kseq_v result;
+  kv_init(result);
+  for (size_t i = 0; i < n_wanted || n_wanted == 0; i++) {
+    if (kseq_read(seq) <= 0)
+      break;
+    kseq_t s;
+    kseq_copy(&s, seq);
+    kv_push(kseq_t, result, s);
+  }
+  return result;
+}
+
+typedef struct {
+  char *target_name;
+  kswr_t loc;
+  uint32_t *cigar;
+  int n_cigar;
+  uint32_t nm;
+} aln_t;
+typedef kvec_t(aln_t) aln_v;
+
+#define __aln_score_lt(a, b) ((a).loc.score > (b).loc.score)
+KSORT_INIT(cdec_score, aln_t, __aln_score_lt)
+
+typedef struct { aln_v alignments; } aln_task_t;
+typedef kvec_t(aln_task_t) aln_task_v;
+
+typedef struct {
+  int32_t gap_o; /* 3 */
+  int32_t gap_e; /* 1 */
+  uint8_t *table;
+  int m;       /* Number of residue tyes */
+  int8_t *mat; /* Scoring matrix */
+  int max_drop;
+  int min_score;
+  unsigned bandwidth;
+} align_config_t;
+
+static aln_t align_read_against_one(kseq_t *target, const int read_len,
+                                    uint8_t *read_num, kswq_t **qry,
+                                    const align_config_t *conf,
+                                    const int min_score) {
+  uint8_t *ref_num = calloc(target->seq.l, sizeof(uint8_t));
+  for (size_t k = 0; k < target->seq.l; ++k)
+    ref_num[k] = conf->table[(int)target->seq.s[k]];
+
+  aln_t aln;
+  aln.cigar = NULL;
+  aln.loc = ksw_align(read_len, read_num, target->seq.l, ref_num, conf->m,
+                      conf->mat, conf->gap_o, conf->gap_e, KSW_XSTART, qry);
+
+  aln.target_name = target->name.s;
+
+  if (aln.loc.score < min_score) {
+    free(ref_num);
+    return aln;
+  }
+
+  ksw_global(aln.loc.qe - aln.loc.qb + 1, &read_num[aln.loc.qb],
+             aln.loc.te - aln.loc.tb + 1, &ref_num[aln.loc.tb], conf->m,
+             conf->mat, conf->gap_o, conf->gap_e, conf->bandwidth, &aln.n_cigar,
+             &aln.cigar);
+
+  aln.nm = 0;
+  size_t qi = aln.loc.qb, ri = aln.loc.tb;
+  for (int k = 0; k < aln.n_cigar; k++) {
+    const int32_t oplen = bam_cigar_oplen(aln.cigar[k]),
+                  optype = bam_cigar_type(aln.cigar[k]);
+
+    if (optype & 3) { // consumes both - check for mismatches
+      for (int j = 0; j < oplen; j++) {
+        if (UNLIKELY(read_num[qi + j] != ref_num[ri + j]))
+          aln.nm++;
+      }
+    } else {
+      aln.nm += oplen;
+    }
+    if (optype & 1)
+      qi += oplen;
+    if (optype & 2)
+      ri += oplen;
+  }
+
+  free(ref_num);
+
+  /* size_t cigar_len = aln.loc.qb; */
+  /* for (int c = 0; c < aln.n_cigar; c++) { */
+  /*   int32_t length = (0xfffffff0 & *(aln.cigar + c)) >> 4; */
+  /*   cigar_len += length; */
+  /* } */
+  /* cigar_len += read_len - aln.loc.qe - 1; */
+  /* if(cigar_len != (size_t)read_len) { */
+  /*   /\* printf("[ig_align] Error: cigar length (score %d) not equal to read length for XXX (target %s): %zu vs %d\n", aln.loc.score, target->name.s, cigar_len, read_len); *\/ */
+  /*   // NOTE: */
+  /*   //   It is *really* *fucking* *scary* that it's spitting out cigars that are not the same length as the query sequence. */
+  /*   //   Nonetheless, fixing it seems to involve delving into the depths of ksw_align() and ksw_global(), which would be very time consuming, and the length discrepancy seems to ony appear in very poor matches. */
+  /*   //   I.e., poor enough that we will subsequently ignore them in partis/python/waterer.py, so it seems to not screw anything up downstream to just set the length-discrepant matches' scores to zero, such that ig-sw doesn't write them to its sam output. */
+  /*   //   Note also that it is not always the lowest- or highest-scoring matches that have discrepant lengths (i.e. setting their scores to zero promotes matches swith poorer scores, but which do not have discrepant lengths. */
+  /*   /\* aln.loc.score = 0; *\/ */
+  /*   aln.cigar = NULL; */
+  /* } */
+
+  return aln;
+}
+
+/* Returns total size after dropping low scores */
+void drop_low_scores(aln_v *vec, int offset, int max_drop) {
+  const int size = kv_size(*vec);
+  ks_introsort(cdec_score, size - offset, vec->a + offset);
+  const int min_score = kv_A(*vec, offset).loc.score - max_drop;
+  for (int i = offset; i < size; i++) {
+    if (kv_A(*vec, i).loc.score < min_score) {
+      vec->n = i;
+
+      /* Free remaining */
+      for (int j = i; j < size; j++)
+        free(kv_A(*vec, j).cigar);
+      return;
+    }
+  }
+}
+
+static aln_v align_read(const kseq_t *read, const kseq_v targets,
+                        const size_t n_extra_targets,
+                        const kseq_v *extra_targets,
+                        const align_config_t *conf) {
+  kseq_t *r;
+  const int32_t read_len = read->seq.l;
+
+  aln_v result;
+  kv_init(result);
+  kv_resize(aln_t, result, kv_size(targets));
+
+  uint8_t *read_num = calloc(read_len, sizeof(uint8_t));  // vector of integers encoding the read sequence (i.e. one integer for each character in the read)
+
+  for (int k = 0; k < read_len; ++k)
+    read_num[k] = conf->table[(int)read->seq.s[k]];
+
+  // first align entire read against first batch of targets (i.e. the v genes)
+  kswq_t *qry = NULL;
+  int min_score = -1000;
+  int max_score = 0;
+  for (size_t j = 0; j < kv_size(targets); j++) {
+    // Encode target
+    r = &kv_A(targets, j);
+    aln_t aln =
+      align_read_against_one(r, read_len, read_num, &qry, conf, min_score);
+    if (aln.cigar != NULL) {
+      max_score = aln.loc.score > max_score ? aln.loc.score : max_score;
+      min_score = (aln.loc.score - conf->max_drop) > min_score
+                      ? (aln.loc.score - conf->max_drop)
+                      : min_score;
+      kv_push(aln_t, result, aln);
+    }
+  }
+
+  /* If no alignments to the first set of targets reached the minimum score,
+   * abort.
+   */
+  if (max_score < conf->min_score) {
+    // kv_size returns the n field of a kvec_t, which is a size_t.
+    for (size_t i = 0; i < kv_size(result); i++)
+      free(kv_A(result, i).cigar);
+    kv_size(result) = 0;
+    free(qry);
+    free(read_num);
+    return result;
+  }
+
+  drop_low_scores(&result, 0, conf->max_drop);
+
+  // Extra references - qe points to the exact end of the sequence
+  int qend = kv_A(result, 0).loc.qe + 1;  // + 1 converts to python slice conventions
+  int read_len_trunc = read_len - qend;
+  uint8_t *read_num_trunc = read_num + qend;  // truncate the encoded read sequence by incremeting the start position (well, pointer to)
+
+  free(qry);
+  qry = NULL;
+
+  // then align any part of the read that remains after truncation against any targets in <extra_targets> (i.e., presumably, first against j [after which we truncate the j match] and then against d)
+  if (read_len_trunc > 2) {
+    for (size_t i = 0; i < n_extra_targets; i++) {
+      const size_t idx = n_extra_targets - i - 1;
+      min_score = -1000;
+      const size_t init_count = kv_size(result);
+      for (size_t j = 0; j < kv_size(extra_targets[idx]); j++) {
+        r = &kv_A(extra_targets[idx], j);
+        aln_t aln = align_read_against_one(r, read_len_trunc, read_num_trunc,
+                                           &qry, conf, min_score);
+
+        if (aln.cigar != NULL) {
+          min_score = (aln.loc.score - conf->max_drop) > min_score
+                          ? (aln.loc.score - conf->max_drop)
+                          : min_score;
+          aln.loc.qb += qend;
+          aln.loc.qe += qend;
+          kv_push(aln_t, result, aln);
+        }
+      }
+      drop_low_scores(&result, init_count, conf->max_drop);
+
+      // truncate read/query sequence by adjusting the length that we pass to the aligner (i.e. we first do j, then effectively remove the j portion of the read by decreasing <read_len_trunc>)
+      read_len_trunc = kv_A(result, init_count).loc.qb - qend;
+      free(qry);
+      qry = NULL;
+    }
+  }
+
+  free(qry);
+  free(read_num);
+
+  return result;
+}
+
+static void write_sam_records(kstring_t *str, const kseq_t *read,
+                              const aln_v result, const char *read_group_id) {
+  if (kv_size(result) == 0)
+    return;
+
+  /* Alignments are sorted by decreasing score */
+  bool wrote_primary_stuff = false;  // can't any more use i==0 criterion, since the first match may be one with discordant cigar and read lengths
+  aln_t *tmp_aln = NULL;  // pointer to first alignment, so we can write a sensible target name to the dummy line
+  for (size_t i = 0; i < kv_size(result); i++) {
+    aln_t a = kv_A(result, i);
+    if (i == 0)
+      tmp_aln = &a;
+
+    kstring_t tmpstr = {0, 0, NULL};  // temporary, so we can avoid writing to <str> until we know if the cigar and read are the same length
+    ksprintf(&tmpstr, "%s\t%d\t", read->name.s, !wrote_primary_stuff ? 0 : 256); /* Secondary */
+    ksprintf(&tmpstr, "%s\t%d\t%d\t", a.target_name,               /* Reference */
+             a.loc.tb + 1,                                     /* POS */
+             40);                                              /* MAPQ */
+    if (a.loc.qb)
+      ksprintf(&tmpstr, "%dS", a.loc.qb);
+    size_t match_length = 0;
+    for (int c = 0; c < a.n_cigar; c++) {
+      int32_t letter = 0xf & *(a.cigar + c);
+      int32_t length = (0xfffffff0 & *(a.cigar + c)) >> 4;
+      ksprintf(&tmpstr, "%d", length);
+      if (letter == 0) {
+        ksprintf(&tmpstr, "M");
+	match_length += length;
+      } else if (letter == 1) {
+        ksprintf(&tmpstr, "I");
+	match_length += length;
+      } else {
+        ksprintf(&tmpstr, "D");
+      }
+    }
+
+    if(a.loc.qe - a.loc.qb != (int)match_length - 1) {
+      /* fprintf(stderr, "[ig_align] Error: match length mismatch for query %s score %d target %s: qe - qb = %d - %d = %d != match_length - 1 = %zu\n", read->name.s, a.loc.score, a.target_name, a.loc.qe, a.loc.qb, a.loc.qe - a.loc.qb, match_length - 1); */
+      /* fprintf(stderr, "        %s    %s\n", tmpstr.s, read->seq.s); */
+      /* // assert(0); */
+      continue;
+    }
+
+    ksprintf(str, "%s", tmpstr.s);
+
+    if (a.loc.qe + 1 != (int)read->seq.l)
+      ksprintf(str, "%luS", read->seq.l - a.loc.qe - 1);
+
+    ksprintf(str, "\t*\t0\t0\t");
+    ksprintf(str, "%s\t", wrote_primary_stuff ? "*" : read->seq.s);
+    if (read->qual.s && !wrote_primary_stuff)
+      ksprintf(str, "%s", read->qual.s);
+    else
+      ksprintf(str, "*");
+
+    ksprintf(str, "\tAS:i:%d\tNM:i:%d", a.loc.score, a.nm);
+    if (read_group_id)
+      ksprintf(str, "\tRG:Z:%s", read_group_id);
+    kputs("\n", str);
+    wrote_primary_stuff = true;
+  }
+
+  if (!wrote_primary_stuff) {  // no matches whatsoever made it through (probably due to lots of cigar/read length discrepancies) -- write a dummy line so the code reading it knows we didn't just lose the query
+    ksprintf(str, "%s\t%d\t%s\t%d\t%d\t%dS\t*\t0\t0\t%s\t*\tAS:i:%d\tNM:i:%d",
+	     read->name.s, 0, tmp_aln ? tmp_aln->target_name : "xxx", 1, 999, (int)read->seq.l, read->seq.s, 0, 0);
+    if (read_group_id)
+      ksprintf(str, "\tRG:Z:%s", read_group_id);
+    kputs("\n", str);
+  }
+}
+
+typedef struct {
+  size_t start;
+  size_t step;
+  size_t n;
+  kseq_v ref_seqs;
+  int n_extra_refs;
+  kseq_v *extra_ref_seqs;
+  kseq_v reads;
+  kstring_t *sams;
+  align_config_t *config;
+  const char *read_group_id;
+} worker_t;
+
+static void *worker(void *data) {
+  worker_t *w = (worker_t *)data;
+  for (size_t i = w->start; i < w->n; i += w->step) {
+    kseq_t *s = &kv_A(w->reads, i);
+    aln_v result = align_read(s, w->ref_seqs, w->n_extra_refs,
+                              w->extra_ref_seqs, w->config);
+
+    kstring_t str = {0, 0, NULL};
+
+    write_sam_records(&str, s, result, w->read_group_id);
+
+    w->sams[i] = str;
+
+    for (size_t j = 0; j < kv_size(result); j++)
+      free(kv_A(result, j).cigar);
+    kv_destroy(result);
+    kseq_stack_destroy(s);
+  }
+
+  return 0;
+}
+
+void ig_align_reads(const char *ref_path, const uint8_t n_extra_refs,
+                    const char **extra_ref_paths, const char *qry_path,
+                    const char *output_path, const int32_t match, /* 2 */
+                    const int32_t mismatch,                       /* 2 */
+                    const int32_t gap_o,                          /* 3 */
+                    const int32_t gap_e,                          /* 1 */
+                    const unsigned max_drop,                      /* 1000 */
+                    const int min_score,                          /* 0 */
+                    const unsigned bandwidth,                     /* 150 */
+                    const uint8_t n_threads,                      /* 1 */
+                    const char *read_group, const char *read_group_id) {
+  gzFile read_fp, ref_fp;
+  FILE *out_fp;
+  int32_t j, k, l;
+  const int m = 5;
+  kseq_t *seq;
+  int8_t *mat = (int8_t *)calloc(25, sizeof(int8_t));
+
+  /* This table is used to transform nucleotide letters into numbers. */
+  uint8_t table[128] = {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+                        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+                        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+                        4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 1, 4, 4, 4, 2, 4, 4, 4, 4,
+                        4, 4, 4, 4, 4, 4, 4, 4, 3, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+                        4, 4, 0, 4, 1, 4, 4, 4, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+                        4, 4, 3, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
+
+  // initialize scoring matrix for genome sequences
+  for (l = k = 0; LIKELY(l < 4); ++l) {
+    for (j = 0; LIKELY(j < 4); ++j)
+      mat[k++] =
+          l == j ? match : -mismatch; /* weight_match : -weight_mismatch */
+    mat[k++] = 0;                     // ambiguous base
+  }
+  for (j = 0; LIKELY(j < 5); ++j)
+    mat[k++] = 0;
+
+  // Read reference sequences
+  ref_fp = gzopen(ref_path, "r");
+  if(ref_fp == NULL) {
+    fprintf(stderr, "Failed to open reference %s\n", ref_path);
+    assert(0);
+  }
+  seq = kseq_init(ref_fp);
+  kseq_v ref_seqs;
+  ref_seqs = read_seqs(seq, 0);
+  kseq_destroy(seq);
+  gzclose(ref_fp);
+
+  fprintf(stderr, "[ig_align] Read %lu references\n", kv_size(ref_seqs));
+
+  kseq_v *extra_ref_seqs = malloc(sizeof(kseq_v) * n_extra_refs);
+
+  for (size_t i = 0; i < n_extra_refs; i++) {
+    ref_fp = gzopen(extra_ref_paths[i], "r");
+    assert(ref_fp != NULL && "Failed to open reference");
+    seq = kseq_init(ref_fp);
+    extra_ref_seqs[i] = read_seqs(seq, 0);
+    kseq_destroy(seq);
+    gzclose(ref_fp);
+    fprintf(stderr, "[ig_align] Read %lu extra references from %s\n",
+            kv_size(extra_ref_seqs[i]), extra_ref_paths[i]);
+  }
+
+  // Print SAM header
+  out_fp = fopen(output_path, "w");
+  fprintf(out_fp, "@HD\tVN:1.4\tSO:unsorted\n");
+  fprintf(out_fp, "@PG\tID:ig_align\tPN:ig_align\tCL:match=%d,mismatch=%d,go=%"
+                  "d,ge=%d\tVN:%s\n",
+          match, mismatch, gap_o, gap_e, xstr(VDJALIGN_VERSION));
+  for (size_t i = 0; i < kv_size(ref_seqs); i++) {
+    seq = &kv_A(ref_seqs, i);
+    fprintf(out_fp, "@SQ\tSN:%s\tLN:%d\n", seq->name.s, (int32_t)seq->seq.l);
+  }
+  for (size_t i = 0; i < n_extra_refs; i++) {
+    for (size_t j = 0; j < kv_size(extra_ref_seqs[i]); j++) {
+      seq = &kv_A(extra_ref_seqs[i], j);
+      fprintf(out_fp, "@SQ\tSN:%s\tLN:%d\n", seq->name.s, (int32_t)seq->seq.l);
+    }
+  }
+  if (read_group) {
+    fputs(read_group, out_fp);
+    fputc('\n', out_fp);
+  }
+
+  align_config_t conf;
+  conf.gap_o = gap_o;
+  conf.gap_e = gap_e;
+  conf.max_drop = max_drop;
+  conf.min_score = min_score;
+  conf.m = m;
+  conf.table = table;
+  conf.mat = mat;
+  conf.bandwidth = bandwidth;
+
+  read_fp = gzopen(qry_path, "r");
+  assert(read_fp != NULL && "Failed to open query");
+  size_t count = 0;
+  seq = kseq_init(read_fp);
+  while (true) {
+    kseq_v reads = read_seqs(seq, 5000 * n_threads);
+    const size_t n_reads = kv_size(reads);
+    if (!n_reads) {
+      break;
+    }
+
+    worker_t *w = calloc(n_threads, sizeof(worker_t));
+    kstring_t *sams = calloc(n_reads, sizeof(kstring_t));
+    for (size_t i = 0; i < n_threads; i++) {
+      w[i].start = i;
+      w[i].n = n_reads;
+      w[i].step = n_threads;
+      w[i].ref_seqs = ref_seqs;
+      w[i].n_extra_refs = n_extra_refs;
+      w[i].extra_ref_seqs = extra_ref_seqs;
+      w[i].reads = reads;
+      w[i].sams = sams;
+      w[i].config = &conf;
+      w[i].read_group_id = read_group_id;
+    }
+
+    if (n_threads == 1) {
+      worker(w);
+    } else {
+      pthread_t *tid = calloc(n_threads, sizeof(pthread_t));
+      for (size_t i = 0; i < n_threads; ++i)
+        pthread_create(&tid[i], 0, worker, &w[i]);
+      for (size_t i = 0; i < n_threads; ++i)
+        pthread_join(tid[i], 0);
+    }
+    free(w);
+
+    for (size_t i = 0; i < n_reads; i++) {
+      if (sams[i].s) {
+        fputs(sams[i].s, out_fp);
+        free(sams[i].s);
+      }
+    }
+    free(sams);
+    count += n_reads;
+    kv_destroy(reads);
+  }
+  kseq_destroy(seq);
+  fprintf(stderr, "[ig_align] Aligned %lu reads\n", count);
+
+  // Clean up reference sequences
+  kvi_destroy(kseq_stack_destroy, ref_seqs);
+
+  // And extra reference sequences
+  for (size_t i = 0; i < n_extra_refs; i++) {
+    kvi_destroy(kseq_stack_destroy, extra_ref_seqs[i]);
+  }
+  free(extra_ref_seqs);
+
+  gzclose(read_fp);
+  fclose(out_fp);
+  free(mat);
+}

--- a/packages/zig-core/src/igsw/c/ig_align.h
+++ b/packages/zig-core/src/igsw/c/ig_align.h
@@ -1,0 +1,26 @@
+#ifndef IG_ALIGN_H
+#define IG_ALIGN_H
+
+#include <stdint.h>
+
+/**
+ * If n_extra_refs is > 0,
+ * it should be in order D, J.
+ */
+void ig_align_reads(const char *ref_path,
+                    const uint8_t n_extra_refs,
+                    const char **extra_ref_paths,
+                    const char *qry_path,
+                    const char *output_path,
+                    const int32_t match,     /* 2 */
+                    const int32_t mismatch,  /* 2 */
+                    const int32_t gap_o,     /* 3 */
+                    const int32_t gap_e,     /* 1 */
+                    const unsigned max_drop, /* 1000 */
+                    const int min_score,     /* 0 */
+                    const unsigned bandwidth,
+                    const uint8_t n_threads,
+                    const char *read_group,
+                    const char *read_group_id);
+
+#endif

--- a/packages/zig-core/src/igsw/c/kseq.h
+++ b/packages/zig-core/src/igsw/c/kseq.h
@@ -1,0 +1,235 @@
+/* The MIT License
+
+   Copyright (c) 2008, 2009, 2011 Attractive Chaos <attractor@live.co.uk>
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+/* Last Modified: 05MAR2012 */
+
+#ifndef AC_KSEQ_H
+#define AC_KSEQ_H
+
+#include <ctype.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define KS_SEP_SPACE 0 // isspace(): \t, \n, \v, \f, \r
+#define KS_SEP_TAB   1 // isspace() && !' '
+#define KS_SEP_LINE  2 // line separator: "\n" (Unix) or "\r\n" (Windows)
+#define KS_SEP_MAX   2
+
+#define __KS_TYPE(type_t)						\
+	typedef struct __kstream_t {				\
+		unsigned char *buf;						\
+		int begin, end, is_eof;					\
+		type_t f;								\
+	} kstream_t;
+
+#define ks_eof(ks) ((ks)->is_eof && (ks)->begin >= (ks)->end)
+#define ks_rewind(ks) ((ks)->is_eof = (ks)->begin = (ks)->end = 0)
+
+#define __KS_BASIC(type_t, __bufsize)								\
+	static inline kstream_t *ks_init(type_t f)						\
+	{																\
+		kstream_t *ks = (kstream_t*)calloc(1, sizeof(kstream_t));	\
+		ks->f = f;													\
+		ks->buf = (unsigned char*)malloc(__bufsize);				\
+		return ks;													\
+	}																\
+	static inline void ks_destroy(kstream_t *ks)					\
+	{																\
+		if (ks) {													\
+			free(ks->buf);											\
+			free(ks);												\
+		}															\
+	}
+
+#define __KS_GETC(__read, __bufsize)						\
+	static inline int ks_getc(kstream_t *ks)				\
+	{														\
+		if (ks->is_eof && ks->begin >= ks->end) return -1;	\
+		if (ks->begin >= ks->end) {							\
+			ks->begin = 0;									\
+			ks->end = __read(ks->f, ks->buf, __bufsize);	\
+			if (ks->end < __bufsize) ks->is_eof = 1;		\
+			if (ks->end == 0) return -1;					\
+		}													\
+		return (int)ks->buf[ks->begin++];					\
+	}
+
+#ifndef KSTRING_T
+#define KSTRING_T kstring_t
+typedef struct __kstring_t {
+	size_t l, m;
+	char *s;
+} kstring_t;
+#endif
+
+#ifndef kroundup32
+#define kroundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
+#endif
+
+#define __KS_GETUNTIL(__read, __bufsize)								\
+	static int ks_getuntil2(kstream_t *ks, int delimiter, kstring_t *str, int *dret, int append) \
+	{																	\
+		if (dret) *dret = 0;											\
+		str->l = append? str->l : 0;									\
+		if (ks->begin >= ks->end && ks->is_eof) return -1;				\
+		for (;;) {														\
+			int i;														\
+			if (ks->begin >= ks->end) {									\
+				if (!ks->is_eof) {										\
+					ks->begin = 0;										\
+					ks->end = __read(ks->f, ks->buf, __bufsize);		\
+					if (ks->end < __bufsize) ks->is_eof = 1;			\
+					if (ks->end == 0) break;							\
+				} else break;											\
+			}															\
+			if (delimiter == KS_SEP_LINE) { \
+				for (i = ks->begin; i < ks->end; ++i) \
+					if (ks->buf[i] == '\n') break; \
+			} else if (delimiter > KS_SEP_MAX) {						\
+				for (i = ks->begin; i < ks->end; ++i)					\
+					if (ks->buf[i] == delimiter) break;					\
+			} else if (delimiter == KS_SEP_SPACE) {						\
+				for (i = ks->begin; i < ks->end; ++i)					\
+					if (isspace(ks->buf[i])) break;						\
+			} else if (delimiter == KS_SEP_TAB) {						\
+				for (i = ks->begin; i < ks->end; ++i)					\
+					if (isspace(ks->buf[i]) && ks->buf[i] != ' ') break; \
+			} else i = 0; /* never come to here! */						\
+			if (str->m - str->l < (size_t)(i - ks->begin + 1)) {		\
+				str->m = str->l + (i - ks->begin) + 1;					\
+				kroundup32(str->m);										\
+				str->s = (char*)realloc(str->s, str->m);				\
+			}															\
+			memcpy(str->s + str->l, ks->buf + ks->begin, i - ks->begin); \
+			str->l = str->l + (i - ks->begin);							\
+			ks->begin = i + 1;											\
+			if (i < ks->end) {											\
+				if (dret) *dret = ks->buf[i];							\
+				break;													\
+			}															\
+		}																\
+		if (str->s == 0) {												\
+			str->m = 1;													\
+			str->s = (char*)calloc(1, 1);								\
+		} else if (delimiter == KS_SEP_LINE && str->l > 1 && str->s[str->l-1] == '\r') --str->l; \
+		str->s[str->l] = '\0';											\
+		return str->l;													\
+	} \
+	static inline int ks_getuntil(kstream_t *ks, int delimiter, kstring_t *str, int *dret) \
+	{ return ks_getuntil2(ks, delimiter, str, dret, 0); }
+
+#define KSTREAM_INIT(type_t, __read, __bufsize) \
+	__KS_TYPE(type_t)							\
+	__KS_BASIC(type_t, __bufsize)				\
+	__KS_GETC(__read, __bufsize)				\
+	__KS_GETUNTIL(__read, __bufsize)
+
+#define kseq_rewind(ks) ((ks)->last_char = (ks)->f->is_eof = (ks)->f->begin = (ks)->f->end = 0)
+
+#define __KSEQ_BASIC(SCOPE, type_t)										\
+	SCOPE kseq_t *kseq_init(type_t fd)									\
+	{																	\
+		kseq_t *s = (kseq_t*)calloc(1, sizeof(kseq_t));					\
+		s->f = ks_init(fd);												\
+		return s;														\
+	}																	\
+	SCOPE void kseq_destroy(kseq_t *ks)									\
+	{																	\
+		if (!ks) return;												\
+		free(ks->name.s); free(ks->comment.s); free(ks->seq.s);	free(ks->qual.s); \
+		ks_destroy(ks->f);												\
+		free(ks);														\
+	}
+
+/* Return value:
+   >=0  length of the sequence (normal)
+   -1   end-of-file
+   -2   truncated quality string
+ */
+#define __KSEQ_READ(SCOPE) \
+	SCOPE int kseq_read(kseq_t *seq) \
+	{ \
+		int c; \
+		kstream_t *ks = seq->f; \
+		if (seq->last_char == 0) { /* then jump to the next header line */ \
+			while ((c = ks_getc(ks)) != -1 && c != '>' && c != '@'); \
+			if (c == -1) return -1; /* end of file */ \
+			seq->last_char = c; \
+		} /* else: the first header char has been read in the previous call */ \
+		seq->comment.l = seq->seq.l = seq->qual.l = 0; /* reset all members */ \
+		if (ks_getuntil(ks, 0, &seq->name, &c) < 0) return -1; /* normal exit: EOF */ \
+		if (c != '\n') ks_getuntil(ks, KS_SEP_LINE, &seq->comment, 0); /* read FASTA/Q comment */ \
+		if (seq->seq.s == 0) { /* we can do this in the loop below, but that is slower */ \
+			seq->seq.m = 256; \
+			seq->seq.s = (char*)malloc(seq->seq.m); \
+		} \
+		while ((c = ks_getc(ks)) != -1 && c != '>' && c != '+' && c != '@') { \
+			if (c == '\n') continue; /* skip empty lines */ \
+			seq->seq.s[seq->seq.l++] = c; /* this is safe: we always have enough space for 1 char */ \
+			ks_getuntil2(ks, KS_SEP_LINE, &seq->seq, 0, 1); /* read the rest of the line */ \
+		} \
+		if (c == '>' || c == '@') seq->last_char = c; /* the first header char has been read */	\
+		if (seq->seq.l + 1 >= seq->seq.m) { /* seq->seq.s[seq->seq.l] below may be out of boundary */ \
+			seq->seq.m = seq->seq.l + 2; \
+			kroundup32(seq->seq.m); /* rounded to the next closest 2^k */ \
+			seq->seq.s = (char*)realloc(seq->seq.s, seq->seq.m); \
+		} \
+		seq->seq.s[seq->seq.l] = 0;	/* null terminated string */ \
+		if (c != '+') return seq->seq.l; /* FASTA */ \
+		if (seq->qual.m < seq->seq.m) {	/* allocate memory for qual in case insufficient */ \
+			seq->qual.m = seq->seq.m; \
+			seq->qual.s = (char*)realloc(seq->qual.s, seq->qual.m); \
+		} \
+		while ((c = ks_getc(ks)) != -1 && c != '\n'); /* skip the rest of '+' line */ \
+		if (c == -1) return -2; /* error: no quality string */ \
+		while (ks_getuntil2(ks, KS_SEP_LINE, &seq->qual, 0, 1) >= 0 && seq->qual.l < seq->seq.l); \
+		seq->last_char = 0;	/* we have not come to the next header line */ \
+		if (seq->seq.l != seq->qual.l) return -2; /* error: qual string is of a different length */ \
+		return seq->seq.l; \
+	}
+
+#define __KSEQ_TYPE(type_t)						\
+	typedef struct {							\
+		kstring_t name, comment, seq, qual;		\
+		int last_char;							\
+		kstream_t *f;							\
+	} kseq_t;
+
+#define KSEQ_INIT2(SCOPE, type_t, __read)		\
+	KSTREAM_INIT(type_t, __read, 16384)			\
+	__KSEQ_TYPE(type_t)							\
+	__KSEQ_BASIC(SCOPE, type_t)					\
+	__KSEQ_READ(SCOPE)
+
+#define KSEQ_INIT(type_t, __read) KSEQ_INIT2(static, type_t, __read)
+
+#define KSEQ_DECLARE(type_t) \
+	__KS_TYPE(type_t) \
+	__KSEQ_TYPE(type_t) \
+	extern kseq_t *kseq_init(type_t fd); \
+	void kseq_destroy(kseq_t *ks); \
+	int kseq_read(kseq_t *seq);
+
+#endif

--- a/packages/zig-core/src/igsw/c/ksort.h
+++ b/packages/zig-core/src/igsw/c/ksort.h
@@ -1,0 +1,280 @@
+/* The MIT License
+   Copyright (c) 2008, 2011 Attractive Chaos <attractor@live.co.uk>
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+/*
+  2011-04-10 (0.1.6):
+  	* Added sample
+  2011-03 (0.1.5):
+	* Added shuffle/permutation
+  2008-11-16 (0.1.4):
+    * Fixed a bug in introsort() that happens in rare cases.
+  2008-11-05 (0.1.3):
+    * Fixed a bug in introsort() for complex comparisons.
+	* Fixed a bug in mergesort(). The previous version is not stable.
+  2008-09-15 (0.1.2):
+	* Accelerated introsort. On my Mac (not on another Linux machine),
+	  my implementation is as fast as std::sort on random input.
+	* Added combsort and in introsort, switch to combsort if the
+	  recursion is too deep.
+  2008-09-13 (0.1.1):
+	* Added k-small algorithm
+  2008-09-05 (0.1.0):
+	* Initial version
+*/
+
+#ifndef AC_KSORT_H
+#define AC_KSORT_H
+
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+	void *left, *right;
+	int depth;
+} ks_isort_stack_t;
+
+#define KSORT_SWAP(type_t, a, b) { register type_t t=(a); (a)=(b); (b)=t; }
+
+#define KSORT_INIT(name, type_t, __sort_lt)								\
+	void ks_mergesort_##name(size_t n, type_t array[], type_t temp[])	\
+	{																	\
+		type_t *a2[2], *a, *b;											\
+		int curr, shift;												\
+																		\
+		a2[0] = array;													\
+		a2[1] = temp? temp : (type_t*)malloc(sizeof(type_t) * n);		\
+		for (curr = 0, shift = 0; (1ul<<shift) < n; ++shift) {			\
+			a = a2[curr]; b = a2[1-curr];								\
+			if (shift == 0) {											\
+				type_t *p = b, *i, *eb = a + n;							\
+				for (i = a; i < eb; i += 2) {							\
+					if (i == eb - 1) *p++ = *i;							\
+					else {												\
+						if (__sort_lt(*(i+1), *i)) {					\
+							*p++ = *(i+1); *p++ = *i;					\
+						} else {										\
+							*p++ = *i; *p++ = *(i+1);					\
+						}												\
+					}													\
+				}														\
+			} else {													\
+				size_t i, step = 1ul<<shift;							\
+				for (i = 0; i < n; i += step<<1) {						\
+					type_t *p, *j, *k, *ea, *eb;						\
+					if (n < i + step) {									\
+						ea = a + n; eb = a;								\
+					} else {											\
+						ea = a + i + step;								\
+						eb = a + (n < i + (step<<1)? n : i + (step<<1)); \
+					}													\
+					j = a + i; k = a + i + step; p = b + i;				\
+					while (j < ea && k < eb) {							\
+						if (__sort_lt(*k, *j)) *p++ = *k++;				\
+						else *p++ = *j++;								\
+					}													\
+					while (j < ea) *p++ = *j++;							\
+					while (k < eb) *p++ = *k++;							\
+				}														\
+			}															\
+			curr = 1 - curr;											\
+		}																\
+		if (curr == 1) {												\
+			type_t *p = a2[0], *i = a2[1], *eb = array + n;				\
+			for (; p < eb; ++i) *p++ = *i;								\
+		}																\
+		if (temp == 0) free(a2[1]);										\
+	}																	\
+	void ks_heapadjust_##name(size_t i, size_t n, type_t l[])			\
+	{																	\
+		size_t k = i;													\
+		type_t tmp = l[i];												\
+		while ((k = (k << 1) + 1) < n) {								\
+			if (k != n - 1 && __sort_lt(l[k], l[k+1])) ++k;				\
+			if (__sort_lt(l[k], tmp)) break;							\
+			l[i] = l[k]; i = k;											\
+		}																\
+		l[i] = tmp;														\
+	}																	\
+	void ks_heapmake_##name(size_t lsize, type_t l[])					\
+	{																	\
+		size_t i;														\
+		for (i = (lsize >> 1) - 1; i != (size_t)(-1); --i)				\
+			ks_heapadjust_##name(i, lsize, l);							\
+	}																	\
+	void ks_heapsort_##name(size_t lsize, type_t l[])					\
+	{																	\
+		size_t i;														\
+		for (i = lsize - 1; i > 0; --i) {								\
+			type_t tmp;													\
+			tmp = *l; *l = l[i]; l[i] = tmp; ks_heapadjust_##name(0, i, l); \
+		}																\
+	}																	\
+	static inline void __ks_insertsort_##name(type_t *s, type_t *t)			\
+	{																	\
+		type_t *i, *j, swap_tmp;										\
+		for (i = s + 1; i < t; ++i)										\
+			for (j = i; j > s && __sort_lt(*j, *(j-1)); --j) {			\
+				swap_tmp = *j; *j = *(j-1); *(j-1) = swap_tmp;			\
+			}															\
+	}																	\
+	void ks_combsort_##name(size_t n, type_t a[])						\
+	{																	\
+		const double shrink_factor = 1.2473309501039786540366528676643; \
+		int do_swap;													\
+		size_t gap = n;													\
+		type_t tmp, *i, *j;												\
+		do {															\
+			if (gap > 2) {												\
+				gap = (size_t)(gap / shrink_factor);					\
+				if (gap == 9 || gap == 10) gap = 11;					\
+			}															\
+			do_swap = 0;												\
+			for (i = a; i < a + n - gap; ++i) {							\
+				j = i + gap;											\
+				if (__sort_lt(*j, *i)) {								\
+					tmp = *i; *i = *j; *j = tmp;						\
+					do_swap = 1;										\
+				}														\
+			}															\
+		} while (do_swap || gap > 2);									\
+		if (gap != 1) __ks_insertsort_##name(a, a + n);					\
+	}																	\
+	void ks_introsort_##name(size_t n, type_t a[])						\
+	{																	\
+		int d;															\
+		ks_isort_stack_t *top, *stack;									\
+		type_t rp, swap_tmp;											\
+		type_t *s, *t, *i, *j, *k;										\
+																		\
+		if (n < 1) return;												\
+		else if (n == 2) {												\
+			if (__sort_lt(a[1], a[0])) { swap_tmp = a[0]; a[0] = a[1]; a[1] = swap_tmp; } \
+			return;														\
+		}																\
+		for (d = 2; 1ul<<d < n; ++d);									\
+		stack = (ks_isort_stack_t*)malloc(sizeof(ks_isort_stack_t) * ((sizeof(size_t)*d)+2)); \
+		top = stack; s = a; t = a + (n-1); d <<= 1;						\
+		while (1) {														\
+			if (s < t) {												\
+				if (--d == 0) {											\
+					ks_combsort_##name(t - s + 1, s);					\
+					t = s;												\
+					continue;											\
+				}														\
+				i = s; j = t; k = i + ((j-i)>>1) + 1;					\
+				if (__sort_lt(*k, *i)) {								\
+					if (__sort_lt(*k, *j)) k = j;						\
+				} else k = __sort_lt(*j, *i)? i : j;					\
+				rp = *k;												\
+				if (k != t) { swap_tmp = *k; *k = *t; *t = swap_tmp; }	\
+				for (;;) {												\
+					do ++i; while (__sort_lt(*i, rp));					\
+					do --j; while (i <= j && __sort_lt(rp, *j));		\
+					if (j <= i) break;									\
+					swap_tmp = *i; *i = *j; *j = swap_tmp;				\
+				}														\
+				swap_tmp = *i; *i = *t; *t = swap_tmp;					\
+				if (i-s > t-i) {										\
+					if (i-s > 16) { top->left = s; top->right = i-1; top->depth = d; ++top; } \
+					s = t-i > 16? i+1 : t;								\
+				} else {												\
+					if (t-i > 16) { top->left = i+1; top->right = t; top->depth = d; ++top; } \
+					t = i-s > 16? i-1 : s;								\
+				}														\
+			} else {													\
+				if (top == stack) {										\
+					free(stack);										\
+					__ks_insertsort_##name(a, a+n);						\
+					return;												\
+				} else { --top; s = (type_t*)top->left; t = (type_t*)top->right; d = top->depth; } \
+			}															\
+		}																\
+	}																	\
+	/* This function is adapted from: http://ndevilla.free.fr/median/ */ \
+	/* 0 <= kk < n */													\
+	type_t ks_ksmall_##name(size_t n, type_t arr[], size_t kk)			\
+	{																	\
+		type_t *low, *high, *k, *ll, *hh, *mid;							\
+		low = arr; high = arr + n - 1; k = arr + kk;					\
+		for (;;) {														\
+			if (high <= low) return *k;									\
+			if (high == low + 1) {										\
+				if (__sort_lt(*high, *low)) KSORT_SWAP(type_t, *low, *high); \
+				return *k;												\
+			}															\
+			mid = low + (high - low) / 2;								\
+			if (__sort_lt(*high, *mid)) KSORT_SWAP(type_t, *mid, *high); \
+			if (__sort_lt(*high, *low)) KSORT_SWAP(type_t, *low, *high); \
+			if (__sort_lt(*low, *mid)) KSORT_SWAP(type_t, *mid, *low);	\
+			KSORT_SWAP(type_t, *mid, *(low+1));							\
+			ll = low + 1; hh = high;									\
+			for (;;) {													\
+				do ++ll; while (__sort_lt(*ll, *low));					\
+				do --hh; while (__sort_lt(*low, *hh));					\
+				if (hh < ll) break;										\
+				KSORT_SWAP(type_t, *ll, *hh);							\
+			}															\
+			KSORT_SWAP(type_t, *low, *hh);								\
+			if (hh <= k) low = ll;										\
+			if (hh >= k) high = hh - 1;									\
+		}																\
+	}																	\
+	void ks_shuffle_##name(size_t n, type_t a[])						\
+	{																	\
+		int i, j;														\
+		for (i = n; i > 1; --i) {										\
+			type_t tmp;													\
+			j = (int)(drand48() * i);									\
+			tmp = a[j]; a[j] = a[i-1]; a[i-1] = tmp;					\
+		}																\
+	}																	\
+	void ks_sample_##name(size_t n, size_t r, type_t a[]) /* FIXME: NOT TESTED!!! */ \
+	{ /* reference: http://code.activestate.com/recipes/272884/ */ \
+		int i, k, pop = n; \
+		for (i = (int)r, k = 0; i >= 0; --i) { \
+			double z = 1., x = drand48(); \
+			type_t tmp; \
+			while (x < z) z -= z * i / (pop--); \
+			/* As described in ig_align these numbers are not close to their max in our */ \
+			/* application, so we don't lose anything casting a size_t to an int. */  \
+			if (k != (int)n - pop - 1) tmp = a[k], a[k] = a[n-pop-1], a[n-pop-1] = tmp; \
+			++k; \
+		} \
+	}
+
+#define ks_mergesort(name, n, a, t) ks_mergesort_##name(n, a, t)
+#define ks_introsort(name, n, a) ks_introsort_##name(n, a)
+#define ks_combsort(name, n, a) ks_combsort_##name(n, a)
+#define ks_heapsort(name, n, a) ks_heapsort_##name(n, a)
+#define ks_heapmake(name, n, a) ks_heapmake_##name(n, a)
+#define ks_heapadjust(name, i, n, a) ks_heapadjust_##name(i, n, a)
+#define ks_ksmall(name, n, a, k) ks_ksmall_##name(n, a, k)
+#define ks_shuffle(name, n, a) ks_shuffle_##name(n, a)
+
+#define ks_lt_generic(a, b) ((a) < (b))
+#define ks_lt_str(a, b) (strcmp((a), (b)) < 0)
+
+typedef const char *ksstr_t;
+
+#define KSORT_INIT_GENERIC(type_t) KSORT_INIT(type_t, type_t, ks_lt_generic)
+#define KSORT_INIT_STR KSORT_INIT(str, ksstr_t, ks_lt_str)
+
+#endif

--- a/packages/zig-core/src/igsw/c/kstring.c
+++ b/packages/zig-core/src/igsw/c/kstring.c
@@ -1,0 +1,229 @@
+#include <stdarg.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+#include <stdint.h>
+#include "kstring.h"
+
+int kvsprintf(kstring_t *s, const char *fmt, va_list ap)
+{
+	va_list args;
+	int l;
+	va_copy(args, ap);
+	l = vsnprintf(s->s + s->l, s->m - s->l, fmt, args); // This line does not work with glibc 2.0. See `man snprintf'.
+	va_end(args);
+	if (l + 1 > s->m - s->l) {
+		s->m = s->l + l + 2;
+		kroundup32(s->m);
+		s->s = (char*)realloc(s->s, s->m);
+		va_copy(args, ap);
+		l = vsnprintf(s->s + s->l, s->m - s->l, fmt, args);
+		va_end(args);
+	}
+	s->l += l;
+	return l;
+}
+
+int ksprintf(kstring_t *s, const char *fmt, ...)
+{
+	va_list ap;
+	int l;
+	va_start(ap, fmt);
+	l = kvsprintf(s, fmt, ap);
+	va_end(ap);
+	return l;
+}
+
+char *kstrtok(const char *str, const char *sep, ks_tokaux_t *aux)
+{
+	const char *p, *start;
+	if (sep) { // set up the table
+		if (str == 0 && (aux->tab[0]&1)) return 0; // no need to set up if we have finished
+		aux->finished = 0;
+		if (sep[1]) {
+			aux->sep = -1;
+			aux->tab[0] = aux->tab[1] = aux->tab[2] = aux->tab[3] = 0;
+			for (p = sep; *p; ++p) aux->tab[*p>>6] |= 1ull<<(*p&0x3f);
+		} else aux->sep = sep[0];
+	}
+	if (aux->finished) return 0;
+	else if (str) aux->p = str - 1, aux->finished = 0;
+	if (aux->sep < 0) {
+		for (p = start = aux->p + 1; *p; ++p)
+			if (aux->tab[*p>>6]>>(*p&0x3f)&1) break;
+	} else {
+		for (p = start = aux->p + 1; *p; ++p)
+			if (*p == aux->sep) break;
+	}
+	aux->p = p; // end of token
+	if (*p == 0) aux->finished = 1; // no more tokens
+	return (char*)start;
+}
+
+// s MUST BE a null terminated string; l = strlen(s)
+int ksplit_core(char *s, int delimiter, int *_max, int **_offsets)
+{
+	int i, n, max, last_char, last_start, *offsets, l;
+	n = 0; max = *_max; offsets = *_offsets;
+	l = strlen(s);
+	
+#define __ksplit_aux do {						\
+		if (_offsets) {						\
+			s[i] = 0;					\
+			if (n == max) {					\
+				int *tmp;				\
+				max = max? max<<1 : 2;			\
+				if ((tmp = (int*)realloc(offsets, sizeof(int) * max))) {  \
+					offsets = tmp;			\
+				} else	{				\
+					free(offsets);			\
+					*_offsets = NULL;		\
+					return 0;			\
+				}					\
+			}						\
+			offsets[n++] = last_start;			\
+		} else ++n;						\
+	} while (0)
+
+	for (i = 0, last_char = last_start = 0; i <= l; ++i) {
+		if (delimiter == 0) {
+			if (isspace(s[i]) || s[i] == 0) {
+				if (isgraph(last_char)) __ksplit_aux; // the end of a field
+			} else {
+				if (isspace(last_char) || last_char == 0) last_start = i;
+			}
+		} else {
+			if (s[i] == delimiter || s[i] == 0) {
+				if (last_char != 0 && last_char != delimiter) __ksplit_aux; // the end of a field
+			} else {
+				if (last_char == delimiter || last_char == 0) last_start = i;
+			}
+		}
+		last_char = s[i];
+	}
+	*_max = max; *_offsets = offsets;
+	return n;
+}
+
+/**********************
+ * Boyer-Moore search *
+ **********************/
+
+typedef unsigned char ubyte_t;
+
+// reference: http://www-igm.univ-mlv.fr/~lecroq/string/node14.html
+static int *ksBM_prep(const ubyte_t *pat, int m)
+{
+	int i, *suff, *prep, *bmGs, *bmBc;
+	prep = (int*)calloc(m + 256, sizeof(int));
+	bmGs = prep; bmBc = prep + m;
+	{ // preBmBc()
+		for (i = 0; i < 256; ++i) bmBc[i] = m;
+		for (i = 0; i < m - 1; ++i) bmBc[pat[i]] = m - i - 1;
+	}
+	suff = (int*)calloc(m, sizeof(int));
+	{ // suffixes()
+		int f = 0, g;
+		suff[m - 1] = m;
+		g = m - 1;
+		for (i = m - 2; i >= 0; --i) {
+			if (i > g && suff[i + m - 1 - f] < i - g)
+				suff[i] = suff[i + m - 1 - f];
+			else {
+				if (i < g) g = i;
+				f = i;
+				while (g >= 0 && pat[g] == pat[g + m - 1 - f]) --g;
+				suff[i] = f - g;
+			}
+		}
+	}
+	{ // preBmGs()
+		int j = 0;
+		for (i = 0; i < m; ++i) bmGs[i] = m;
+		for (i = m - 1; i >= 0; --i)
+			if (suff[i] == i + 1)
+				for (; j < m - 1 - i; ++j)
+					if (bmGs[j] == m)
+						bmGs[j] = m - 1 - i;
+		for (i = 0; i <= m - 2; ++i)
+			bmGs[m - 1 - suff[i]] = m - 1 - i;
+	}
+	free(suff);
+	return prep;
+}
+
+void *kmemmem(const void *_str, int n, const void *_pat, int m, int **_prep)
+{
+	int i, j, *prep = 0, *bmGs, *bmBc;
+	const ubyte_t *str, *pat;
+	str = (const ubyte_t*)_str; pat = (const ubyte_t*)_pat;
+	prep = (_prep == 0 || *_prep == 0)? ksBM_prep(pat, m) : *_prep;
+	if (_prep && *_prep == 0) *_prep = prep;
+	bmGs = prep; bmBc = prep + m;
+	j = 0;
+	while (j <= n - m) {
+		for (i = m - 1; i >= 0 && pat[i] == str[i+j]; --i);
+		if (i >= 0) {
+			int max = bmBc[str[i+j]] - m + 1 + i;
+			if (max < bmGs[i]) max = bmGs[i];
+			j += max;
+		} else return (void*)(str + j);
+	}
+	if (_prep == 0) free(prep);
+	return 0;
+}
+
+char *kstrstr(const char *str, const char *pat, int **_prep)
+{
+	return (char*)kmemmem(str, strlen(str), pat, strlen(pat), _prep);
+}
+
+char *kstrnstr(const char *str, const char *pat, int n, int **_prep)
+{
+	return (char*)kmemmem(str, n, pat, strlen(pat), _prep);
+}
+
+/***********************
+ * The main() function *
+ ***********************/
+
+#ifdef KSTRING_MAIN
+#include <stdio.h>
+int main()
+{
+	kstring_t *s;
+	int *fields, n, i;
+	ks_tokaux_t aux;
+	char *p;
+	s = (kstring_t*)calloc(1, sizeof(kstring_t));
+	// test ksprintf()
+	ksprintf(s, " abcdefg:    %d ", 100);
+	printf("'%s'\n", s->s);
+	// test ksplit()
+	fields = ksplit(s, 0, &n);
+	for (i = 0; i < n; ++i)
+		printf("field[%d] = '%s'\n", i, s->s + fields[i]);
+	// test kstrtok()
+	s->l = 0;
+	for (p = kstrtok("ab:cde:fg/hij::k", ":/", &aux); p; p = kstrtok(0, 0, &aux)) {
+		kputsn(p, aux.p - p, s);
+		kputc('\n', s);
+	}
+	printf("%s", s->s);
+	// free
+	free(s->s); free(s); free(fields);
+
+	{
+		static char *str = "abcdefgcdgcagtcakcdcd";
+		static char *pat = "cd";
+		char *ret, *s = str;
+		int *prep = 0;
+		while ((ret = kstrstr(s, pat, &prep)) != 0) {
+			printf("match: %s\n", ret);
+			s = ret + prep[0];
+		}
+		free(prep);
+	}
+	return 0;
+}
+#endif

--- a/packages/zig-core/src/igsw/c/kstring.h
+++ b/packages/zig-core/src/igsw/c/kstring.h
@@ -1,0 +1,259 @@
+/* The MIT License
+
+   Copyright (c) by Attractive Chaos <attractor@live.co.uk> 
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+#ifndef KSTRING_H
+#define KSTRING_H
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#ifndef kroundup32
+#define kroundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
+#endif
+
+#if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ > 4)
+#define KS_ATTR_PRINTF(fmt, arg) __attribute__((__format__ (__printf__, fmt, arg)))
+#else
+#define KS_ATTR_PRINTF(fmt, arg)
+#endif
+
+
+/* kstring_t is a simple non-opaque type whose fields are likely to be
+ * used directly by user code (but see also ks_str() and ks_len() below).
+ * A kstring_t object is initialised by either of
+ *       kstring_t str = { 0, 0, NULL };
+ *       kstring_t str; ...; str.l = str.m = 0; str.s = NULL;
+ * and either ownership of the underlying buffer should be given away before
+ * the object disappears (i.e., the str.s pointer copied and something else
+ * responsible for freeing it), or the kstring_t should be destroyed with
+ *       free(str.s);  */
+#ifndef KSTRING_T
+#define KSTRING_T kstring_t
+typedef struct __kstring_t {
+	size_t l, m;
+	char *s;
+} kstring_t;
+#endif
+
+typedef struct {
+	uint64_t tab[4];
+	int sep, finished;
+	const char *p; // end of the current token
+} ks_tokaux_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	int kvsprintf(kstring_t *s, const char *fmt, va_list ap) KS_ATTR_PRINTF(2,0);
+	int ksprintf(kstring_t *s, const char *fmt, ...) KS_ATTR_PRINTF(2,3);
+	int ksplit_core(char *s, int delimiter, int *_max, int **_offsets);
+	char *kstrstr(const char *str, const char *pat, int **_prep);
+	char *kstrnstr(const char *str, const char *pat, int n, int **_prep);
+	void *kmemmem(const void *_str, int n, const void *_pat, int m, int **_prep);
+
+	/* kstrtok() is similar to strtok_r() except that str is not
+	 * modified and both str and sep can be NULL. For efficiency, it is
+	 * actually recommended to set both to NULL in the subsequent calls
+	 * if sep is not changed. */
+	char *kstrtok(const char *str, const char *sep, ks_tokaux_t *aux);
+
+#ifdef __cplusplus
+}
+#endif
+
+static inline int ks_resize(kstring_t *s, size_t size)
+{
+	if (s->m < size) {
+		char *tmp;
+		s->m = size;
+		kroundup32(s->m);
+		if ((tmp = (char*)realloc(s->s, s->m)))
+			s->s = tmp;
+		else
+			return -1;
+	}
+	return 0;
+}
+
+static inline char *ks_str(kstring_t *s)
+{
+	return s->s;
+}
+
+static inline size_t ks_len(kstring_t *s)
+{
+	return s->l;
+}
+
+static inline int kputsn(const char *p, int l, kstring_t *s)
+{
+	if (s->l + l + 1 >= s->m) {
+		char *tmp;
+		s->m = s->l + l + 2;
+		kroundup32(s->m);
+		if ((tmp = (char*)realloc(s->s, s->m)))
+			s->s = tmp;
+		else
+			return EOF;
+	}
+	memcpy(s->s + s->l, p, l);
+	s->l += l;
+	s->s[s->l] = 0;
+	return l;
+}
+
+static inline int kputs(const char *p, kstring_t *s)
+{
+	return kputsn(p, strlen(p), s);
+}
+
+static inline int kputc(int c, kstring_t *s)
+{
+	if (s->l + 1 >= s->m) {
+		char *tmp;
+		s->m = s->l + 2;
+		kroundup32(s->m);
+		if ((tmp = (char*)realloc(s->s, s->m)))
+			s->s = tmp;
+		else
+			return EOF;
+	}
+	s->s[s->l++] = c;
+	s->s[s->l] = 0;
+	return c;
+}
+
+static inline int kputc_(int c, kstring_t *s)
+{
+	if (s->l + 1 > s->m) {
+		char *tmp;
+		s->m = s->l + 1;
+		kroundup32(s->m);
+		if ((tmp = (char*)realloc(s->s, s->m)))
+			s->s = tmp;
+		else
+			return EOF;
+	}
+	s->s[s->l++] = c;
+	return 1;
+}
+
+static inline int kputsn_(const void *p, int l, kstring_t *s)
+{
+	if (s->l + l > s->m) {
+		char *tmp;
+		s->m = s->l + l;
+		kroundup32(s->m);
+		if ((tmp = (char*)realloc(s->s, s->m)))
+			s->s = tmp;
+		else
+			return EOF;
+	}
+	memcpy(s->s + s->l, p, l);
+	s->l += l;
+	return l;
+}
+
+static inline int kputw(int c, kstring_t *s)
+{
+	char buf[16];
+	int i, l = 0;
+	unsigned int x = c;
+	if (c < 0) x = -x;
+	do { buf[l++] = x%10 + '0'; x /= 10; } while (x > 0);
+	if (c < 0) buf[l++] = '-';
+	if (s->l + l + 1 >= s->m) {
+		char *tmp;
+		s->m = s->l + l + 2;
+		kroundup32(s->m);
+		if ((tmp = (char*)realloc(s->s, s->m)))
+			s->s = tmp;
+		else
+			return EOF;
+	}
+	for (i = l - 1; i >= 0; --i) s->s[s->l++] = buf[i];
+	s->s[s->l] = 0;
+	return 0;
+}
+
+static inline int kputuw(unsigned c, kstring_t *s)
+{
+	char buf[16];
+	int l, i;
+	unsigned x;
+	if (c == 0) return kputc('0', s);
+	for (l = 0, x = c; x > 0; x /= 10) buf[l++] = x%10 + '0';
+	if (s->l + l + 1 >= s->m) {
+		char *tmp;
+		s->m = s->l + l + 2;
+		kroundup32(s->m);
+		if ((tmp = (char*)realloc(s->s, s->m)))
+			s->s = tmp;
+		else
+			return EOF;
+	}
+	for (i = l - 1; i >= 0; --i) s->s[s->l++] = buf[i];
+	s->s[s->l] = 0;
+	return 0;
+}
+
+static inline int kputl(long c, kstring_t *s)
+{
+	char buf[32];
+	int i, l = 0;
+	unsigned long x = c;
+	if (c < 0) x = -x;
+	do { buf[l++] = x%10 + '0'; x /= 10; } while (x > 0);
+	if (c < 0) buf[l++] = '-';
+	if (s->l + l + 1 >= s->m) {
+		char *tmp;
+		s->m = s->l + l + 2;
+		kroundup32(s->m);
+		if ((tmp = (char*)realloc(s->s, s->m)))
+			s->s = tmp;
+		else
+			return EOF;
+	}
+	for (i = l - 1; i >= 0; --i) s->s[s->l++] = buf[i];
+	s->s[s->l] = 0;
+	return 0;
+}
+
+/*
+ * Returns 's' split by delimiter, with *n being the number of components;
+ *         NULL on failue.
+ */
+static inline int *ksplit(kstring_t *s, int delimiter, int *n)
+{
+	int max = 0, *offsets = 0;
+	*n = ksplit_core(s->s, delimiter, &max, &offsets);
+	return offsets;
+}
+
+#endif

--- a/packages/zig-core/src/igsw/c/ksw.c
+++ b/packages/zig-core/src/igsw/c/ksw.c
@@ -1,0 +1,650 @@
+/* The MIT License
+
+   Copyright (c) 2011 by Attractive Chaos <attractor@live.co.uk>
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <emmintrin.h>
+#include "ksw.h"
+
+#ifdef USE_MALLOC_WRAPPERS
+#  include "malloc_wrap.h"
+#endif
+
+#ifdef __GNUC__
+#define LIKELY(x) __builtin_expect((x),1)
+#define UNLIKELY(x) __builtin_expect((x),0)
+#else
+#define LIKELY(x) (x)
+#define UNLIKELY(x) (x)
+#endif
+
+const kswr_t g_defr = { 0, -1, -1, -1, -1, -1, -1 };
+
+struct _kswq_t {
+	int qlen, slen;
+	uint8_t shift, mdiff, max, size;
+	__m128i *qp, *H0, *H1, *E, *Hmax;
+};
+
+/**
+ * Initialize the query data structure
+ *
+ * @param size   Number of bytes used to store a score; valid valures are 1 or 2
+ * @param qlen   Length of the query sequence
+ * @param query  Query sequence
+ * @param m      Size of the alphabet
+ * @param mat    Scoring matrix in a one-dimension array
+ *
+ * @return       Query data structure
+ */
+kswq_t *ksw_qinit(int size, int qlen, const uint8_t *query, int m, const int8_t *mat)
+{
+	kswq_t *q;
+	int slen, a, tmp, p;
+
+	size = size > 1? 2 : 1;
+	p = 8 * (3 - size); // # values per __m128i
+	slen = (qlen + p - 1) / p; // segmented length
+	q = (kswq_t*)malloc(sizeof(kswq_t) + 256 + 16 * slen * (m + 4)); // a single block of memory
+	q->qp = (__m128i*)(((size_t)q + sizeof(kswq_t) + 15) >> 4 << 4); // align memory
+	q->H0 = q->qp + slen * m;
+	q->H1 = q->H0 + slen;
+	q->E  = q->H1 + slen;
+	q->Hmax = q->E + slen;
+	q->slen = slen; q->qlen = qlen; q->size = size;
+	// compute shift
+	tmp = m * m;
+	for (a = 0, q->shift = 127, q->mdiff = 0; a < tmp; ++a) { // find the minimum and maximum score
+		if (mat[a] < (int8_t)q->shift) q->shift = mat[a];
+		if (mat[a] > (int8_t)q->mdiff) q->mdiff = mat[a];
+	}
+	q->max = q->mdiff;
+	q->shift = 256 - q->shift; // NB: q->shift is uint8_t
+	q->mdiff += q->shift; // this is the difference between the min and max scores
+	// An example: p=8, qlen=19, slen=3 and segmentation:
+	//  {{0,3,6,9,12,15,18,-1},{1,4,7,10,13,16,-1,-1},{2,5,8,11,14,17,-1,-1}}
+	if (size == 1) {
+		int8_t *t = (int8_t*)q->qp;
+		for (a = 0; a < m; ++a) {
+			int i, k, nlen = slen * p;
+			const int8_t *ma = mat + a * m;
+			for (i = 0; i < slen; ++i)
+				for (k = i; k < nlen; k += slen) // p iterations
+					*t++ = (k >= qlen? 0 : ma[query[k]]) + q->shift;
+		}
+	} else {
+		int16_t *t = (int16_t*)q->qp;
+		for (a = 0; a < m; ++a) {
+			int i, k, nlen = slen * p;
+			const int8_t *ma = mat + a * m;
+			for (i = 0; i < slen; ++i)
+				for (k = i; k < nlen; k += slen) // p iterations
+					*t++ = (k >= qlen? 0 : ma[query[k]]);
+		}
+	}
+	return q;
+}
+
+kswr_t ksw_u8(kswq_t *q, int tlen, const uint8_t *target, int _gapo, int _gape, int xtra) // the first gap costs -(_o+_e)
+{
+	int slen, i, m_b, n_b, te = -1, gmax = 0, minsc, endsc;
+	uint64_t *b;
+	__m128i zero, gapoe, gape, shift, *H0, *H1, *E, *Hmax;
+	kswr_t r;
+
+#define __max_16(ret, xx) do { \
+		(xx) = _mm_max_epu8((xx), _mm_srli_si128((xx), 8)); \
+		(xx) = _mm_max_epu8((xx), _mm_srli_si128((xx), 4)); \
+		(xx) = _mm_max_epu8((xx), _mm_srli_si128((xx), 2)); \
+		(xx) = _mm_max_epu8((xx), _mm_srli_si128((xx), 1)); \
+    	(ret) = _mm_extract_epi16((xx), 0) & 0x00ff; \
+	} while (0)
+
+	// initialization
+	r = g_defr;
+	minsc = (xtra&KSW_XSUBO)? xtra&0xffff : 0x10000;
+	endsc = (xtra&KSW_XSTOP)? xtra&0xffff : 0x10000;
+	m_b = n_b = 0; b = 0;
+	zero = _mm_set1_epi32(0);
+	gapoe = _mm_set1_epi8(_gapo + _gape);
+	gape = _mm_set1_epi8(_gape);
+	shift = _mm_set1_epi8(q->shift);
+	H0 = q->H0; H1 = q->H1; E = q->E; Hmax = q->Hmax;
+	slen = q->slen;
+	for (i = 0; i < slen; ++i) {
+		_mm_store_si128(E + i, zero);
+		_mm_store_si128(H0 + i, zero);
+		_mm_store_si128(Hmax + i, zero);
+	}
+	// the core loop
+	for (i = 0; i < tlen; ++i) {
+		int j, k, cmp, imax;
+		__m128i e, h, f = zero, max = zero, *S = q->qp + target[i] * slen; // s is the 1st score vector
+		h = _mm_load_si128(H0 + slen - 1); // h={2,5,8,11,14,17,-1,-1} in the above example
+		h = _mm_slli_si128(h, 1); // h=H(i-1,-1); << instead of >> because x64 is little-endian
+		for (j = 0; LIKELY(j < slen); ++j) {
+			/* SW cells are computed in the following order:
+			 *   H(i,j)   = max{H(i-1,j-1)+S(i,j), E(i,j), F(i,j)}
+			 *   E(i+1,j) = max{H(i,j)-q, E(i,j)-r}
+			 *   F(i,j+1) = max{H(i,j)-q, F(i,j)-r}
+			 */
+			// compute H'(i,j); note that at the beginning, h=H'(i-1,j-1)
+			h = _mm_adds_epu8(h, _mm_load_si128(S + j));
+			h = _mm_subs_epu8(h, shift); // h=H'(i-1,j-1)+S(i,j)
+			e = _mm_load_si128(E + j); // e=E'(i,j)
+			h = _mm_max_epu8(h, e);
+			h = _mm_max_epu8(h, f); // h=H'(i,j)
+			max = _mm_max_epu8(max, h); // set max
+			_mm_store_si128(H1 + j, h); // save to H'(i,j)
+			// now compute E'(i+1,j)
+			h = _mm_subs_epu8(h, gapoe); // h=H'(i,j)-gapo
+			e = _mm_subs_epu8(e, gape); // e=E'(i,j)-gape
+			e = _mm_max_epu8(e, h); // e=E'(i+1,j)
+			_mm_store_si128(E + j, e); // save to E'(i+1,j)
+			// now compute F'(i,j+1)
+			f = _mm_subs_epu8(f, gape);
+			f = _mm_max_epu8(f, h);
+			// get H'(i-1,j) and prepare for the next j
+			h = _mm_load_si128(H0 + j); // h=H'(i-1,j)
+		}
+		// NB: we do not need to set E(i,j) as we disallow adjecent insertion and then deletion
+		for (k = 0; LIKELY(k < 16); ++k) { // this block mimics SWPS3; NB: H(i,j) updated in the lazy-F loop cannot exceed max
+			f = _mm_slli_si128(f, 1);
+			for (j = 0; LIKELY(j < slen); ++j) {
+				h = _mm_load_si128(H1 + j);
+				h = _mm_max_epu8(h, f); // h=H'(i,j)
+				_mm_store_si128(H1 + j, h);
+				h = _mm_subs_epu8(h, gapoe);
+				f = _mm_subs_epu8(f, gape);
+				cmp = _mm_movemask_epi8(_mm_cmpeq_epi8(_mm_subs_epu8(f, h), zero));
+				if (UNLIKELY(cmp == 0xffff)) goto end_loop16;
+			}
+		}
+end_loop16:
+		//int k;for (k=0;k<16;++k)printf("%d ", ((uint8_t*)&max)[k]);printf("\n");
+		__max_16(imax, max); // imax is the maximum number in max
+		if (imax >= minsc) { // write the b array; this condition adds branching unfornately
+			if (n_b == 0 || (int32_t)b[n_b-1] + 1 != i) { // then append
+				if (n_b == m_b) {
+					m_b = m_b? m_b<<1 : 8;
+					b = (uint64_t*)realloc(b, 8 * m_b);
+				}
+				b[n_b++] = (uint64_t)imax<<32 | i;
+			} else if ((int)(b[n_b-1]>>32) < imax) b[n_b-1] = (uint64_t)imax<<32 | i; // modify the last
+		}
+		if (imax > gmax) {
+			gmax = imax; te = i; // te is the end position on the target
+			for (j = 0; LIKELY(j < slen); ++j) // keep the H1 vector
+				_mm_store_si128(Hmax + j, _mm_load_si128(H1 + j));
+			if (gmax + q->shift >= 255 || gmax >= endsc) break;
+		}
+		S = H1; H1 = H0; H0 = S; // swap H0 and H1
+	}
+	r.score = gmax + q->shift < 255? gmax : 255;
+	r.te = te;
+	if (r.score != 255) { // get a->qe, the end of query match; find the 2nd best score
+		int max = -1, tmp, low, high, qlen = slen * 16;
+		uint8_t *t = (uint8_t*)Hmax;
+		for (i = 0; i < qlen; ++i, ++t)
+			if ((int)*t > max) max = *t, r.qe = i / 16 + i % 16 * slen;
+			else if ((int)*t == max && (tmp = i / 16 + i % 16 * slen) < r.qe) r.qe = tmp; 
+		//printf("%d,%d\n", max, gmax);
+		if (b) {
+			i = (r.score + q->max - 1) / q->max;
+			low = te - i; high = te + i;
+			for (i = 0; i < n_b; ++i) {
+				int e = (int32_t)b[i];
+				if ((e < low || e > high) && (int)(b[i]>>32) > r.score2)
+					r.score2 = b[i]>>32, r.te2 = e;
+			}
+		}
+	}
+	free(b);
+	return r;
+}
+
+kswr_t ksw_i16(kswq_t *q, int tlen, const uint8_t *target, int _gapo, int _gape, int xtra) // the first gap costs -(_o+_e)
+{
+	int slen, i, m_b, n_b, te = -1, gmax = 0, minsc, endsc;
+	uint64_t *b;
+	__m128i zero, gapoe, gape, *H0, *H1, *E, *Hmax;
+	kswr_t r;
+
+#define __max_8(ret, xx) do { \
+		(xx) = _mm_max_epi16((xx), _mm_srli_si128((xx), 8)); \
+		(xx) = _mm_max_epi16((xx), _mm_srli_si128((xx), 4)); \
+		(xx) = _mm_max_epi16((xx), _mm_srli_si128((xx), 2)); \
+    	(ret) = _mm_extract_epi16((xx), 0); \
+	} while (0)
+
+	// initialization
+	r = g_defr;
+	minsc = (xtra&KSW_XSUBO)? xtra&0xffff : 0x10000;
+	endsc = (xtra&KSW_XSTOP)? xtra&0xffff : 0x10000;
+	m_b = n_b = 0; b = 0;
+	zero = _mm_set1_epi32(0);
+	gapoe = _mm_set1_epi16(_gapo + _gape);
+	gape = _mm_set1_epi16(_gape);
+	H0 = q->H0; H1 = q->H1; E = q->E; Hmax = q->Hmax;
+	slen = q->slen;
+	for (i = 0; i < slen; ++i) {
+		_mm_store_si128(E + i, zero);
+		_mm_store_si128(H0 + i, zero);
+		_mm_store_si128(Hmax + i, zero);
+	}
+	// the core loop
+	for (i = 0; i < tlen; ++i) {
+		int j, k, imax;
+		__m128i e, h, f = zero, max = zero, *S = q->qp + target[i] * slen; // s is the 1st score vector
+		h = _mm_load_si128(H0 + slen - 1); // h={2,5,8,11,14,17,-1,-1} in the above example
+		h = _mm_slli_si128(h, 2);
+		for (j = 0; LIKELY(j < slen); ++j) {
+			h = _mm_adds_epi16(h, *S++);
+			e = _mm_load_si128(E + j);
+			h = _mm_max_epi16(h, e);
+			h = _mm_max_epi16(h, f);
+			max = _mm_max_epi16(max, h);
+			_mm_store_si128(H1 + j, h);
+			h = _mm_subs_epu16(h, gapoe);
+			e = _mm_subs_epu16(e, gape);
+			e = _mm_max_epi16(e, h);
+			_mm_store_si128(E + j, e);
+			f = _mm_subs_epu16(f, gape);
+			f = _mm_max_epi16(f, h);
+			h = _mm_load_si128(H0 + j);
+		}
+		for (k = 0; LIKELY(k < 16); ++k) {
+			f = _mm_slli_si128(f, 2);
+			for (j = 0; LIKELY(j < slen); ++j) {
+				h = _mm_load_si128(H1 + j);
+				h = _mm_max_epi16(h, f);
+				_mm_store_si128(H1 + j, h);
+				h = _mm_subs_epu16(h, gapoe);
+				f = _mm_subs_epu16(f, gape);
+				if(UNLIKELY(!_mm_movemask_epi8(_mm_cmpgt_epi16(f, h)))) goto end_loop8;
+			}
+		}
+end_loop8:
+		__max_8(imax, max);
+		if (imax >= minsc) {
+			if (n_b == 0 || (int32_t)b[n_b-1] + 1 != i) {
+				if (n_b == m_b) {
+					m_b = m_b? m_b<<1 : 8;
+					b = (uint64_t*)realloc(b, 8 * m_b);
+				}
+				b[n_b++] = (uint64_t)imax<<32 | i;
+			} else if ((int)(b[n_b-1]>>32) < imax) b[n_b-1] = (uint64_t)imax<<32 | i; // modify the last
+		}
+		if (imax > gmax) {
+			gmax = imax; te = i;
+			for (j = 0; LIKELY(j < slen); ++j)
+				_mm_store_si128(Hmax + j, _mm_load_si128(H1 + j));
+			if (gmax >= endsc) break;
+		}
+		S = H1; H1 = H0; H0 = S;
+	}
+	r.score = gmax; r.te = te;
+	{
+		int max = -1, tmp, low, high, qlen = slen * 8;
+		uint16_t *t = (uint16_t*)Hmax;
+		for (i = 0, r.qe = -1; i < qlen; ++i, ++t)
+			if ((int)*t > max) max = *t, r.qe = i / 8 + i % 8 * slen;
+			else if ((int)*t == max && (tmp = i / 8 + i % 8 * slen) < r.qe) r.qe = tmp; 
+		if (b) {
+			i = (r.score + q->max - 1) / q->max;
+			low = te - i; high = te + i;
+			for (i = 0; i < n_b; ++i) {
+				int e = (int32_t)b[i];
+				if ((e < low || e > high) && (int)(b[i]>>32) > r.score2)
+					r.score2 = b[i]>>32, r.te2 = e;
+			}
+		}
+	}
+	free(b);
+	return r;
+}
+
+static void revseq(int l, uint8_t *s)
+{
+	int i, t;
+	for (i = 0; i < l>>1; ++i)
+		t = s[i], s[i] = s[l - 1 - i], s[l - 1 - i] = t;
+}
+
+kswr_t ksw_align(int qlen, uint8_t *query, int tlen, uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int xtra, kswq_t **qry)
+{
+	int size;
+	kswq_t *q;
+	kswr_t r, rr;
+	kswr_t (*func)(kswq_t*, int, const uint8_t*, int, int, int);
+
+	q = (qry && *qry)? *qry : ksw_qinit((xtra&KSW_XBYTE)? 1 : 2, qlen, query, m, mat);
+	if (qry && *qry == 0) *qry = q;
+	func = q->size == 2? ksw_i16 : ksw_u8;
+	size = q->size;
+	r = func(q, tlen, target, gapo, gape, xtra);
+	if (qry == 0) free(q);
+	if ((xtra&KSW_XSTART) == 0 || ((xtra&KSW_XSUBO) && r.score < (xtra&0xffff))) return r;
+	revseq(r.qe + 1, query); revseq(r.te + 1, target); // +1 because qe/te points to the exact end, not the position after the end
+	q = ksw_qinit(size, r.qe + 1, query, m, mat);
+	rr = func(q, tlen, target, gapo, gape, KSW_XSTOP | r.score);
+	revseq(r.qe + 1, query); revseq(r.te + 1, target);
+	free(q);
+	if (r.score == rr.score)
+		r.tb = r.te - rr.te, r.qb = r.qe - rr.qe;
+	return r;
+}
+
+/********************
+ *** SW extension ***
+ ********************/
+
+typedef struct {
+	int32_t h, e;
+} eh_t;
+
+int ksw_extend(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int end_bonus, int zdrop, int h0, int *_qle, int *_tle, int *_gtle, int *_gscore, int *_max_off)
+{
+	eh_t *eh; // score array
+	int8_t *qp; // query profile
+	int i, j, k, gapoe = gapo + gape, beg, end, max, max_i, max_j, max_gap, max_ie, gscore, max_off;
+	if (h0 < 0) h0 = 0;
+	// allocate memory
+	qp = malloc(qlen * m);
+	eh = calloc(qlen + 1, 8);
+	// generate the query profile
+	for (k = i = 0; k < m; ++k) {
+		const int8_t *p = &mat[k * m];
+		for (j = 0; j < qlen; ++j) qp[i++] = p[query[j]];
+	}
+	// fill the first row
+	eh[0].h = h0; eh[1].h = h0 > gapoe? h0 - gapoe : 0;
+	for (j = 2; j <= qlen && eh[j-1].h > gape; ++j)
+		eh[j].h = eh[j-1].h - gape;
+	// adjust $w if it is too large
+	k = m * m;
+	for (i = 0, max = 0; i < k; ++i) // get the max score
+		max = max > mat[i]? max : mat[i];
+	max_gap = (int)((double)(qlen * max + end_bonus - gapo) / gape + 1.);
+	max_gap = max_gap > 1? max_gap : 1;
+	w = w < max_gap? w : max_gap;
+	// DP loop
+	max = h0, max_i = max_j = -1; max_ie = -1, gscore = -1;
+	max_off = 0;
+	beg = 0, end = qlen;
+	for (i = 0; LIKELY(i < tlen); ++i) {
+		int f = 0, h1, m = 0, mj = -1;
+		int8_t *q = &qp[target[i] * qlen];
+		// compute the first column
+		h1 = h0 - (gapo + gape * (i + 1));
+		if (h1 < 0) h1 = 0;
+		// apply the band and the constraint (if provided)
+		if (beg < i - w) beg = i - w;
+		if (end > i + w + 1) end = i + w + 1;
+		if (end > qlen) end = qlen;
+		for (j = beg; LIKELY(j < end); ++j) {
+			// At the beginning of the loop: eh[j] = { H(i-1,j-1), E(i,j) }, f = F(i,j) and h1 = H(i,j-1)
+			// Similar to SSE2-SW, cells are computed in the following order:
+			//   H(i,j)   = max{H(i-1,j-1)+S(i,j), E(i,j), F(i,j)}
+			//   E(i+1,j) = max{H(i,j)-gapo, E(i,j)} - gape
+			//   F(i,j+1) = max{H(i,j)-gapo, F(i,j)} - gape
+			eh_t *p = &eh[j];
+			int h = p->h, e = p->e; // get H(i-1,j-1) and E(i-1,j)
+			p->h = h1;          // set H(i,j-1) for the next row
+			h += q[j];
+			h = h > e? h : e;
+			h = h > f? h : f;
+			h1 = h;             // save H(i,j) to h1 for the next column
+			mj = m > h? mj : j; // record the position where max score is achieved
+			m = m > h? m : h;   // m is stored at eh[mj+1]
+			h -= gapoe;
+			h = h > 0? h : 0;
+			e -= gape;
+			e = e > h? e : h;   // computed E(i+1,j)
+			p->e = e;           // save E(i+1,j) for the next row
+			f -= gape;
+			f = f > h? f : h;   // computed F(i,j+1)
+		}
+		eh[end].h = h1; eh[end].e = 0;
+		if (j == qlen) {
+			max_ie = gscore > h1? max_ie : i;
+			gscore = gscore > h1? gscore : h1;
+		}
+		if (m == 0 || (zdrop > 0 && max - m - abs((i - max_i) - (j - max_j)) * gape > zdrop)) break; // drop to zero, or below Z-dropoff
+		if (m > max) {
+			max = m, max_i = i, max_j = mj;
+			max_off = max_off > abs(mj - i)? max_off : abs(mj - i);
+		}
+		// update beg and end for the next round
+		for (j = mj; j >= beg && eh[j].h; --j);
+		beg = j + 1;
+		for (j = mj + 2; j <= end && eh[j].h; ++j);
+		end = j;
+		//beg = 0; end = qlen; // uncomment this line for debugging
+	}
+	free(eh); free(qp);
+	if (_qle) *_qle = max_j + 1;
+	if (_tle) *_tle = max_i + 1;
+	if (_gtle) *_gtle = max_ie + 1;
+	if (_gscore) *_gscore = gscore;
+	if (_max_off) *_max_off = max_off;
+	return max;
+}
+
+/********************
+ * Global alignment *
+ ********************/
+
+#define MINUS_INF -0x40000000
+
+static inline uint32_t *push_cigar(int *n_cigar, int *m_cigar, uint32_t *cigar, int op, int len)
+{
+	if (*n_cigar == 0 || (uint32_t)op != (cigar[(*n_cigar) - 1]&0xf)) {
+		if (*n_cigar == *m_cigar) {
+			*m_cigar = *m_cigar? (*m_cigar)<<1 : 4;
+			cigar = realloc(cigar, (*m_cigar) << 2);
+		}
+		cigar[(*n_cigar)++] = len<<4 | op;
+	} else cigar[(*n_cigar)-1] += len<<4;
+	return cigar;
+}
+
+int ksw_global(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int *n_cigar_, uint32_t **cigar_)
+{
+	eh_t *eh;
+	int8_t *qp; // query profile
+	int i, j, k, gapoe = gapo + gape, score, n_col;
+	uint8_t *z; // backtrack matrix; in each cell: f<<4|e<<2|h; in principle, we can halve the memory, but backtrack will be a little more complex
+	if (n_cigar_) *n_cigar_ = 0;
+	// allocate memory
+	n_col = qlen < 2*w+1? qlen : 2*w+1; // maximum #columns of the backtrack matrix
+	z = malloc(n_col * tlen);
+	qp = malloc(qlen * m);
+	eh = calloc(qlen + 1, 8);
+	// generate the query profile
+	for (k = i = 0; k < m; ++k) {
+		const int8_t *p = &mat[k * m];
+		for (j = 0; j < qlen; ++j) qp[i++] = p[query[j]];
+	}
+	// fill the first row
+	eh[0].h = 0; eh[0].e = MINUS_INF;
+	for (j = 1; j <= qlen && j <= w; ++j)
+		eh[j].h = -(gapo + gape * j), eh[j].e = MINUS_INF;
+	for (; j <= qlen; ++j) eh[j].h = eh[j].e = MINUS_INF; // everything is -inf outside the band
+	// DP loop
+	for (i = 0; LIKELY(i < tlen); ++i) { // target sequence is in the outer loop
+		int32_t f = MINUS_INF, h1, beg, end;
+		int8_t *q = &qp[target[i] * qlen];
+		uint8_t *zi = &z[i * n_col];
+		beg = i > w? i - w : 0;
+		end = i + w + 1 < qlen? i + w + 1 : qlen; // only loop through [beg,end) of the query sequence
+		h1 = beg == 0? -(gapo + gape * (i + 1)) : MINUS_INF;
+		for (j = beg; LIKELY(j < end); ++j) {
+			// This loop is organized in a similar way to ksw_extend() and ksw_sse2(), except:
+			// 1) not checking h>0; 2) recording direction for backtracking
+			eh_t *p = &eh[j];
+			int32_t h = p->h, e = p->e;
+			uint8_t d; // direction
+			p->h = h1;
+			h += q[j];
+			d = h >= e? 0 : 1;
+			h = h >= e? h : e;
+			d = h >= f? d : 2;
+			h = h >= f? h : f;
+			h1 = h;
+			h -= gapoe;
+			e -= gape;
+			d |= e > h? 1<<2 : 0;
+			e = e > h? e : h;
+			p->e = e;
+			f -= gape;
+			d |= f > h? 2<<4 : 0; // if we want to halve the memory, use one bit only, instead of two
+			f = f > h? f : h;
+			zi[j - beg] = d; // z[i,j] keeps h for the current cell and e/f for the next cell
+		}
+		eh[end].h = h1; eh[end].e = MINUS_INF;
+	}
+	score = eh[qlen].h;
+	if (n_cigar_ && cigar_) { // backtrack
+		int n_cigar = 0, m_cigar = 0, which = 0;
+		uint32_t *cigar = 0, tmp;
+		i = tlen - 1; k = (i + w + 1 < qlen? i + w + 1 : qlen) - 1; // (i,k) points to the last cell
+		while (i >= 0 && k >= 0) {
+			which = z[i * n_col + (k - (i > w? i - w : 0))] >> (which<<1) & 3;
+			if (which == 0)      cigar = push_cigar(&n_cigar, &m_cigar, cigar, 0, 1), --i, --k;
+			else if (which == 1) cigar = push_cigar(&n_cigar, &m_cigar, cigar, 2, 1), --i;
+			else                 cigar = push_cigar(&n_cigar, &m_cigar, cigar, 1, 1), --k;
+		}
+		if (i >= 0) cigar = push_cigar(&n_cigar, &m_cigar, cigar, 2, i + 1);
+		if (k >= 0) cigar = push_cigar(&n_cigar, &m_cigar, cigar, 1, k + 1);
+		for (i = 0; i < n_cigar>>1; ++i) // reverse CIGAR
+			tmp = cigar[i], cigar[i] = cigar[n_cigar-1-i], cigar[n_cigar-1-i] = tmp;
+		*n_cigar_ = n_cigar, *cigar_ = cigar;
+	}
+	free(eh); free(qp); free(z);
+	return score;
+}
+
+/*******************************************
+ * Main function (not compiled by default) *
+ *******************************************/
+
+#ifdef _KSW_MAIN
+
+#include <unistd.h>
+#include <stdio.h>
+#include <zlib.h>
+#include "kseq.h"
+KSEQ_INIT(gzFile, err_gzread)
+
+unsigned char seq_nt4_table[256] = {
+	4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+	4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+	4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
+	4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+	4, 0, 4, 1,  4, 4, 4, 2,  4, 4, 4, 4,  4, 4, 4, 4, 
+	4, 4, 4, 4,  3, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+	4, 0, 4, 1,  4, 4, 4, 2,  4, 4, 4, 4,  4, 4, 4, 4, 
+	4, 4, 4, 4,  3, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+	4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+	4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+	4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+	4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+	4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+	4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+	4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4, 
+	4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4
+};
+
+int main(int argc, char *argv[])
+{
+	int c, sa = 1, sb = 3, i, j, k, forward_only = 0, max_rseq = 0;
+	int8_t mat[25];
+	int gapo = 5, gape = 2, minsc = 0, xtra = KSW_XSTART;
+	uint8_t *rseq = 0;
+	gzFile fpt, fpq;
+	kseq_t *kst, *ksq;
+
+	// parse command line
+	while ((c = getopt(argc, argv, "a:b:q:r:ft:1")) >= 0) {
+		switch (c) {
+			case 'a': sa = atoi(optarg); break;
+			case 'b': sb = atoi(optarg); break;
+			case 'q': gapo = atoi(optarg); break;
+			case 'r': gape = atoi(optarg); break;
+			case 't': minsc = atoi(optarg); break;
+			case 'f': forward_only = 1; break;
+			case '1': xtra |= KSW_XBYTE; break;
+		}
+	}
+	if (optind + 2 > argc) {
+		fprintf(stderr, "Usage: ksw [-1] [-f] [-a%d] [-b%d] [-q%d] [-r%d] [-t%d] <target.fa> <query.fa>\n", sa, sb, gapo, gape, minsc);
+		return 1;
+	}
+	if (minsc > 0xffff) minsc = 0xffff;
+	xtra |= KSW_XSUBO | minsc;
+	// initialize scoring matrix
+	for (i = k = 0; i < 4; ++i) {
+		for (j = 0; j < 4; ++j)
+			mat[k++] = i == j? sa : -sb;
+		mat[k++] = 0; // ambiguous base
+	}
+	for (j = 0; j < 5; ++j) mat[k++] = 0;
+	// open file
+	fpt = xzopen(argv[optind],   "r"); kst = kseq_init(fpt);
+	fpq = xzopen(argv[optind+1], "r"); ksq = kseq_init(fpq);
+	// all-pair alignment
+	while (kseq_read(ksq) > 0) {
+		kswq_t *q[2] = {0, 0};
+		kswr_t r;
+		for (i = 0; i < (int)ksq->seq.l; ++i) ksq->seq.s[i] = seq_nt4_table[(int)ksq->seq.s[i]];
+		if (!forward_only) { // reverse
+			if ((int)ksq->seq.m > max_rseq) {
+				max_rseq = ksq->seq.m;
+				rseq = (uint8_t*)realloc(rseq, max_rseq);
+			}
+			for (i = 0, j = ksq->seq.l - 1; i < (int)ksq->seq.l; ++i, --j)
+				rseq[j] = ksq->seq.s[i] == 4? 4 : 3 - ksq->seq.s[i];
+		}
+		gzrewind(fpt); kseq_rewind(kst);
+		while (kseq_read(kst) > 0) {
+			for (i = 0; i < (int)kst->seq.l; ++i) kst->seq.s[i] = seq_nt4_table[(int)kst->seq.s[i]];
+			r = ksw_align(ksq->seq.l, (uint8_t*)ksq->seq.s, kst->seq.l, (uint8_t*)kst->seq.s, 5, mat, gapo, gape, xtra, &q[0]);
+			if (r.score >= minsc)
+				err_printf("%s\t%d\t%d\t%s\t%d\t%d\t%d\t%d\t%d\n", kst->name.s, r.tb, r.te+1, ksq->name.s, r.qb, r.qe+1, r.score, r.score2, r.te2);
+			if (rseq) {
+				r = ksw_align(ksq->seq.l, rseq, kst->seq.l, (uint8_t*)kst->seq.s, 5, mat, gapo, gape, xtra, &q[1]);
+				if (r.score >= minsc)
+					err_printf("%s\t%d\t%d\t%s\t%d\t%d\t%d\t%d\t%d\n", kst->name.s, r.tb, r.te+1, ksq->name.s, (int)ksq->seq.l - r.qb, (int)ksq->seq.l - 1 - r.qe, r.score, r.score2, r.te2);
+			}
+		}
+		free(q[0]); free(q[1]);
+	}
+	free(rseq);
+	kseq_destroy(kst); err_gzclose(fpt);
+	kseq_destroy(ksq); err_gzclose(fpq);
+	return 0;
+}
+#endif

--- a/packages/zig-core/src/igsw/c/ksw.h
+++ b/packages/zig-core/src/igsw/c/ksw.h
@@ -1,0 +1,111 @@
+#ifndef __AC_KSW_H
+#define __AC_KSW_H
+
+#include <stdint.h>
+
+#define KSW_XBYTE  0x10000
+#define KSW_XSTOP  0x20000
+#define KSW_XSUBO  0x40000
+#define KSW_XSTART 0x80000
+
+struct _kswq_t;
+typedef struct _kswq_t kswq_t;
+
+typedef struct {
+	int score; // best score
+	int te, qe; // target end and query end
+	int score2, te2; // second best score and ending position on the target
+	int tb, qb; // target start and query start
+} kswr_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	/**
+	 * Aligning two sequences
+	 *
+	 * @param qlen    length of the query sequence (typically <tlen)
+	 * @param query   query sequence with 0 <= query[i] < m
+	 * @param tlen    length of the target sequence
+	 * @param target  target sequence
+	 * @param m       number of residue types
+	 * @param mat     m*m scoring matrix in one-dimension array
+	 * @param gapo    gap open penalty; a gap of length l cost "-(gapo+l*gape)"
+	 * @param gape    gap extension penalty
+	 * @param xtra    extra information (see below)
+	 * @param qry     query profile (see below)
+	 *
+	 * @return        alignment information in a struct; unset values to -1
+	 *
+	 * When xtra==0, ksw_align() uses a signed two-byte integer to store a
+	 * score and only finds the best score and the end positions. The 2nd best
+	 * score or the start positions are not attempted. The default behavior can
+	 * be tuned by setting KSW_X* flags:
+	 *
+	 *   KSW_XBYTE:  use an unsigned byte to store a score. If overflow occurs,
+	 *               kswr_t::score will be set to 255
+	 *
+	 *   KSW_XSUBO:  track the 2nd best score and the ending position on the
+	 *               target if the 2nd best is higher than (xtra&0xffff)
+	 *
+	 *   KSW_XSTOP:  stop if the maximum score is above (xtra&0xffff)
+	 *
+	 *   KSW_XSTART: find the start positions
+	 *
+	 * When *qry==NULL, ksw_align() will compute and allocate the query profile
+	 * and when the function returns, *qry will point to the profile, which can
+	 * be deallocated simply by free(). If one query is aligned against multiple
+	 * target sequences, *qry should be set to NULL during the first call and
+	 * freed after the last call. Note that qry can equal 0. In this case, the
+	 * query profile will be deallocated in ksw_align().
+	 */
+	kswr_t ksw_align(int qlen, uint8_t *query, int tlen, uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int xtra, kswq_t **qry);
+
+	/**
+	 * Banded global alignment
+	 *
+	 * @param qlen    query length
+	 * @param query   query sequence with 0 <= query[i] < m
+	 * @param tlen    target length
+	 * @param target  target sequence with 0 <= target[i] < m
+	 * @param m       number of residue types
+	 * @param mat     m*m scoring mattrix in one-dimension array
+	 * @param gapo    gap open penalty; a gap of length l cost "-(gapo+l*gape)"
+	 * @param gape    gap extension penalty
+	 * @param w       band width
+	 * @param n_cigar (out) number of CIGAR elements
+	 * @param cigar   (out) BAM-encoded CIGAR; caller need to deallocate with free()
+	 *
+	 * @return        score of the alignment
+	 */
+	int ksw_global(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int *n_cigar, uint32_t **cigar);
+
+	/**
+	 * Extend alignment
+	 *
+	 * The routine aligns $query and $target, assuming their upstream sequences,
+	 * which are not provided, have been aligned with score $h0. In return,
+	 * region [0,*qle) on the query and [0,*tle) on the target sequences are
+	 * aligned together. If *gscore>=0, *gscore keeps the best score such that
+	 * the entire query sequence is aligned; *gtle keeps the position on the
+	 * target where *gscore is achieved. Returning *gscore and *gtle helps the
+	 * caller to decide whether an end-to-end hit or a partial hit is preferred.
+	 *
+	 * The first 9 parameters are identical to those in ksw_global()
+	 *
+	 * @param h0      alignment score of upstream sequences
+	 * @param _qle    (out) length of the query in the alignment
+	 * @param _tle    (out) length of the target in the alignment
+	 * @param _gtle   (out) length of the target if query is fully aligned
+	 * @param _gscore (out) score of the best end-to-end alignment; negative if not found
+	 *
+	 * @return        best semi-local alignment score
+	 */
+	int ksw_extend(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int end_bonus, int zdrop, int h0, int *qle, int *tle, int *gtle, int *gscore, int *max_off);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/packages/zig-core/src/igsw/c/kvec.h
+++ b/packages/zig-core/src/igsw/c/kvec.h
@@ -1,0 +1,90 @@
+/* The MIT License
+
+   Copyright (c) 2008, by Attractive Chaos <attractor@live.co.uk>
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+/*
+  An example:
+
+#include "kvec.h"
+int main() {
+	kvec_t(int) array;
+	kv_init(array);
+	kv_push(int, array, 10); // append
+	kv_a(int, array, 20) = 5; // dynamic
+	kv_A(array, 20) = 4; // static
+	kv_destroy(array);
+	return 0;
+}
+*/
+
+/*
+  2008-09-22 (0.1.0):
+
+	* The initial version.
+
+*/
+
+#ifndef AC_KVEC_H
+#define AC_KVEC_H
+
+#include <stdlib.h>
+
+#define kv_roundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
+
+#define kvec_t(type) struct { size_t n, m; type *a; }
+#define kv_init(v) ((v).n = (v).m = 0, (v).a = 0)
+#define kv_destroy(v) free((v).a)
+#define kv_A(v, i) ((v).a[(i)])
+#define kv_pop(v) ((v).a[--(v).n])
+#define kv_size(v) ((v).n)
+#define kv_max(v) ((v).m)
+
+#define kv_resize(type, v, s)  ((v).m = (s), (v).a = (type*)realloc((v).a, sizeof(type) * (v).m))
+
+#define kv_copy(type, v1, v0) do {							\
+		if ((v1).m < (v0).n) kv_resize(type, v1, (v0).n);	\
+		(v1).n = (v0).n;									\
+		memcpy((v1).a, (v0).a, sizeof(type) * (v0).n);		\
+	} while (0)												\
+
+#define kv_push(type, v, x) do {									\
+		if ((v).n == (v).m) {										\
+			(v).m = (v).m? (v).m<<1 : 2;							\
+			(v).a = (type*)realloc((v).a, sizeof(type) * (v).m);	\
+		}															\
+		(v).a[(v).n++] = (x);										\
+	} while (0)
+
+#define kv_pushp(type, v) (((v).n == (v).m)?							\
+						   ((v).m = ((v).m? (v).m<<1 : 2),				\
+							(v).a = (type*)realloc((v).a, sizeof(type) * (v).m), 0)	\
+						   : 0), ((v).a + ((v).n++))
+
+#define kv_a(type, v, i) (((v).m <= (size_t)(i)? \
+						  ((v).m = (v).n = (i) + 1, kv_roundup32((v).m), \
+						   (v).a = (type*)realloc((v).a, sizeof(type) * (v).m), 0) \
+						  : (v).n <= (size_t)(i)? (v).n = (i) + 1 \
+						  : 0), (v).a[(i)])
+
+#endif

--- a/packages/zig-core/src/igsw/ig_align.zig
+++ b/packages/zig-core/src/igsw/ig_align.zig
@@ -1,0 +1,70 @@
+/// igsw/ig_align.zig — Zig wrapper for ig_align C library
+///
+/// Wraps the ig_align C API via @cImport.  The C sources (ig_align.c, ksw.c,
+/// kstring.c) are compiled as C objects by build.zig and linked into the
+/// partis-zig-core library.  This Zig module re-exports the public entry
+/// point and provides a Zig-friendly wrapper.
+///
+/// C source: packages/ig-sw/src/ig_align/ig_align.c  (+ ksw.c, kstring.c)
+/// C author: psathyrella/ig-sw (based on lh3/ksw / Heng Li)
+
+const std = @import("std");
+
+// ksw.zig exports C-ABI ksw_align/ksw_global/ksw_qinit/ksw_extend, replacing
+// the C ksw.c which uses SSE2 intrinsics. Importing it here compiles it into
+// the same artifact so the linker resolves ig_align.c's references to ksw_*.
+comptime {
+    _ = @import("ksw.zig");
+}
+
+pub const c = @cImport({
+    @cInclude("ig_align.h");
+});
+
+/// Wrapper around the C `ig_align_reads` function.
+///
+/// Aligns query FASTA sequences against one primary reference FASTA and zero
+/// or more extra references (D, J genes) using Smith-Waterman, writing SAM
+/// output to `output_path`.
+///
+/// Parameters mirror the C function exactly.  Default values used by partis:
+///   match=2, mismatch=2, gap_o=3, gap_e=1, max_drop=1000, min_score=0,
+///   bandwidth=1000, n_threads=1.
+pub fn alignReads(
+    ref_path: [*:0]const u8,
+    extra_ref_paths: []const [*:0]const u8,
+    qry_path: [*:0]const u8,
+    output_path: [*:0]const u8,
+    match: i32,
+    mismatch: i32,
+    gap_o: i32,
+    gap_e: i32,
+    max_drop: c_uint,
+    min_score: c_int,
+    bandwidth: c_uint,
+    n_threads: u8,
+    read_group: ?[*:0]const u8,
+    read_group_id: ?[*:0]const u8,
+) void {
+    const n_extra: u8 = @intCast(extra_ref_paths.len);
+    // The C function takes `const char **extra_ref_paths`.
+    // We need a pointer to the first element (or null if empty).
+    const extra_ptr: ?[*]const [*:0]const u8 = if (n_extra > 0) extra_ref_paths.ptr else null;
+    c.ig_align_reads(
+        ref_path,
+        n_extra,
+        if (extra_ptr) |p| @ptrCast(@constCast(p)) else null,
+        qry_path,
+        output_path,
+        match,
+        mismatch,
+        gap_o,
+        gap_e,
+        max_drop,
+        min_score,
+        bandwidth,
+        n_threads,
+        read_group orelse null,
+        read_group_id orelse null,
+    );
+}

--- a/packages/zig-core/src/igsw/ksw.zig
+++ b/packages/zig-core/src/igsw/ksw.zig
@@ -1,0 +1,836 @@
+/// igsw/ksw.zig — Zig port of ksw.c (Farrar striped Smith-Waterman)
+///
+/// Exports C-ABI ksw_align, ksw_global, ksw_qinit, ksw_extend using
+/// @Vector(16, u8) / @Vector(8, i16) instead of SSE2 intrinsics.
+/// Compiles and runs correctly on any platform (ARM64, x86, RISC-V, …).
+///
+/// C source: packages/ig-sw/src/ig_align/ksw.c (Attractive Chaos, MIT)
+/// Algorithm: Farrar (2007) striped Smith-Waterman
+
+const std = @import("std");
+
+// ─── vector types ─────────────────────────────────────────────────────────────
+
+/// 16 unsigned bytes  ≡  __m128i in the u8 path
+const V16u8 = @Vector(16, u8);
+/// 8 signed 16-bit integers  ≡  __m128i in the i16 path
+const V8i16 = @Vector(8, i16);
+/// 8 unsigned 16-bit — for _mm_subs_epu16 emulation
+const V8u16 = @Vector(8, u16);
+
+// ─── helper: _mm_slli_si128 emulation ─────────────────────────────────────────
+//
+// _mm_slli_si128(v, 1 byte) shifts the 128-bit register left by 1 byte:
+//   result[0] = 0,  result[i] = v[i-1]   (i >= 1)
+// In @Vector terms: elements move toward higher indices; 0 fills index 0.
+//
+// For V16u8:  shift by 1 element = 1 byte
+// For V8i16:  shift by 1 element = 2 bytes (≡ slli_si128 by 2)
+
+inline fn slli1_u8(v: V16u8) V16u8 {
+    const z: V16u8 = @splat(0);
+    return @shuffle(u8, v, z, [16]i32{ -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 });
+}
+
+inline fn slli1_i16(v: V8i16) V8i16 {
+    const z: V8i16 = @splat(0);
+    return @shuffle(i16, v, z, [8]i32{ -1, 0, 1, 2, 3, 4, 5, 6 });
+}
+
+// ─── helper: _mm_subs_epu16 emulation ─────────────────────────────────────────
+// Unsigned saturating subtract on 16-bit elements.
+inline fn subsEpu16(a: V8i16, b: V8i16) V8i16 {
+    const au: V8u16 = @bitCast(a);
+    const bu: V8u16 = @bitCast(b);
+    return @bitCast(au -| bu);
+}
+
+// ─── kswr_t  (must match C struct layout exactly) ────────────────────────────
+
+pub const Kswr = extern struct {
+    score: c_int = 0,
+    te: c_int = -1,
+    qe: c_int = -1,
+    score2: c_int = -1,
+    te2: c_int = -1,
+    tb: c_int = -1,
+    qb: c_int = -1,
+};
+
+const g_defr = Kswr{};
+
+// KSW flags
+const KSW_XBYTE: c_int = 0x10000;
+const KSW_XSTOP: c_int = 0x20000;
+const KSW_XSUBO: c_int = 0x40000;
+const KSW_XSTART: c_int = 0x80000;
+
+// ─── kswq_t internal struct ───────────────────────────────────────────────────
+//
+// Completely opaque to ig_align.c — it only ever holds a kswq_t* pointer.
+// Single malloc block: [Kswq][padding][qp vectors][H0..Hmax vectors]
+// All pointer fields point into the same block so free(q) releases everything.
+
+const Kswq = struct {
+    qlen: c_int,
+    slen: c_int,
+    shift: u8,
+    mdiff: u8,
+    max: u8,
+    size: u8, // 1 = u8 path, 2 = i16 path
+    // These point into the malloc block past this struct (16-byte aligned)
+    qp: [*]align(16) [16]u8,
+    H0: [*]align(16) [16]u8,
+    H1: [*]align(16) [16]u8,
+    E: [*]align(16) [16]u8,
+    Hmax: [*]align(16) [16]u8,
+};
+
+// ─── ksw_qinit ────────────────────────────────────────────────────────────────
+
+pub export fn ksw_qinit(
+    size: c_int,
+    qlen: c_int,
+    query: [*]const u8,
+    m: c_int,
+    mat: [*]const i8,
+) callconv(.c) ?*Kswq {
+    const sz: usize = if (size > 1) 2 else 1;
+    const p: usize = 8 * (3 - sz); // 16 for u8, 8 for i16
+    const slen: usize = (@as(usize, @intCast(qlen)) + p - 1) / p;
+    const mu: usize = @intCast(m);
+
+    const total: usize = @sizeOf(Kswq) + 256 + 16 * slen * (mu + 4);
+    const raw = std.c.malloc(total) orelse return null;
+
+    // Zero the entire block so DP arrays start at zero
+    @memset(@as([*]u8, @ptrCast(raw))[0..total], 0);
+
+    const q: *Kswq = @ptrCast(@alignCast(raw));
+
+    // Align vector area to 16 bytes
+    const arr_start: usize = (@intFromPtr(raw) + @sizeOf(Kswq) + 15) & ~@as(usize, 15);
+    const vec_base: [*]align(16) [16]u8 = @ptrFromInt(arr_start);
+
+    q.qlen = qlen;
+    q.slen = @intCast(slen);
+    q.size = @intCast(sz);
+    q.qp = vec_base;
+    q.H0 = vec_base + slen * mu;
+    q.H1 = q.H0 + slen;
+    q.E = q.H1 + slen;
+    q.Hmax = q.E + slen;
+
+    // Compute shift (minimum score) and mdiff — identical for both paths
+    const mat_len: usize = mu * mu;
+    var min_s: i32 = 127;
+    var max_s: i32 = 0;
+    for (0..mat_len) |i| {
+        const v: i32 = @intCast(mat[i]);
+        if (v < min_s) min_s = v;
+        if (v > max_s) max_s = v;
+    }
+    q.max = @intCast(max_s);
+    // q->shift = 256 - min_score (as uint8, may wrap)
+    q.shift = @truncate(@as(u32, @intCast(256 - min_s)));
+    // q->mdiff = max_score + shift
+    q.mdiff = @intCast(max_s + @as(i32, q.shift));
+
+    const qlen_u: usize = @intCast(qlen);
+
+    if (sz == 1) {
+        // u8 path: 16 elements per segment; scores stored with +shift bias
+        const t: [*]u8 = @ptrCast(q.qp);
+        var ti: usize = 0;
+        for (0..mu) |a| {
+            const nlen = slen * p;
+            const ma: [*]const i8 = mat + a * mu;
+            for (0..slen) |i| {
+                var k: usize = i;
+                while (k < nlen) : (k += slen) {
+                    t[ti] = if (k >= qlen_u) 0 else @intCast(@as(i32, @intCast(ma[query[k]])) + @as(i32, q.shift));
+                    ti += 1;
+                }
+            }
+        }
+    } else {
+        // i16 path: 8 elements per segment; raw scores (no bias)
+        const t: [*]i16 = @ptrCast(@alignCast(q.qp));
+        var ti: usize = 0;
+        for (0..mu) |a| {
+            const nlen = slen * p;
+            const ma: [*]const i8 = mat + a * mu;
+            for (0..slen) |i| {
+                var k: usize = i;
+                while (k < nlen) : (k += slen) {
+                    t[ti] = if (k >= qlen_u) 0 else @intCast(ma[query[k]]);
+                    ti += 1;
+                }
+            }
+        }
+    }
+    return q;
+}
+
+// ─── ksw_u8 (internal) ────────────────────────────────────────────────────────
+
+fn ksw_u8(q: *Kswq, tlen: c_int, target: [*]const u8, _gapo: c_int, _gape: c_int, xtra: c_int) Kswr {
+    const slen: usize = @intCast(q.slen);
+    if (slen == 0) return g_defr;
+    var r = g_defr;
+
+    const minsc: i32 = if ((xtra & KSW_XSUBO) != 0) xtra & 0xffff else 0x10000;
+    const endsc: i32 = if ((xtra & KSW_XSTOP) != 0) xtra & 0xffff else 0x10000;
+
+    const zero: V16u8 = @splat(0);
+    const gapoe: V16u8 = @splat(@intCast(_gapo + _gape));
+    const gape_v: V16u8 = @splat(@intCast(_gape));
+    const shift_v: V16u8 = @splat(q.shift);
+
+    var H0: [*]V16u8 = @ptrCast(q.H0);
+    var H1: [*]V16u8 = @ptrCast(q.H1);
+    const E: [*]V16u8 = @ptrCast(q.E);
+    const Hmax: [*]V16u8 = @ptrCast(q.Hmax);
+
+    // Zero DP arrays
+    for (0..slen) |i| {
+        H0[i] = zero;
+        H1[i] = zero;
+        E[i] = zero;
+        Hmax[i] = zero;
+    }
+
+    var m_b: usize = 0;
+    var n_b: usize = 0;
+    var b: ?[*]u64 = null;
+    defer if (b) |ptr| std.c.free(ptr);
+
+    var gmax: i32 = 0;
+    var te: i32 = -1;
+
+    const tlen_u: usize = @intCast(tlen);
+    const qp: [*]V16u8 = @ptrCast(q.qp);
+
+    var i: usize = 0;
+    while (i < tlen_u) : (i += 1) {
+        // Load last H0 segment, shift left by 1 byte
+        var h = slli1_u8(H0[slen - 1]);
+        var f: V16u8 = zero;
+        var max_v: V16u8 = zero;
+        const S: [*]V16u8 = qp + target[i] * slen;
+
+        var j: usize = 0;
+        while (j < slen) : (j += 1) {
+            // H' = max(H(i-1,j-1) + S(i,j) - shift, E(i,j), F(i,j))
+            h = (h +| S[j]) -| shift_v;
+            const e = E[j];
+            h = @max(h, e);
+            h = @max(h, f);
+            max_v = @max(max_v, h);
+            H1[j] = h;
+            // E(i+1,j) = max(H(i,j)-gapo, E(i,j)) - gape → stored as primed
+            h = h -| gapoe;
+            E[j] = @max(h, e -| gape_v);
+            // F(i,j+1)
+            f = @max(h, f -| gape_v);
+            // advance h
+            h = H0[j];
+        }
+
+        // Lazy-F loop: propagate F that may have been updated
+        var k: usize = 0;
+        while (k < 16) : (k += 1) {
+            f = slli1_u8(f);
+            var done = true;
+            var jj: usize = 0;
+            while (jj < slen) : (jj += 1) {
+                h = H1[jj];
+                h = @max(h, f);
+                H1[jj] = h;
+                h = h -| gapoe;
+                f = f -| gape_v; // lazy-F: only decrement, no max with h
+                const diff = f -| h;
+                if (@reduce(.Or, diff != zero)) done = false;
+            }
+            if (done) break;
+        }
+
+        // Horizontal max of max_v
+        const imax: i32 = @reduce(.Max, max_v);
+
+        if (imax >= minsc) {
+            if (n_b == 0 or @as(i32, @truncate(@as(i64, @bitCast(b.?[n_b - 1])))) + 1 != @as(i32, @intCast(i))) {
+                if (n_b == m_b) {
+                    m_b = if (m_b != 0) m_b << 1 else 8;
+                    b = @ptrCast(@alignCast(std.c.realloc(if (b) |p| p else null, 8 * m_b)));
+                }
+                b.?[n_b] = @as(u64, @intCast(imax)) << 32 | i;
+                n_b += 1;
+            } else if (@as(i32, @intCast(b.?[n_b - 1] >> 32)) < imax) {
+                b.?[n_b - 1] = @as(u64, @intCast(imax)) << 32 | i;
+            }
+        }
+
+        if (imax > gmax) {
+            gmax = imax;
+            te = @intCast(i);
+            for (0..slen) |jj| Hmax[jj] = H1[jj];
+            if (gmax + @as(i32, q.shift) >= 255 or gmax >= endsc) break;
+        }
+
+        // Swap H0 ↔ H1
+        const tmp_H = H0;
+        H0 = H1;
+        H1 = tmp_H;
+    }
+
+    r.score = if (gmax + @as(i32, q.shift) < 255) gmax else 255;
+    r.te = te;
+
+    if (r.score != 255) {
+        var best: i32 = -1;
+        const qlen_loop: usize = slen * 16;
+        const hmax_bytes: [*]u8 = @ptrCast(q.Hmax);
+        var qi: usize = 0;
+        while (qi < qlen_loop) : (qi += 1) {
+            const v: i32 = @intCast(hmax_bytes[qi]);
+            const pos: i32 = @intCast(qi / 16 + qi % 16 * slen);
+            if (v > best) {
+                best = v;
+                r.qe = pos;
+            } else if (v == best and pos < r.qe) {
+                r.qe = pos;
+            }
+        }
+        if (b) |bp| {
+            const margin: i32 = @divTrunc(r.score + @as(i32, q.max) - 1, @as(i32, q.max));
+            const low: i32 = te - margin;
+            const high: i32 = te + margin;
+            var bi: usize = 0;
+            while (bi < n_b) : (bi += 1) {
+                const e: i32 = @truncate(@as(i64, @bitCast(bp[bi])));
+                if ((e < low or e > high) and @as(i32, @intCast(bp[bi] >> 32)) > r.score2) {
+                    r.score2 = @intCast(bp[bi] >> 32);
+                    r.te2 = e;
+                }
+            }
+        }
+    }
+    return r;
+}
+
+// ─── ksw_i16 (internal) ───────────────────────────────────────────────────────
+
+fn ksw_i16(q: *Kswq, tlen: c_int, target: [*]const u8, _gapo: c_int, _gape: c_int, xtra: c_int) Kswr {
+    const slen: usize = @intCast(q.slen);
+    if (slen == 0) return g_defr;
+    var r = g_defr;
+
+    const minsc: i32 = if ((xtra & KSW_XSUBO) != 0) xtra & 0xffff else 0x10000;
+    const endsc: i32 = if ((xtra & KSW_XSTOP) != 0) xtra & 0xffff else 0x10000;
+
+    const zero: V8i16 = @splat(0);
+    const gapoe: V8i16 = @splat(@intCast(_gapo + _gape));
+    const gape_v: V8i16 = @splat(@intCast(_gape));
+
+    var H0: [*]V8i16 = @ptrCast(q.H0);
+    var H1: [*]V8i16 = @ptrCast(q.H1);
+    const E: [*]V8i16 = @ptrCast(q.E);
+    const Hmax: [*]V8i16 = @ptrCast(q.Hmax);
+    const qp: [*]V8i16 = @ptrCast(q.qp);
+
+    for (0..slen) |i| {
+        H0[i] = zero;
+        H1[i] = zero;
+        E[i] = zero;
+        Hmax[i] = zero;
+    }
+
+    var m_b: usize = 0;
+    var n_b: usize = 0;
+    var b: ?[*]u64 = null;
+    defer if (b) |ptr| std.c.free(ptr);
+
+    var gmax: i32 = 0;
+    var te: i32 = -1;
+    const tlen_u: usize = @intCast(tlen);
+
+    var i: usize = 0;
+    while (i < tlen_u) : (i += 1) {
+        var h = slli1_i16(H0[slen - 1]);
+        var f: V8i16 = zero;
+        var max_v: V8i16 = zero;
+        const S: [*]V8i16 = qp + target[i] * slen;
+
+        var j: usize = 0;
+        while (j < slen) : (j += 1) {
+            h = h +| S[j];
+            const e = E[j];
+            h = @max(h, e);
+            h = @max(h, f);
+            max_v = @max(max_v, h);
+            H1[j] = h;
+            h = subsEpu16(h, gapoe);
+            E[j] = @max(h, subsEpu16(e, gape_v));
+            f = @max(h, subsEpu16(f, gape_v));
+            h = H0[j];
+        }
+
+        var k: usize = 0;
+        while (k < 16) : (k += 1) {
+            f = slli1_i16(f);
+            var done = true;
+            var jj: usize = 0;
+            while (jj < slen) : (jj += 1) {
+                h = H1[jj];
+                h = @max(h, f);
+                H1[jj] = h;
+                h = subsEpu16(h, gapoe);
+                f = subsEpu16(f, gape_v); // lazy-F: only decrement, no max with h
+                if (@reduce(.Or, f > h)) done = false;
+            }
+            if (done) break;
+        }
+
+        const imax: i32 = @reduce(.Max, max_v);
+
+        if (imax >= minsc) {
+            if (n_b == 0 or @as(i32, @truncate(@as(i64, @bitCast(b.?[n_b - 1])))) + 1 != @as(i32, @intCast(i))) {
+                if (n_b == m_b) {
+                    m_b = if (m_b != 0) m_b << 1 else 8;
+                    b = @ptrCast(@alignCast(std.c.realloc(if (b) |p| p else null, 8 * m_b)));
+                }
+                b.?[n_b] = @as(u64, @intCast(imax)) << 32 | i;
+                n_b += 1;
+            } else if (@as(i32, @intCast(b.?[n_b - 1] >> 32)) < imax) {
+                b.?[n_b - 1] = @as(u64, @intCast(imax)) << 32 | i;
+            }
+        }
+
+        if (imax > gmax) {
+            gmax = imax;
+            te = @intCast(i);
+            for (0..slen) |jj| Hmax[jj] = H1[jj];
+            if (gmax >= endsc) break;
+        }
+
+        // Swap H0 ↔ H1 (local vars, like ksw_u8)
+        const tmp_H = H0;
+        H0 = H1;
+        H1 = tmp_H;
+    }
+
+    r.score = gmax;
+    r.te = te;
+
+    {
+        var best: i32 = -1;
+        const qlen_loop: usize = slen * 8;
+        const hmax_shorts: [*]i16 = @ptrCast(@alignCast(q.Hmax));
+        var qi: usize = 0;
+        r.qe = -1;
+        while (qi < qlen_loop) : (qi += 1) {
+            const v: i32 = @intCast(hmax_shorts[qi]);
+            const pos: i32 = @intCast(qi / 8 + qi % 8 * slen);
+            if (v > best) {
+                best = v;
+                r.qe = pos;
+            } else if (v == best and pos < r.qe) {
+                r.qe = pos;
+            }
+        }
+        if (b) |bp| {
+            const margin: i32 = @divTrunc(r.score + @as(i32, q.max) - 1, @as(i32, q.max));
+            const low: i32 = te - margin;
+            const high: i32 = te + margin;
+            var bi: usize = 0;
+            while (bi < n_b) : (bi += 1) {
+                const e: i32 = @truncate(@as(i64, @bitCast(bp[bi])));
+                if ((e < low or e > high) and @as(i32, @intCast(bp[bi] >> 32)) > r.score2) {
+                    r.score2 = @intCast(bp[bi] >> 32);
+                    r.te2 = e;
+                }
+            }
+        }
+    }
+    return r;
+}
+
+// ─── revseq ───────────────────────────────────────────────────────────────────
+
+fn revseq(l: usize, s: [*]u8) void {
+    var i: usize = 0;
+    while (i < l >> 1) : (i += 1) {
+        const tmp = s[i];
+        s[i] = s[l - 1 - i];
+        s[l - 1 - i] = tmp;
+    }
+}
+
+// ─── ksw_align ────────────────────────────────────────────────────────────────
+
+pub export fn ksw_align(
+    qlen: c_int,
+    query: [*]u8,
+    tlen: c_int,
+    target: [*]u8,
+    m: c_int,
+    mat: [*]const i8,
+    gapo: c_int,
+    gape: c_int,
+    xtra: c_int,
+    qry: ?*?*Kswq,
+) callconv(.c) Kswr {
+    // Determine size (1 = u8, 2 = i16)
+    const use_byte = (xtra & KSW_XBYTE) != 0;
+
+    // Get or allocate query profile
+    const q: *Kswq = blk: {
+        if (qry) |qp| {
+            if (qp.*) |existing| {
+                break :blk existing;
+            } else {
+                const nq = ksw_qinit(if (use_byte) 1 else 2, qlen, query, m, mat) orelse return g_defr;
+                qp.* = nq;
+                break :blk nq;
+            }
+        } else {
+            break :blk ksw_qinit(if (use_byte) 1 else 2, qlen, query, m, mat) orelse return g_defr;
+        }
+    };
+    const own_q = (qry == null); // we own q if caller passed null for qry
+
+    const size = q.size;
+    const func: *const fn (*Kswq, c_int, [*]const u8, c_int, c_int, c_int) Kswr =
+        if (size == 2) &ksw_i16 else &ksw_u8;
+
+    var r = func(q, tlen, target, gapo, gape, xtra);
+
+    if (own_q) std.c.free(q);
+
+    if ((xtra & KSW_XSTART) == 0 or ((xtra & KSW_XSUBO) != 0 and r.score < (xtra & 0xffff))) return r;
+
+    // Find start positions by reversing and re-aligning
+    const qe: usize = @intCast(r.qe + 1);
+    const te_end: usize = @intCast(r.te + 1);
+    revseq(qe, query);
+    revseq(te_end, target);
+    const q2 = ksw_qinit(@intCast(size), r.qe + 1, query, m, mat) orelse {
+        revseq(qe, query);
+        revseq(te_end, target);
+        return r;
+    };
+    const rr = func(q2, tlen, target, gapo, gape, KSW_XSTOP | r.score);
+    std.c.free(q2);
+    revseq(qe, query);
+    revseq(te_end, target);
+
+    if (r.score == rr.score) {
+        r.tb = r.te - rr.te;
+        r.qb = r.qe - rr.qe;
+    }
+    return r;
+}
+
+// ─── ksw_extend (scalar, no SIMD) ────────────────────────────────────────────
+
+pub export fn ksw_extend(
+    qlen: c_int,
+    query: [*]const u8,
+    tlen: c_int,
+    target: [*]const u8,
+    m: c_int,
+    mat: [*]const i8,
+    gapo: c_int,
+    gape: c_int,
+    w: c_int,
+    end_bonus: c_int,
+    zdrop: c_int,
+    h0: c_int,
+    _qle: ?*c_int,
+    _tle: ?*c_int,
+    _gtle: ?*c_int,
+    _gscore: ?*c_int,
+    _max_off: ?*c_int,
+) callconv(.c) c_int {
+    const qlen_u: usize = @intCast(qlen);
+    const tlen_u: usize = @intCast(tlen);
+    const mu: usize = @intCast(m);
+    const gapoe: i32 = gapo + gape;
+    const h0v: i32 = if (h0 < 0) 0 else h0;
+
+    // query profile
+    const qp: [*]i8 = @ptrCast(std.c.malloc(qlen_u * mu) orelse return 0);
+    defer std.c.free(qp);
+    // eh array: {H, E} pairs
+    const Eh = extern struct { h: i32, e: i32 };
+    const eh: [*]Eh = @ptrCast(@alignCast(std.c.malloc((qlen_u + 1) * @sizeOf(Eh)) orelse return 0));
+    defer std.c.free(eh);
+    @memset(@as([*]u8, @ptrCast(eh))[0..(qlen_u + 1) * @sizeOf(Eh)], 0);
+
+    // fill query profile
+    var k: usize = 0;
+    var idx: usize = 0;
+    while (k < mu) : (k += 1) {
+        const p: [*]const i8 = mat + k * mu;
+        var j: usize = 0;
+        while (j < qlen_u) : (j += 1) {
+            qp[idx] = p[query[j]];
+            idx += 1;
+        }
+    }
+
+    // fill first row
+    eh[0].h = h0v;
+    eh[1].h = if (h0v > gapoe) h0v - gapoe else 0;
+    {
+        var j: usize = 2;
+        while (j <= qlen_u and eh[j - 1].h > gape) : (j += 1) {
+            eh[j].h = eh[j - 1].h - gape;
+        }
+    }
+
+    // bandwidth
+    var max_score: i32 = 0;
+    {
+        var ki: usize = 0;
+        while (ki < mu * mu) : (ki += 1) {
+            if (@as(i32, @intCast(mat[ki])) > max_score) max_score = @intCast(mat[ki]);
+        }
+    }
+    var max_gap: i32 = @intFromFloat(@as(f64, @floatFromInt(qlen_u)) * @as(f64, @floatFromInt(max_score)) + @as(f64, @floatFromInt(end_bonus)) - @as(f64, @floatFromInt(gapo)));
+    max_gap = @divFloor(max_gap, gape) + 1;
+    if (max_gap < 1) max_gap = 1;
+    const eff_w: i32 = if (w < max_gap) w else max_gap;
+
+    var max: i32 = h0v;
+    var max_i: i32 = -1;
+    var max_j: i32 = -1;
+    var max_ie: i32 = -1;
+    var gscore: i32 = -1;
+    var max_off: i32 = 0;
+    var beg: i32 = 0;
+    var end_: i32 = @intCast(qlen_u);
+
+    var i: i32 = 0;
+    while (i < @as(i32, @intCast(tlen_u))) : (i += 1) {
+        const target_i: i8 = @intCast(target[@intCast(i)]);
+        var f: i32 = 0;
+        var h1: i32 = h0v - (gapo + gape * (i + 1));
+        if (h1 < 0) h1 = 0;
+        const q_row: [*]const i8 = qp + @as(usize, @intCast(target_i)) * qlen_u;
+        var cur_m: i32 = 0;
+        var mj: i32 = -1;
+        if (beg < i - eff_w) beg = i - eff_w;
+        if (end_ > i + eff_w + 1) end_ = i + eff_w + 1;
+        if (end_ > @as(i32, @intCast(qlen_u))) end_ = @intCast(qlen_u);
+        var j: i32 = beg;
+        while (j < end_) : (j += 1) {
+            const ju: usize = @intCast(j);
+            var h = eh[ju].h;
+            var e = eh[ju].e;
+            eh[ju].h = h1;
+            h += @intCast(q_row[ju]);
+            h = @max(h, e);
+            h = @max(h, f);
+            h1 = h;
+            if (h > cur_m) { cur_m = h; mj = j; }
+            h -= gapoe;
+            if (h < 0) h = 0;
+            e -= gape;
+            eh[ju].e = if (e > h) e else h;
+            f -= gape;
+            f = if (f > h) f else h;
+        }
+        eh[@intCast(end_)].h = h1;
+        eh[@intCast(end_)].e = 0;
+        if (j == @as(i32, @intCast(qlen_u))) {
+            if (h1 > gscore) { gscore = h1; max_ie = i; }
+        }
+        if (cur_m == 0 or (zdrop > 0 and @as(i32, @intCast(@abs(i - max_i))) + @as(i32, @intCast(@abs(mj - max_j))) > @divFloor(max - cur_m, gape) + zdrop)) break;
+        if (cur_m > max) {
+            max = cur_m;
+            max_i = i;
+            max_j = mj;
+            const off: i32 = @intCast(@abs(mj - i));
+            if (off > max_off) max_off = off;
+        }
+        // update beg/end for next round
+        j = mj;
+        while (j >= beg and eh[@intCast(j)].h != 0) j -= 1;
+        beg = j + 1;
+        j = mj + 2;
+        while (j <= end_ and eh[@intCast(j)].h != 0) j += 1;
+        end_ = j;
+    }
+
+    if (_qle) |p| p.* = max_j + 1;
+    if (_tle) |p| p.* = max_i + 1;
+    if (_gtle) |p| p.* = max_ie + 1;
+    if (_gscore) |p| p.* = gscore;
+    if (_max_off) |p| p.* = max_off;
+    return @intCast(max);
+}
+
+// ─── ksw_global (scalar, no SIMD) ────────────────────────────────────────────
+
+pub export fn ksw_global(
+    qlen: c_int,
+    query: [*]const u8,
+    tlen: c_int,
+    target: [*]const u8,
+    m: c_int,
+    mat: [*]const i8,
+    gapo: c_int,
+    gape: c_int,
+    w: c_int,
+    n_cigar_: ?*c_int,
+    cigar_: ?*?[*]u32,
+) callconv(.c) c_int {
+    const qlen_u: usize = @intCast(qlen);
+    const tlen_u: usize = @intCast(tlen);
+    const mu: usize = @intCast(m);
+    const gapoe: i32 = gapo + gape;
+    const MINUS_INF: i32 = -0x40000000;
+
+    if (n_cigar_) |p| p.* = 0;
+    if (qlen_u == 0 or tlen_u == 0) return 0;
+
+    const n_col: usize = if (@as(usize, @intCast(qlen)) < @as(usize, @intCast(2 * w + 1)))
+        qlen_u
+    else
+        @intCast(2 * w + 1);
+
+    // z: backtrack matrix n_col * tlen
+    const z: [*]u8 = @ptrCast(std.c.malloc(n_col * tlen_u) orelse return 0);
+    defer std.c.free(z);
+    const Eh = extern struct { h: i32, e: i32 };
+    const qp: [*]i8 = @ptrCast(std.c.malloc(qlen_u * mu) orelse return 0);
+    defer std.c.free(qp);
+    const eh: [*]Eh = @ptrCast(@alignCast(std.c.calloc(qlen_u + 1, @sizeOf(Eh)) orelse return 0));
+    defer std.c.free(eh);
+
+    // query profile
+    {
+        var k: usize = 0;
+        var ti: usize = 0;
+        while (k < mu) : (k += 1) {
+            const p: [*]const i8 = mat + k * mu;
+            var j: usize = 0;
+            while (j < qlen_u) : (j += 1) {
+                qp[ti] = p[query[j]];
+                ti += 1;
+            }
+        }
+    }
+
+    // fill first row
+    eh[0].h = 0;
+    eh[0].e = MINUS_INF;
+    {
+        var j: usize = 1;
+        while (j <= qlen_u and @as(i32, @intCast(j)) <= w) : (j += 1) {
+            eh[j].h = -(gapo + gape * @as(i32, @intCast(j)));
+            eh[j].e = MINUS_INF;
+        }
+        while (j <= qlen_u) : (j += 1) {
+            eh[j].h = MINUS_INF;
+            eh[j].e = MINUS_INF;
+        }
+    }
+
+    // DP
+    var i: i32 = 0;
+    while (i < @as(i32, @intCast(tlen_u))) : (i += 1) {
+        const iu: usize = @intCast(i);
+        var f: i32 = MINUS_INF;
+        const beg: i32 = if (i > w) i - w else 0;
+        const end_: i32 = if (i + w + 1 < @as(i32, @intCast(qlen_u))) i + w + 1 else @intCast(qlen_u);
+        const q_row: [*]const i8 = qp + @as(usize, @intCast(target[iu])) * qlen_u;
+        const zi: [*]u8 = z + iu * n_col;
+        var h1: i32 = if (beg == 0) -(gapo + gape * (i + 1)) else MINUS_INF;
+        var j: i32 = beg;
+        while (j < end_) : (j += 1) {
+            const ju: usize = @intCast(j);
+            var h = eh[ju].h;
+            var e = eh[ju].e;
+            var d: u8 = undefined;
+            eh[ju].h = h1;
+            h += @intCast(q_row[ju]);
+            d = if (h >= e) 0 else 1;
+            h = if (h >= e) h else e;
+            d = if (h >= f) d else 2;
+            h = if (h >= f) h else f;
+            h1 = h;
+            h -= gapoe;
+            e -= gape;
+            d |= if (e > h) @as(u8, 1) << 2 else 0;
+            e = if (e > h) e else h;
+            eh[ju].e = e;
+            f -= gape;
+            d |= if (f > h) @as(u8, 2) << 4 else 0;
+            f = if (f > h) f else h;
+            zi[@intCast(j - beg)] = d;
+        }
+        eh[@intCast(end_)].h = h1;
+        eh[@intCast(end_)].e = MINUS_INF;
+    }
+
+    const score = eh[qlen_u].h;
+
+    // backtrack
+    if (n_cigar_ != null and cigar_ != null) {
+        var n_cigar: c_int = 0;
+        var m_cigar: c_int = 0;
+        var cigar: ?[*]u32 = null;
+        var which: i32 = 0;
+        var ti: i32 = @intCast(tlen_u - 1);
+        var k: i32 = @intCast((if (ti + w + 1 < @as(i32, @intCast(qlen_u))) ti + w + 1 else @as(i32, @intCast(qlen_u))) - 1);
+        while (ti >= 0 and k >= 0) {
+            const beg_i: i32 = if (ti > w) ti - w else 0;
+            const d = z[@as(usize, @intCast(ti)) * n_col + @as(usize, @intCast(k - beg_i))];
+            which = (d >> @intCast(which * 2)) & 3;
+            if (which == 0) {
+                cigar = pushCigar(&n_cigar, &m_cigar, cigar, 0, 1);
+                ti -= 1;
+                k -= 1;
+            } else if (which == 1) {
+                cigar = pushCigar(&n_cigar, &m_cigar, cigar, 2, 1);
+                ti -= 1;
+            } else {
+                cigar = pushCigar(&n_cigar, &m_cigar, cigar, 1, 1);
+                k -= 1;
+            }
+        }
+        if (ti >= 0) cigar = pushCigar(&n_cigar, &m_cigar, cigar, 2, @intCast(ti + 1));
+        if (k >= 0) cigar = pushCigar(&n_cigar, &m_cigar, cigar, 1, @intCast(k + 1));
+        // reverse
+        var lo: usize = 0;
+        var hi: usize = @intCast(n_cigar - 1);
+        while (lo < hi) : ({ lo += 1; hi -= 1; }) {
+            const tmp = cigar.?[lo];
+            cigar.?[lo] = cigar.?[hi];
+            cigar.?[hi] = tmp;
+        }
+        n_cigar_.?.* = n_cigar;
+        cigar_.?.* = cigar;
+    }
+
+    return @intCast(score);
+}
+
+fn pushCigar(n_cigar: *c_int, m_cigar: *c_int, cigar: ?[*]u32, op: u32, len: u32) ?[*]u32 {
+    if (n_cigar.* == 0 or op != (cigar.?[@intCast(n_cigar.* - 1)] & 0xf)) {
+        var result = cigar;
+        if (n_cigar.* == m_cigar.*) {
+            m_cigar.* = if (m_cigar.* != 0) m_cigar.* << 1 else 4;
+            result = @ptrCast(@alignCast(std.c.realloc(if (cigar) |p| @ptrCast(p) else null, @intCast(m_cigar.* * 4))));
+        }
+        result.?[@intCast(n_cigar.*)] = len << 4 | op;
+        n_cigar.* += 1;
+        return result;
+    } else {
+        cigar.?[@intCast(n_cigar.* - 1)] += len << 4;
+        return cigar;
+    }
+}

--- a/packages/zig-core/src/igsw/main.zig
+++ b/packages/zig-core/src/igsw/main.zig
@@ -1,0 +1,200 @@
+/// igsw/main.zig — CLI entry point for partis-zig-igsw
+///
+/// Drop-in replacement for the C ig-sw binary.  Parses the same flags that
+/// partis passes via get_ig_sw_cmd_str, constructs germline FASTA paths by
+/// replicating GetFileName() from ig_align_main.cpp, then delegates to the
+/// Zig ig_align wrapper.
+///
+/// C++ source: packages/ig-sw/src/ig_align/ig_align_main.cpp
+
+const std = @import("std");
+const ig_align = @import("ig_align.zig");
+
+// ─── path construction (replicates C++ GetFileName) ──────────────────────────
+
+const Locus = enum { IGH, IGK, IGL, TRA, TRB, TRG, TRD, DJ };
+
+fn parseLocus(s: []const u8) ?Locus {
+    if (std.mem.eql(u8, s, "IGH")) return .IGH;
+    if (std.mem.eql(u8, s, "IGK")) return .IGK;
+    if (std.mem.eql(u8, s, "IGL")) return .IGL;
+    if (std.mem.eql(u8, s, "TRA")) return .TRA;
+    if (std.mem.eql(u8, s, "TRB")) return .TRB;
+    if (std.mem.eql(u8, s, "TRG")) return .TRG;
+    if (std.mem.eql(u8, s, "TRD")) return .TRD;
+    if (std.mem.eql(u8, s, "DJ"))  return .DJ;
+    return null;
+}
+
+/// Build the list of germline FASTA paths from (vdj_dir, locus).
+/// Returns paths as owned null-terminated strings; caller must free via gpa.
+/// paths[0] = ref_path, paths[1..] = extra_ref_paths (D, J).
+fn getFileNames(
+    allocator: std.mem.Allocator,
+    vdj_dir: []const u8,
+    locus: Locus,
+) !std.ArrayListUnmanaged([:0]u8) {
+    var paths: std.ArrayListUnmanaged([:0]u8) = .{};
+    errdefer {
+        for (paths.items) |p| allocator.free(p);
+        paths.deinit(allocator);
+    }
+
+    // gene letters and locus prefix follow C++ GetFileName() exactly
+    const genes: []const u8 = switch (locus) {
+        .IGH, .TRB, .TRD => "vdj",
+        .IGK, .IGL, .TRA, .TRG => "vj",
+        .DJ => "dj",
+    };
+    // DJ uses the "igh" prefix for the files
+    const lower_locus: []const u8 = switch (locus) {
+        .IGH, .DJ => "igh",
+        .IGK => "igk",
+        .IGL => "igl",
+        .TRA => "tra",
+        .TRB => "trb",
+        .TRG => "trg",
+        .TRD => "trd",
+    };
+
+    for (genes) |gene| {
+        const path_str = try std.fmt.allocPrint(allocator, "{s}{s}{c}.fasta", .{ vdj_dir, lower_locus, gene });
+        const path_z = try allocator.dupeZ(u8, path_str);
+        allocator.free(path_str);
+        try paths.append(allocator, path_z);
+    }
+    return paths;
+}
+
+// ─── CLI parsing ─────────────────────────────────────────────────────────────
+
+const Args = struct {
+    locus: []const u8 = "IGH",
+    vdj_dir: []const u8 = "",
+    match: i32 = 2,
+    mismatch: i32 = 2,
+    gap_o: i32 = 3,
+    gap_e: i32 = 1,
+    max_drop: u32 = 1000,
+    min_score: i32 = 0,
+    bandwidth: u32 = 150,
+    n_threads: u8 = 1,
+    query_fasta: []const u8 = "",
+    output_sam: []const u8 = "",
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const argv = std.os.argv;
+    var args: Args = .{};
+    var positionals: u8 = 0;
+
+    var i: usize = 1;
+    while (i < argv.len) : (i += 1) {
+        const flag = std.mem.span(argv[i]);
+        // single-char flags that take a value
+        if (flag.len == 2 and flag[0] == '-') {
+            const ch = flag[1];
+            switch (ch) {
+                'l', 'd', 'm', 'u', 'o', 'p', 'e', 'b', 's', 'j' => {
+                    if (i + 1 >= argv.len) {
+                        std.debug.print("error: flag -{c} requires a value\n", .{ch});
+                        std.process.exit(1);
+                    }
+                    i += 1;
+                    const val = std.mem.span(argv[i]);
+                    switch (ch) {
+                        'l' => args.locus = val,
+                        'd' => args.max_drop = try std.fmt.parseInt(u32, val, 10),
+                        'm' => args.match = try std.fmt.parseInt(i32, val, 10),
+                        'u' => args.mismatch = try std.fmt.parseInt(i32, val, 10),
+                        'o' => args.gap_o = try std.fmt.parseInt(i32, val, 10),
+                        'p' => args.vdj_dir = val,
+                        'e' => args.gap_e = try std.fmt.parseInt(i32, val, 10),
+                        'b' => args.bandwidth = try std.fmt.parseInt(u32, val, 10),
+                        's' => args.min_score = try std.fmt.parseInt(i32, val, 10),
+                        'j' => args.n_threads = try std.fmt.parseInt(u8, val, 10),
+                        else => unreachable,
+                    }
+                },
+                else => {
+                    // unknown single-char flag: skip its value if present
+                    if (i + 1 < argv.len) {
+                        const next = std.mem.span(argv[i + 1]);
+                        if (next.len == 0 or next[0] != '-') i += 1;
+                    }
+                },
+            }
+        } else if (flag.len > 2 and flag[0] == '-' and flag[1] == '-') {
+            // long flag: skip it and its value
+            if (i + 1 < argv.len) {
+                const next = std.mem.span(argv[i + 1]);
+                if (next.len == 0 or next[0] != '-') i += 1;
+            }
+        } else {
+            // positional
+            if (positionals == 0) {
+                args.query_fasta = flag;
+            } else if (positionals == 1) {
+                args.output_sam = flag;
+            }
+            positionals += 1;
+        }
+    }
+
+    if (positionals < 2 or args.vdj_dir.len == 0) {
+        std.debug.print(
+            \\Usage: partis-zig-igsw -l <LOCUS> -p <vdj_dir/> [-d <max_drop>] [-m <match>]
+            \\                       [-u <mismatch>] [-o <gap_open>] [-e <gap_extend>]
+            \\                       [-b <bandwidth>] [-s <min_score>] [-j <threads>]
+            \\                       <query_fasta> <output_sam>
+            \\
+        , .{});
+        std.process.exit(1);
+    }
+
+    const locus = parseLocus(args.locus) orelse {
+        std.debug.print("error: unknown locus '{s}'\n", .{args.locus});
+        std.process.exit(1);
+    };
+
+    // Build null-terminated path strings for the C API
+    var paths = try getFileNames(allocator, args.vdj_dir, locus);
+    defer {
+        for (paths.items) |p| allocator.free(p);
+        paths.deinit(allocator);
+    }
+
+    const ref_path: [*:0]const u8 = paths.items[0].ptr;
+
+    // Build extra_ref_paths array (stack-allocated; max 2 entries)
+    var extra_buf: [2][*:0]const u8 = undefined;
+    const n_extra = paths.items.len - 1;
+    for (paths.items[1..], 0..) |p, idx| extra_buf[idx] = p.ptr;
+    const extra_ref_paths: []const [*:0]const u8 = extra_buf[0..n_extra];
+
+    const qry_z = try allocator.dupeZ(u8, args.query_fasta);
+    defer allocator.free(qry_z);
+    const out_z = try allocator.dupeZ(u8, args.output_sam);
+    defer allocator.free(out_z);
+
+    ig_align.alignReads(
+        ref_path,
+        extra_ref_paths,
+        qry_z.ptr,
+        out_z.ptr,
+        args.match,
+        args.mismatch,
+        args.gap_o,
+        args.gap_e,
+        args.max_drop,
+        @intCast(args.min_score),
+        args.bandwidth,
+        args.n_threads,
+        null,
+        null,
+    );
+}

--- a/packages/zig-core/src/main.zig
+++ b/packages/zig-core/src/main.zig
@@ -1,0 +1,46 @@
+/// main.zig — partis-zig-core executable entry point.
+///
+/// Delegates all HMM computation to bcrham.run(), which accepts the same
+/// CLI arguments as the C++ bcrham binary and produces compatible CSV output.
+///
+/// Usage:
+///   partis-zig-core --hmmdir <dir> --datadir <dir> --infile <file> \
+///                   --outfile <file> --algorithm <viterbi|forward> \
+///                   --locus <igh|igk|igl|tra|trb|trg|trd> [optional-args...]
+///
+/// Unknown arguments are silently ignored (bcrham compat).
+
+const std = @import("std");
+const bcrham = @import("ham/bcrham.zig");
+
+pub fn main() !void {
+    const allocator = if (@import("builtin").mode == .Debug) blk: {
+        // In debug builds, use GPA for leak detection and use-after-free checks.
+        break :blk gpa_instance.allocator();
+    } else
+        // In release builds, use the C allocator — GPA's per-allocation tracking
+        // metadata adds massive overhead (observed 11 GB vs 278 MB on a 5k-sequence
+        // partition workload).
+        std.heap.c_allocator;
+    defer if (@import("builtin").mode == .Debug) {
+        _ = gpa_instance.deinit();
+    };
+    try bcrham.run(allocator, std.os.argv[1..]);
+}
+
+var gpa_instance = std.heap.GeneralPurposeAllocator(.{}){};
+
+// In test mode, force the analyzer to walk all decls reachable from the
+// executable so that tests in transitively-imported files get discovered by
+// `zig build test`. Without this, only tests in main.zig itself would run —
+// and main.zig has no tests. (`refAllDeclsRecursive` is a no-op outside tests.)
+//
+// The eval-branch quota is bumped because `refAllDeclsRecursive` walks the
+// full decl tree of `bcrham` (and everything it imports — args, model, state,
+// dp_handler, glomerator, bcr_utils, etc.); the default 1000 is exceeded.
+// 20000 was the smallest round number that compiled with current sources;
+// raise it (don't lower) if a future module addition trips the quota again.
+test {
+    @setEvalBranchQuota(20000);
+    std.testing.refAllDeclsRecursive(bcrham);
+}

--- a/partis/partitiondriver.py
+++ b/partis/partitiondriver.py
@@ -1084,7 +1084,7 @@ class PartitionDriver(object):
             if len(additional_clusters) > 0 and any(list(c) not in clusters_to_annotate for c in additional_clusters):
                 cluster_set = set([tuple(c) for c in clusters_to_annotate]) | additional_clusters
                 clusters_to_annotate = [list(c) for c in cluster_set]
-                actual_new_clusters = [c for c in clusters_to_annotate if c not in cpath.best()]
+                actual_new_clusters = sorted([c for c in clusters_to_annotate if c not in cpath.best()], key=lambda c: (-len(c), c[0] if len(c) > 0 else ''))
                 self.added_extra_clusters_to_annotate = True
                 print('    added %d cluster%s with size%s %s (in addition to the %d from the best partition) before running cluster annotations' % (len(actual_new_clusters), utils.plural(len(actual_new_clusters)), utils.plural(len(actual_new_clusters)),
                                                                                                                                                     ' '.join(str(len(c)) for c in actual_new_clusters), len(cpath.best())))
@@ -1107,7 +1107,7 @@ class PartitionDriver(object):
             return
         action_cache = self.current_action  # hackey, but probably not worth trying (more) to improve
         self.current_action = 'annotate'
-        clusters_to_annotate = sorted(clusters_to_annotate, key=len, reverse=True)  # as opposed to in clusterpath, where we *don't* want to sort by size, it's nicer to have them sorted by size here, since then as you're scanning down a long list of cluster annotations you know once you get to the singletons you won't be missing something big
+        clusters_to_annotate = sorted(clusters_to_annotate, key=lambda c: (-len(c), c[0] if len(c) > 0 else ''))  # sort by size (descending), then by first uid for determinism among same-size clusters
         n_procs = min(self.args.n_procs, len(clusters_to_annotate))  # we want as many procs as possible, since the large clusters can take a long time (depending on if we're translating...), but in general we treat <self.args.n_procs> as the maximum allowable number of processes
         print('getting annotations for final partition%s%s' % (' (including additional clusters)' if len(clusters_to_annotate) > len(cpath.best()) else '', ' (with star tree annotation since --subcluster-annotation-size is None)' if self.args.subcluster_annotation_size is None else ''))
         all_annotations, hmm_failures = self.actually_get_annotations_for_clusters(clusters_to_annotate=clusters_to_annotate, n_procs=n_procs, dont_print_annotations=True)  # have to print annotations below so we can also print the cpath
@@ -1167,9 +1167,9 @@ class PartitionDriver(object):
             extra = set(cached_naive_seqs) - set(expected_queries)
             missing = set(expected_queries) - set(cached_naive_seqs)
             if len(extra) > 0:
-                print('    %s read %d extra queries from hmm cache file %s' % (utils.color('yellow', 'warning:'), len(extra), ' '.join(extra)))
+                print('    %s read %d extra queries from hmm cache file %s' % (utils.color('yellow', 'warning:'), len(extra), ' '.join(sorted(extra))))
             if len(missing) > 0:
-                print('    %s missing %d/%d queries from hmm cache file (using sw naive sequence instead): %s' % (utils.color('yellow', 'warning:'), len(missing), len(expected_queries), ' '.join(missing)))
+                print('    %s missing %d/%d queries from hmm cache file (using sw naive sequence instead): %s' % (utils.color('yellow', 'warning:'), len(missing), len(expected_queries), ' '.join(sorted(missing))))
                 for ustr in missing:
                     cached_naive_seqs[ustr] = self.sw_info[ustr.split(':')[0]]['naive_seq']
 

--- a/partis/partitiondriver.py
+++ b/partis/partitiondriver.py
@@ -2099,7 +2099,7 @@ class PartitionDriver(object):
             # OR this query's genes into the ones from previous queries
             combo['only_genes'] |= genes_to_use  # NOTE using the OR of all sets of genes (from all query seqs) like this *really* helps,
 
-        combo['only_genes'] = list(combo['only_genes'])  # maybe I don't need to convert it to a list, but it used to be a list, and I don't want to make sure there wasn't a reason for that
+        combo['only_genes'] = sorted(combo['only_genes'])  # sort for determinism: set iteration order varies across runs due to PYTHONHASHSEED
 
         # if we don't have at least one gene for each region, add all available genes from that regions
         if set(utils.regions) > set(utils.get_region(g) for g in combo['only_genes']):  # this is *very* rare

--- a/partis/partitiondriver.py
+++ b/partis/partitiondriver.py
@@ -38,6 +38,17 @@ from .hist import Hist
 from . import seqfileopener
 
 # ----------------------------------------------------------------------------------------
+# Process-global accumulator for bcrham subprocess wall time, used to print a
+# "bcrham time: X (Y% of total)" summary alongside the final "total time:" line
+# in bin/partis. Phase 0 of issue #366 deferred pinning the bcrham fraction
+# pending partis-level timing instrumentation; this is that instrumentation.
+_cumul_bcrham_time = 0.0
+_cumul_bcrham_calls = 0
+
+def get_bcrham_summary():
+    return _cumul_bcrham_time, _cumul_bcrham_calls
+
+# ----------------------------------------------------------------------------------------
 class PartitionDriver(object):
     """ Class to parse input files, start bcrham jobs, and parse/interpret bcrham output for annotation and partitioning """
     def __init__(self, args, glfo, input_info, simglfo, reco_info):
@@ -1392,7 +1403,11 @@ class PartitionDriver(object):
                    'outfname' : get_outfname(iproc),
                    'dbgfo' : self.bcrham_proc_info[iproc]}
                   for iproc in range(n_procs)]
+        run_start = time.time()
         utils.run_cmds(cmdfos, batch_system=self.args.batch_system, batch_options=self.args.batch_options, batch_config_fname=self.args.batch_config_fname, debug='print' if self.args.debug else None)
+        global _cumul_bcrham_time, _cumul_bcrham_calls
+        _cumul_bcrham_time += time.time() - run_start
+        _cumul_bcrham_calls += 1
         self.print_partition_dbgfo()
 
         self.check_wait_times(time.time()-start)

--- a/partis/partitiondriver.py
+++ b/partis/partitiondriver.py
@@ -773,7 +773,7 @@ class PartitionDriver(object):
 
     # ----------------------------------------------------------------------------------------
     def shall_we_reduce_n_procs(self, last_n_procs):
-        if self.timing_info[-1]['total'] < self.args.min_hmm_step_time:  # mostly for when you're running on really small samples
+        if not self.args.no_time_based_n_proc_reduction and self.timing_info[-1]['total'] < self.args.min_hmm_step_time:  # mostly for when you're running on really small samples (--no-time-based-n-proc-reduction skips only this time-based check, for C++/Zig reproducibility since Zig is faster)
             return True
         n_calcd_per_process = self.get_n_calculated_per_process()
         if n_calcd_per_process < self.args.n_max_to_calc_per_process and last_n_procs > 2:  # should be replaced by time requirement, since especially in later iterations, the larger clusters make this a crappy metric (2 is kind of a special case, becase, well, small integers and all)
@@ -1269,7 +1269,7 @@ class PartitionDriver(object):
     # ----------------------------------------------------------------------------------------
     def get_hmm_cmd_str(self, algorithm, csv_infname, csv_outfname, parameter_dir, precache_all_naive_seqs, n_procs):
         """ Return the appropriate bcrham command string """
-        cmd_str = self.args.partis_dir + '/packages/ham/bcrham'
+        cmd_str = self.args.bcrham_binary
         cmd_str += ' --algorithm ' + algorithm
         if self.args.debug > 0:
             cmd_str += ' --debug ' + str(self.args.debug)

--- a/partis/partitiondriver.py
+++ b/partis/partitiondriver.py
@@ -1219,7 +1219,7 @@ class PartitionDriver(object):
 
         partition = utils.split_clusters_by_cdr3(partition, self.sw_info, warn=True)  # if we didn't use sw cdr3 lengths to start with here, there can be clusters with multiple sw cdr3 lengths, which then break when we go to get annotations later (it'd be too hard to avoid using sw info when getting annotations). And we don't really care which is right -- in general if we can get different cdr3 lengths for a sequence, it's absolute garbage to begin with
         # should really also re-pad after this i think (at least i'm getting naive seq len errors when merging paired partitions cause some look un/wrongly padded)
-        # utils.re_pad_hmm_seqs(self.input_antn_list, self.input_glfo, self.sw_info)  # can't do this in the self init fcn since at that point we haven't yet read the sw cache file
+        # utils.re_pad_hmm_seqs(self.input_antn_list, self.input_glfo, self.sw_info, self.sw_glfo)  # can't do this in the self init fcn since at that point we haven't yet read the sw cache file
 
         perf_metrics = None
         if not self.args.is_data:  # i'm no longer calculating ccfs here, so could remove/move some of this inside the pairwise clustering metric block
@@ -2142,7 +2142,7 @@ class PartitionDriver(object):
             # antn_dict, _ = self.convert_sw_annotations(partition=nsets)  # we *have* the annotations for the input partition, which would be better, but their seqs aren't correctly padded to the same length (since they were run in different subsets/procs), and propagating the new sw padding info (sw gets re-padded when we read the subset-merged sw info) to the input partition annotations would be hard, so we just use the sw annotations to get the naive seqs here
             # def naive_seq_fcn(query_name_list):
             #     return antn_dict.get(':'.join(query_name_list))['naive_seq']
-            utils.re_pad_hmm_seqs(self.input_antn_list, self.input_glfo, self.sw_info)  # can't do this in the self init fcn since at that point we haven't yet read the sw cache file
+            utils.re_pad_hmm_seqs(self.input_antn_list, self.input_glfo, self.sw_info, self.sw_glfo)  # can't do this in the self init fcn since at that point we haven't yet read the sw cache file
             self.input_antn_dict = utils.get_annotation_dict(self.input_antn_list)  # fcn in previous line only replaces elements in list (rather than modifying those elements) in very rare cases, but for cases when it does, whe have to replace the associated dict
             def naive_seq_fcn(query_name_list):
                 if ':'.join(query_name_list) not in self.input_antn_dict:

--- a/partis/partitiondriver.py
+++ b/partis/partitiondriver.py
@@ -1421,7 +1421,7 @@ class PartitionDriver(object):
             # n_clusters = len(superclust) // self.args.subcluster_annotation_size  # old way: truncates the decimal (see note in subcl_split())
             n_clusters = int(math.ceil(len(superclust) / float(self.args.subcluster_annotation_size)))  # taking the ceiling keeps the max un-split cluster size equal to <self.args.subcluster_annotation_size> (rather than one less than twice that)
             if n_clusters < 2:  # initially we don't call this function unless superclust is big enough for two clusters of size self.args.subcluster_annotation_size, but on subsequent rounds the clusters fom naive_ancestor_hashes can be smaller than that
-                return [superclust]
+                return [superclust] if len(superclust) > 0 else []
 
             if False: # self.args.kmeans_subclusters:  # this gives you clusters that are "tighter" -- i.e. clusters similar sequences together
                 from . import mds  # this works fine, but it's not really different (on balance with kmeans is probably a bit worse) than the simple way. Which is weird, I would think it would help? but otoh it gives you non-equal-sized clusters, which sometimes i think is worse, although sometimes i also think is better
@@ -1473,7 +1473,8 @@ class PartitionDriver(object):
                 # raise Exception('hashid %s already in sw info (i.e. the uids that made the hash were already read: %s)' % (hashid, ':'.join(line['unique_ids'])))
                 if not self.added_extra_clusters_to_annotate:
                     print('  %s hashid %s already in sw info (i.e. the uids that made the hash were already read: %s)' % (utils.color('yellow', 'warning'), hashid, ':'.join(line['unique_ids'])))
-                return False
+                    return False
+                return True  # hashid seq already set up in sw_info from previous subcluster annotation pass; still need to add to naive_ancestor_hashes so subclustering continues
             self.sw_info[hashid] = swhfo
             if len(set(self.sw_info[u]['cdr3_length'] for u in naive_hash_ids)) > 1:  # the time this happened, it was because sw was still allowing conserved codon deletion, and now it (kind of) isn't so maybe it won't happen any more? ("kind of" because it does actually allow it, but it expands kbounds to let the hmm not delete the codon, and the hmm builder also by default doesn't allow them, so... it shouldn't happen)
                 existing_cdr3_lengths = list(set([self.sw_info[u]['cdr3_length'] for u in naive_hash_ids[:-1]]))
@@ -1520,6 +1521,8 @@ class PartitionDriver(object):
                     if skey(tclust) in subd_clusters:  # subsequent rounds: get subclusters from intermediate inferred naives (hashids) from the last round
                         subclusters = getsubclusters(naive_ancestor_hashes[skey(tclust)])
                         del naive_ancestor_hashes[skey(tclust)]
+                        if len(subclusters) == 0 and len(subd_clusters[skey(tclust)][-1]) > 0:  # converged: all naive seqs already in sw_info (add_hash_seq returned False for all subclusters); force finalization by re-running just the first subcluster from the last round
+                            subclusters = subd_clusters[skey(tclust)][-1][:1]
                     else:  # first time through: add <tclust> to subd_clusters and get initial subclusters
                         subd_clusters[skey(tclust)] = []
                         subclusters = getsubclusters(tclust, shuffle=self.reco_info is not None and istep==0)  # the order of uids in each cluster that comes out of simulation is the order of leaves in the tree (i.e. they're sorted by similarity), so it's *extremely* important to shuffle them to get a fair comparison
@@ -1528,7 +1531,8 @@ class PartitionDriver(object):
                     if debug:
                         n_prev = len(subd_clusters[skey(tclust)]) - 1
                         mphfracs = [utils.mean_pairwise_hfrac([self.sw_info[u]['seqs'][0] for u in c]) for c in subclusters]
-                        mean_weighted_pw_hfrac = numpy.average(mphfracs, weights=[len(c) / float(len(tclust)) for c in subclusters])
+                        weights = [len(c) / float(len(tclust)) for c in subclusters]
+                        mean_weighted_pw_hfrac = numpy.average(mphfracs, weights=weights) if sum(weights) > 0 else 0.
                         print('       %4d      %s      %s      %3d      %4.2f      %s' % (len(tclust), '   ' if n_prev==0 else '%3d'%n_prev, '   ' if n_prev==0 else '%3d'%sum(len(c) for c in subclusters), len(subclusters), mean_weighted_pw_hfrac, ' '.join(str(len(c)) for c in subclusters)))
             _, step_antns, step_failures = self.run_hmm('viterbi', parameter_in_dir, partition=clusters_to_run, is_subcluster_recursed=True)  # is_subcluster_recursed is really just a speed optimization so it doesn't have to check the length of every cluster
             if istep == 0 and self.args.calculate_alternative_annotations:  # could do this in one of the loops below, but it's nice to have it separate since it doesn't really have anything to do with subcluster annotation
@@ -1574,6 +1578,11 @@ class PartitionDriver(object):
             n_sub_finished = 0
             for uidstr, subcluster_lists in list(subd_clusters.items()):  # handle the ones that're done (at this point they should be an annotation of about length self.args.subcluster_annotation_size consisting of just inferred subcluster naives)
                 if len(subcluster_lists[-1]) > 1:  # not finished yet
+                    continue
+                if len(subcluster_lists[-1]) == 0:  # empty subcluster from degenerate input (e.g. empty naive_ancestor_hashes): clean up and skip
+                    all_hmm_failures |= set(skey_inverse(uidstr))
+                    clusters_still_to_do.remove(skey_inverse(uidstr))
+                    del subd_clusters[uidstr]
                     continue
                 sclust = skey_inverse(uidstr)
                 if debug:

--- a/partis/utils.py
+++ b/partis/utils.py
@@ -6022,7 +6022,7 @@ def process_out_err(logdir, extra_str='', dbgfo=None, cmd_str=None, debug=None, 
         err_str += [line]
     err_str = '\n'.join(err_str)
 
-    if 'bcrham' in cmd_str:
+    if 'bcrham' in cmd_str or 'partis-zig-core' in cmd_str:
         for line in logstrs['out'].split('\n'):  # print debug info related to --n-final-clusters/--min-largest-cluster-size force merging
             if 'force' in line:
                 print('    %s %s' % (color('yellow', 'force info:'), line))

--- a/partis/utils.py
+++ b/partis/utils.py
@@ -4758,7 +4758,7 @@ def re_pad_atn(n_fv_pad, n_jf_pad, atn, glfo, extra_str='      ', debug=False): 
 # Here we add any extra padding in the sw info (which will have been padded on the full sample when reading the subset-merged sw cache file)
 # UPDATE: actually also need to *trim* padding in input annotations, at least for the case we're subset partitioning and ignoring small clusters, in which case sw padding in the merge process will be missing all the sequences from small clusters, so it can end up with less padding than the original sw (and thus input annotation)
 # NOTE that in most cases this just modifies elements in <input_antn_list>, but sometimes also modifies the list, so in general you need to e.g. remake any associated annotation dict from the calling fcn
-def re_pad_hmm_seqs(input_antn_list, input_glfo, sw_info, debug=False):  # NOTE quite similar to pad_seqs_to_same_length() in waterer.py (although there we change a lot more stuff by hand, i think because i didn't yet have remove_all_implicit_info [or maybe bc that would be slower])
+def re_pad_hmm_seqs(input_antn_list, input_glfo, sw_info, sw_glfo, debug=False):  # NOTE quite similar to pad_seqs_to_same_length() in waterer.py (although there we change a lot more stuff by hand, i think because i didn't yet have remove_all_implicit_info [or maybe bc that would be slower])
     from . import indelutils
     # ----------------------------------------------------------------------------------------
     def has_bad_lengths(iatn):
@@ -4776,7 +4776,7 @@ def re_pad_hmm_seqs(input_antn_list, input_glfo, sw_info, debug=False):  # NOTE 
             continue
         if debug:
             print_aligned_seqs(iatn)
-        sw_ldists, sw_rdists = zip(*[get_pad_parameters(sw_info[iatn['unique_ids'][i]], input_glfo) for i, u in enumerate(iatn['unique_ids'])])
+        sw_ldists, sw_rdists = zip(*[get_pad_parameters(sw_info[iatn['unique_ids'][i]], sw_glfo) for i, u in enumerate(iatn['unique_ids'])])  # sw annotations can reference v genes that aren't in the input partition's glfo
         sw_ldist, sw_rdist = [max(l) for l in [sw_ldists, sw_rdists]]
         ia_ldist, ia_rdist = get_pad_parameters(iatn, input_glfo)  # they should all be the same, so can use 0 (?)
         leftpad, rightpad = sw_ldist - ia_ldist, sw_rdist - ia_rdist

--- a/partis/waterer.py
+++ b/partis/waterer.py
@@ -1259,9 +1259,9 @@ class Waterer(object):
             if self.debug:
                 print('  %s nonsense k bounds for %s (v: %d %d  d: %d %d)' % (utils.color('red', 'error'), qinfo['name'], k_v_min, k_v_max, k_d_min, k_d_max))
             return None
-        if self.args.is_data and k_v_min - len(line['fv_insertion']) < 0:
+        if self.args.is_data and k_v_min - len(line['fv_insertion']) <= 0:
             if self.debug:
-                print('%s trimming fwk insertion would take k_v min to less than zero for %s: %d - %d = %d   %s' % (utils.color('yellow', 'warning'), ' '.join(line['unique_ids']), k_v_min, len(line['fv_insertion']), k_v_min - len(line['fv_insertion']), utils.reverse_complement_warning()))
+                print('%s trimming fwk insertion would take k_v min to zero or less for %s: %d - %d = %d   %s' % (utils.color('yellow', 'warning'), ' '.join(line['unique_ids']), k_v_min, len(line['fv_insertion']), k_v_min - len(line['fv_insertion']), utils.reverse_complement_warning()))
             return None
 
         kbounds = {'v' : {'best' : best_k_v, 'min' : k_v_min, 'max' : k_v_max},
@@ -1565,6 +1565,7 @@ class Waterer(object):
                     print('      sw called a v indel, but there\'s already a vsearch v indel, so give up (delete vsearch indel, ignore new sw indel, and rerun sw forbidding indels)')
                 if qinfo['name'] in self.info['indels']:
                     del self.info['indels'][qinfo['name']]
+                self.vs_indels.discard(qinfo['name'])
                 return None
 
             vs_indelfo = self.info['indels'][qinfo['name']]

--- a/test/test.py
+++ b/test/test.py
@@ -427,6 +427,12 @@ class Tester(object):
                 if tkey in info:
                     cmd_str += ' --%s %s' % (tkey if tkey != 'inpath' else self.astr('in', dt=idt), info[tkey])
             cmd_str += ' %s' % ' '.join(info['extras'] + self.common_extras)
+            if args.bcrham_binary is not None:
+                cmd_str += ' --bcrham-binary %s' % args.bcrham_binary
+            if args.ig_sw_binary is not None:
+                cmd_str += ' --ig-sw-binary %s' % args.ig_sw_binary
+            if args.zig:
+                cmd_str += ' --zig'
 
             if name == 'simulate':
                 cmd_str += ' --%s %s' % (self.astr('out'), self.inpath('new', 'simu'))
@@ -952,6 +958,9 @@ parser.add_argument('--print-width', type=int, default=300, help='set to 0 for i
 
 parser.add_argument('--glfo-dir', default='data/germlines/human')
 parser.add_argument('--locus', default='igh')
+parser.add_argument('--bcrham-binary', default=None, help='override default bcrham binary path (e.g. Zig drop-in replacement)')
+parser.add_argument('--ig-sw-binary', default=None, help='override default ig-sw binary path (e.g. Zig drop-in replacement)')
+parser.add_argument('--zig', action='store_true', help='use Zig backend (equivalent to --bcrham-binary and --ig-sw-binary pointing to packages/zig-core/zig-out/bin/)')
 args = parser.parse_args()
 assert not (args.quick and args.slow)  # it just doesn't make sense
 assert not (args.quick and args.paired)  # --quick ignores --paired, which is confusing


### PR DESCRIPTION
This compares the existing `--zig` backend option against the C++ backend on this feature branch's
setup, 200k simulated set, 3 donors x 3 loci, full pipeline from `cache-parameters` through refine.
Both runs used `--random-seed 1`, `--no-time-based-n-proc-reduction` and `PYTHONHASHSEED=0`, so any
difference between them is attributable to the backend rather than write-order or dict-iteration
noise.

| Metric | Result |
| --- | --- |
| Output | Identical, byte for byte, across every output file |
| Total CPU time | 2.62x less with zig (about 5h57m against 15h34m, total) |
| Peak memory | No change, within 9 MB on every stage |

Key takeaway: zig produces the same result as C++, faster. The speedup is not uniform across the
pipeline, it comes almost entirely from `bcrham`.

| Pipeline stage | CPU time, C++ against zig |
| --- | --- |
| `bcrham` (HA) | 3.23x faster overall, 4.48x faster on igh |
| search (vsearch/sw) | 1.63x faster |
| grouping, ha-prepare, ha-assemble, refine | about 1.0x, no meaningful change |

That last row is a useful check on its own. None of those stages call `bcrham`, so they should be
unaffected by a `bcrham`-only speedup, and they are. That supports attributing the gain to `bcrham`
specifically rather than to general noise or a faster node.

#### 1M run

Given the 200k result above already shows identical output between backends, the 1M run used zig
only. The purpose is to measure real wall-clock speedup at a larger, more realistic scale.

`cache-parameters` wall clock, chunked into 4 pieces per donor:

| Donor | Wall clock (h:mm:ss) |
| --- | --- |
| d1 | 2:28:04 |
| d3 | 1:50:08 |
| d4 | 1:57:27 |

An older C++-only `cache-parameters` run of the same size predates this work and took roughly
2:26:53 per donor, close to the numbers above. `bcrham`'s share of `cache-parameters` is small (5 to
12 percent of wall clock), so this stage is not where the speedup shows up.

The rest of the pipeline, vsearch through refine, ran on all 3 donors and all 3 loci at 1M, zig only,
on the same resource settings as an older run of the same donors and loci. `bcrham` (the HA stage) is
the only stage compared below, as the median per-bundle runtime, not a sum across the pipeline:

| Donor / locus | Old, C++ bcrham (h:mm:ss) | New, zig bcrham (h:mm:ss) | Ratio | Note |
| --- | --- | --- | --- | --- |
| d1-igh | 1:58:04 | 25:36 | 4.6x | igh: 4.6x to 4.8x, matches the controlled 200k igh ratio (4.48x) |
| d3-igh | 41:31 | 8:44 | 4.7x | |
| d4-igh | 50:52 | 10:38 | 4.8x | |
| d1-igk | 20:55 | 8:51 | 2.4x | igk: 2.3x to 2.4x |
| d3-igk | 13:42 | 5:54 | 2.3x | |
| d4-igk | 17:15 | 7:06 | 2.4x | |
| d1-igl | 10:39 | 5:03 | 2.1x | igl: 2.1x to 2.3x |
| d3-igl | 8:50 | 4:07 | 2.1x | |
| d4-igl | 8:53 | 3:57 | 2.3x | |

#### Replicating the 30k parity test, on a substitute input

`bin/partis-30k-parity-test.sh` on main/dev documents byte-identical output between backends on a
30k input, but its default input file, `/tmp/paired-paper-all-seqs.fa`, could not be located to
rerun that test directly. A substitute was used instead, `vs-shm/v4/seed-0/scratch-mute-freq-0.05`
(30k, a different draw of the same simulation, used for spot-checking, not part of the 200k/1M work
above). On this substitute input, the byte-identical result did not hold: the two backends produced
a real difference, worth documenting even though it does not affect the 200k/1M results above.

| Question | Answer |
| --- | --- |
| What happened | Running the same input through both backends produced different partitions on 5 of 6 output files: 0.47 to 0.77 percent of sequences ended up in different clusters |
| Compared against what | The two backends against each other, same input, same run, both seeded. Not compared against ground truth |
| Root cause | Isolated by swapping `bcrham` and `ig-sw` independently between backends. `--bcrham-binary` (zig) with the C++ `ig-sw` is byte-identical to all-C++. The C++ `bcrham` with the zig `ig-sw` reproduces the full failure. So the divergence is entirely in `partis-zig-igsw`, not in the `bcrham` port. Per-query diff of `sw-cache.yaml` shows every divergent query differs only in its D gene call, at tied top score and identical alignment bounds: `ig_align.c:212` ranks matches with `ks_introsort`, which is not a stable sort, and `waterer.py:587` takes the aligner's emission order as the ranking, so tied entries get ordered differently by the two aligner implementations. Light chain has no D segment and its output is untouched |
| Does this affect the 200k or 1M work above | No. The same C++-against-zig comparison was repeated on the actual 200k donor data, during `cache-parameters` (the only stage that runs `ig-sw` from scratch rather than reading a cache), and found 0 of 95,917 top-score D ties flipped, byte-identical parameter trees, despite that dataset having more tied D scores than the 30k set (95,917 against 11,466) |
| Why 30k differs from 200k | Not the invocation, ruled out empirically: rerunning the 30k input through the exact `cache-parameters --paired-loci --no-pairing-info` invocation used at 200k, instead of `partition --paired-loci`, reproduces the same 28 flipped queries, byte for byte. **Why this particular input has a higher D-gene tie rate than the 200k donor data is still unknown** |

A second run at what was meant to be a 50k cut of the same file was also submitted, but
`--n-max-queries` counts droplets, not sequences, and the file has only 29,887 droplets, so that run
selected the same whole file and repeated the 30k computation exactly. Its only use was confirming
each backend reproduces itself byte-for-byte on repeat, which it does (this is what lets the
cross-backend divergence above be attributed to the backend, not to nondeterminism).

#### Build note

Building the zig backend inside the project's pixi/conda environment fails at link time
(`ld.lld: cannot open /lib64/libm.so.6`): pixi sets `CC` to conda's cross-compiler with
`LIBRARY_PATH` pointed at conda's `lib64`-convention sysroot, and zig resolves libc paths through
`CC`, so it looks for `/lib64/libm.so.6` at the real filesystem root, which does not exist on this
distribution. Building in a bare environment (`env -i HOME=$HOME PATH=/usr/local/bin:/usr/bin:/bin`)
avoids this; the zig toolchain itself needs nothing from pixi or conda, only the partis invocations
that call the resulting binaries do.

Separately, a zig binary built on the build host failed on the cluster's compute nodes with
`GLIBC_2.34' not found`, since the build host and the compute nodes run different glibc versions and
`zig build` targets the native platform by default. Worked around by passing an explicit
`-Dtarget=x86_64-linux-gnu.2.27` for the compute nodes' glibc, run by hand outside `bin/zig-build.sh`
for this work.

Neither of these is fixed in `bin/zig-build.sh` itself, both are manual workarounds used to get
these builds running. `bin/zig-build.sh` has no `-Dtarget` passthrough, so any future build on
this cluster has to repeat the manual step above until one is added.
